### PR TITLE
feat(traefik): add internal traefik-internal instance (ClusterIP, dedicated IngressClass)

### DIFF
--- a/argocd-helm-charts/traefik/Chart.lock
+++ b/argocd-helm-charts/traefik/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: traefik
   repository: https://helm.traefik.io/traefik
   version: 41.0.0
-digest: sha256:ac3cbc24b76d5d13d6882cf541602492bd9b6021aee14075d641b8bf4b836d5d
-generated: "2026-06-22T18:19:47.757666448+05:30"
+- name: traefik
+  repository: https://helm.traefik.io/traefik
+  version: 41.0.0
+digest: sha256:860c08d5c913bd1bea57d73c1a4508bb3b0f39a27b83b0bacf7208272878827b
+generated: "2026-07-02T14:43:03.4560509+05:30"

--- a/argocd-helm-charts/traefik/Chart.yaml
+++ b/argocd-helm-charts/traefik/Chart.yaml
@@ -6,3 +6,13 @@ dependencies:
     version: "41.0.0"
     repository: https://helm.traefik.io/traefik
     #repository: "oci://ghcr.io/Obmondo"
+  # Second, ClusterIP-only Traefik instance for internal / mesh-only domains
+  # (its own `traefik-internal` IngressClass). Reached over the NetBird mesh via
+  # a netbird-operator networkResource, not a public LB. Off by default; toggled
+  # by traefik-internal.enabled — kubeaid-cli sets it when a NetBird Mgmt key is
+  # configured.
+  - name: traefik
+    alias: traefik-internal
+    version: "41.0.0"
+    repository: https://helm.traefik.io/traefik
+    condition: traefik-internal.enabled

--- a/argocd-helm-charts/traefik/values.yaml
+++ b/argocd-helm-charts/traefik/values.yaml
@@ -63,3 +63,28 @@ traefik:
 #      annotations:
 #        traefik.ingress.kubernetes.io/router.tls: "true"
 #        cert-manager.io/cluster-issuer: letsencrypt
+
+# Internal Traefik instance (aliased subchart above), OFF by default. A
+# ClusterIP-only controller with its own `traefik-internal` IngressClass, for
+# internal / mesh-only domains reached over the NetBird mesh instead of a public
+# HCloud LB. Deliberately NOT the default IngressClass and NO proxyprotocol
+# (there's no LB in front to originate PROXY headers). Web/TLS entrypoints keep
+# upstream defaults; internal Ingresses set their own TLS. kubeaid-cli flips
+# enabled=true when a NetBird Mgmt key is configured, and the netbird-operator
+# then exposes the traefik-internal Service to the mesh via a networkResource.
+traefik-internal:
+  enabled: false
+  fullnameOverride: traefik-internal
+  instanceLabelOverride: traefik-internal
+  service:
+    # traefik chart v41 nests the Service type under service.spec (v29 used
+    # service.type). ClusterIP is load-bearing: the upstream default is
+    # LoadBalancer, which would provision a second public LB.
+    spec:
+      type: ClusterIP
+  ingressClass:
+    enabled: true
+    isDefaultClass: false
+    name: traefik-internal
+  deployment:
+    replicas: 1


### PR DESCRIPTION
## Summary
- Adds a second aliased upstream traefik (41.0.0) dependency, off by default via condition `traefik-internal.enabled`.
- Runs as a ClusterIP Service with its own non-default `traefik-internal` IngressClass, for internal/mesh-only domains reached over the NetBird mesh instead of the public HCloud LB fronting the default traefik instance.
- Pairs with the kubeaid-cli change that renders `enabled: true` into `values-traefik.yaml` whenever a NetBird Mgmt key is configured in `secrets.yaml`.

## Test plan
- [ ] `helm dependency update argocd-helm-charts/traefik` resolves both aliased subcharts
- [ ] `helm template` with `traefik-internal.enabled=false` (default) renders no traefik-internal resources
- [ ] `helm template` with `traefik-internal.enabled=true` renders a ClusterIP Service + `traefik-internal` IngressClass, not marked default