### PR TITLE
feat(velero): skip CloudNativePG PVC volumes in backups

### DIFF
--- a/argocd-helm-charts/velero/templates/velero-resource-policy.yaml
+++ b/argocd-helm-charts/velero/templates/velero-resource-policy.yaml
@@ -12,6 +12,11 @@ data:
     volumePolicies:
       - conditions:
           pvcLabels:
+            app: rabbitmq
+            redis_setup_type: cluster
+            redis_setup_type: standalone
+            app: mongodb-replica-set-svc
+            app.kubernetes.io/name: opensearch
             app.kubernetes.io/managed-by: cloudnative-pg
         action:
           type: skip

--- a/argocd-helm-charts/velero/templates/velero-resource-policy.yaml
+++ b/argocd-helm-charts/velero/templates/velero-resource-policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cnpg-skip-volumes
+  namespace: velero
+  labels:
+    argocd.argoproj.io/instance: velero
+data:
+  # Skip Velero volume backups for CloudNativePG PVCs (covered by CNPG's own WAL/base backups).
+  policy.yaml: |
+    version: v1
+    volumePolicies:
+      - conditions:
+          pvcLabels:
+            app.kubernetes.io/managed-by: cloudnative-pg
+        action:
+          type: skip

--- a/argocd-helm-charts/velero/templates/velero-schedules.yaml
+++ b/argocd-helm-charts/velero/templates/velero-schedules.yaml
@@ -9,6 +9,9 @@ spec:
   schedule: '0 {{ .Values.schedule.dailyHour | default 3 }} * * 1-6'
   template:
     hooks: {}
+    resourcePolicy:
+      kind: configmap
+      name: cnpg-skip-volumes
     csiSnapshotTimeout: 40m
     itemOperationTimeout: 300m
     includedNamespaces: 
@@ -37,6 +40,9 @@ spec:
   schedule: '0 0 * * 0'
   template:
     hooks: {}
+    resourcePolicy:
+      kind: configmap
+      name: cnpg-skip-volumes
     csiSnapshotTimeout: 40m
     itemOperationTimeout: 300m
     includedNamespaces: 
@@ -66,6 +72,9 @@ spec:
   schedule: '0 6,12,18 * * *'
   template:
     hooks: {}
+    resourcePolicy:
+      kind: configmap
+      name: cnpg-skip-volumes
     csiSnapshotTimeout: 40m
     itemOperationTimeout: 300m
     includedNamespaces: 


### PR DESCRIPTION
Adds a Velero volume resource policy (`skip` action) for CloudNativePG PVCs and wires it into the three backup Schedules.

CNPG databases are backed up by CNPG itself (WAL archiving + base backups); a Velero snapshot of a live Postgres data directory is crash-inconsistent. Only the volume *data* is skipped — the PVC objects are still backed up.

Match: `app.kubernetes.io/managed-by: cloudnative-pg` (present on every CNPG PVC).

Fixes #66
