### PR TITLE
chore: replace bitnami image references with soldevelo equivalents

### DIFF
--- a/argocd-helm-charts/funkwhale/templates/config-generator-job.yaml
+++ b/argocd-helm-charts/funkwhale/templates/config-generator-job.yaml
@@ -72,7 +72,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: config-generator
-          image: bitnami/kubectl:latest
+          image: soldevelo/kubectl:latest
           env:
             - name: SECRET_NAME
               value: "{{ $fullname }}"

--- a/argocd-helm-charts/lemmy/templates/config-generator-job.yaml
+++ b/argocd-helm-charts/lemmy/templates/config-generator-job.yaml
@@ -21,7 +21,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: config-generator
-          image: bitnami/kubectl:latest
+          image: soldevelo/kubectl:latest
           env:
             - name: PGPASSWORD
               valueFrom:


### PR DESCRIPTION
## Why this change

Bitnami moved image updates behind a paywall on August 28 2025, and public images no longer receive ongoing updates.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements with active support.

## Image replacements

- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)