### PR TITLE
fix(build): only scrape existing namespaces with kube-prometheus

### DIFF
--- a/build/kube-prometheus/common-template.jsonnet
+++ b/build/kube-prometheus/common-template.jsonnet
@@ -289,10 +289,9 @@ local scrape_namespaces = std.uniq(std.sort(std.flattenArrays(
     vars.prometheus_scrape_namespaces,
   ] + [
     ['argocd'],
-    ['system'],
+    ['kube-system'],
     ['sealed-secrets'],
     ['cert-manager'],
-    ['traefik'],
     ['monitoring'],
   ] + (
     if std.objectHas(vars, 'connect_obmondo') && vars.connect_obmondo then


### PR DESCRIPTION
When setting up my kubeaid-based install, the prometheus install didn't go through, complaining that it couldn't install resources in the `system` and `traefik` namespaces (which do not exist in my install).

This configuration change makes it so that those namespaces no longer get scraped by default.
I figured that `system` meant to be `kube-system`, so I updated the name there.