### PR TITLE
fix(cert-manager): use http01.solvers.ingress.ingressClassName field

### DIFF
--- a/argocd-helm-charts/cert-manager/templates/clusterissuer.yaml
+++ b/argocd-helm-charts/cert-manager/templates/clusterissuer.yaml
@@ -72,7 +72,7 @@ spec:
     {{- else if eq (toString $v.type) "http"}}
     - http01:
         ingress:
-          class: {{ $v.http01.ingress.ingressClassName }}
+          ingressClassName: {{ $v.http01.ingress.ingressClassName }}
     {{- end -}}
     {{- end }}
 {{- else }}


### PR DESCRIPTION
As described in the documentation, the recommended field name is `ingressClassName`: https://cert-manager.io/docs/configuration/acme/http01/#ingressclassname

My ingress choice didn't get picked up until I changed the name of the field, so it appears not to be equivalent to using the old `class` field.