### PR TITLE
fix(hetzner-robot): use node public IP for failover; add nodes RBAC

### DIFF
--- a/argocd-helm-charts/hetzner-robot/templates/deployment.yaml
+++ b/argocd-helm-charts/hetzner-robot/templates/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         app: {{ .Release.Name }}-failover
     spec:
+      # Needs to read Node objects (get nodes) to resolve this node's ExternalIP.
+      serviceAccountName: {{ .Release.Name }}-failover
       containers:
       - name: {{ .Release.Name }}-failover
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -27,10 +29,15 @@ spec:
           value: {{ .Values.failoverIP }}
         - name: CRON_TIME_INTERVAL
           value: {{ .Values.cronTimeInterval }}
-        - name: SERVER_IP
+        # The pod's own node name. The controller looks the Node up via the
+        # Kubernetes API and uses its ExternalIP (public main IP) as the Robot
+        # Failover target. status.hostIP cannot be used here: with kubelet
+        # --node-ip set to the private vSwitch network it is an RFC1918 address,
+        # which the Robot API rejects with FAILOVER_NEW_SERVER_NOT_FOUND.
+        - name: NODE_NAME
           valueFrom:
             fieldRef:
-              fieldPath: status.hostIP
+              fieldPath: spec.nodeName
         - name: HETZNER_ROBOT_USERNAME
           valueFrom:
             secretKeyRef:
@@ -51,7 +58,12 @@ spec:
             command:
             - /bin/sh
             - -c
-            - "pgrep hetzner-failover"
+            # Match the binary by its full argv. The [h] makes the pattern match
+            # the running process but not pgrep's own /bin/sh wrapper (whose argv
+            # literally contains "[h]etzner..."). Plain "pgrep hetzner-failover"
+            # never matched: the kernel truncates comm to 15 chars
+            # ("hetzner-failove"), so the probe always failed.
+            - "pgrep -f '[h]etzner-failover-script'"
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5
@@ -61,7 +73,12 @@ spec:
             command:
             - /bin/sh
             - -c
-            - "pgrep hetzner-failover"
+            # Match the binary by its full argv. The [h] makes the pattern match
+            # the running process but not pgrep's own /bin/sh wrapper (whose argv
+            # literally contains "[h]etzner..."). Plain "pgrep hetzner-failover"
+            # never matched: the kernel truncates comm to 15 chars
+            # ("hetzner-failove"), so the probe always failed.
+            - "pgrep -f '[h]etzner-failover-script'"
           initialDelaySeconds: 15
           periodSeconds: 5
           timeoutSeconds: 5

--- a/argocd-helm-charts/hetzner-robot/templates/rbac.yaml
+++ b/argocd-helm-charts/hetzner-robot/templates/rbac.yaml
@@ -1,0 +1,35 @@
+---
+# The failover controller resolves the public address (status.addresses ->
+# ExternalIP) of the node it runs on, so it needs to read Node objects.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-failover
+  labels:
+    app: {{ .Release.Name }}-failover
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-failover
+  labels:
+    app: {{ .Release.Name }}-failover
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-failover
+  labels:
+    app: {{ .Release.Name }}-failover
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-failover
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-failover

--- a/argocd-helm-charts/hetzner-robot/values.yaml
+++ b/argocd-helm-charts/hetzner-robot/values.yaml
@@ -1,7 +1,10 @@
 ---
 image:
   repository: ghcr.io/obmondo/hetzner-failover-script
-  tag: v1.1.0
+  # v1.2.0 resolves the node's public IP via the Kubernetes API (needs the RBAC
+  # in templates/rbac.yaml) instead of the private status.hostIP. Requires the
+  # dockerfiles repo to be tagged v1.2.0 so CI publishes this image first.
+  tag: v1.2.0
 
 # Failover IP that pod will manage
 failoverIP: ""


### PR DESCRIPTION
Companion to Obmondo/dockerfiles#54.

## Problem

The `hetzner-robot-failover` controller pointed the Hetzner Failover IP at the node's `status.hostIP`, which is the **private vSwitch IP** (RFC1918) on these clusters. The Robot API rejects it with `FAILOVER_NEW_SERVER_NOT_FOUND`, and the pod crash-looped (900+ restarts).

## Changes

- **`templates/rbac.yaml`** (new): ServiceAccount + ClusterRole (`get nodes`) + ClusterRoleBinding — the controller now reads its own Node's `ExternalIP` via the Kubernetes API.
- **`templates/deployment.yaml`**: set `serviceAccountName`; replace `SERVER_IP` (`status.hostIP`) with `NODE_NAME` (`spec.nodeName`); fix the liveness/readiness probes — the old `pgrep hetzner-failover` never matched the 15-char-truncated process `comm` (`hetzner-failove`) and would also self-match the `/bin/sh` wrapper, so it's replaced with a self-match-safe `pgrep -f '[h]etzner-failover-script'`.
- **`values.yaml`**: bump image to `v1.2.0`.

## Merge ordering ⚠️

Do not sync this before the image exists:

1. Merge Obmondo/dockerfiles#54.
2. Tag dockerfiles `v1.2.0` → CI publishes `ghcr.io/obmondo/hetzner-failover-script:v1.2.0`.
3. Merge this PR → ArgoCD syncs the new ServiceAccount + RBAC + `NODE_NAME` + image.

Verified: `helm template` renders valid manifests.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)