### PR TITLE
Deprecate filebeat and loki-stack charts

### DIFF
--- a/argocd-helm-charts/filebeat/Chart.yaml
+++ b/argocd-helm-charts/filebeat/Chart.yaml
@@ -1,6 +1,9 @@
 apiVersion: v2
 name: filebeat
-version: 1.0.0
+version: 1.0.1
+# Deprecated: use the OpenTelemetry Collector (or Fluent Bit) shipping to OpenObserve.
+# See README.md and docs/monitoring.md.
+deprecated: true
 dependencies:
   - name: filebeat
     version: 8.5.1

--- a/argocd-helm-charts/filebeat/README.md
+++ b/argocd-helm-charts/filebeat/README.md
@@ -1,0 +1,31 @@
+# Filebeat (deprecated)
+
+> **⚠️ Deprecated.** This chart is deprecated and is not recommended for new KubeAid
+> installations. Filebeat is the Elastic Beats-era log shipper. KubeAid standardizes log
+> collection on the **OpenTelemetry Collector** (with **Fluent Bit** as a lightweight
+> alternative), shipping to [OpenObserve](../openobserve/README.md) by default, or to
+> [OpenSearch](../opensearch/README.md) where an Apache-2.0 backend is required.
+>
+> The chart remains in the repository for existing clusters but will not receive further
+> updates. See [Monitoring in KubeAid](../../docs/monitoring.md) for the current log
+> collection and storage options.
+
+## What this chart does
+
+Filebeat runs as a DaemonSet and ships container and node logs to Elasticsearch- or
+OpenSearch-compatible backends. It wraps the upstream
+[`elastic/filebeat`](https://helm.elastic.co) chart.
+
+## Migrating off Filebeat
+
+Log collection in KubeAid is handled by an agent running as a DaemonSet on every node, which
+tails `/var/log/pods` and ships logs to a backend. Replace Filebeat with one of:
+
+- **OpenTelemetry Collector** — the default agent for logs, metrics, and traces; ingested by
+  OpenObserve over `OTLP`. See the
+  [OpenObserve Collector reference](../openobserve/charts/openobserve-collector/docs/README.md).
+- **Fluent Bit** — a lightweight logs-only shipper for resource-constrained nodes; see the
+  [`fluent-bit`](../fluent-bit) chart.
+
+Both feed [OpenObserve](../openobserve/README.md) (default) or
+[OpenSearch](../opensearch/README.md).

--- a/argocd-helm-charts/loki-stack/Chart.yaml
+++ b/argocd-helm-charts/loki-stack/Chart.yaml
@@ -10,10 +10,13 @@ description: A Helm chart for Kubernetes
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
+# Deprecated: KubeAid standardizes logs on OpenTelemetry Collector -> OpenObserve.
+# See README.md and docs/monitoring.md.
+deprecated: true
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/argocd-helm-charts/loki-stack/README.md
+++ b/argocd-helm-charts/loki-stack/README.md
@@ -1,0 +1,23 @@
+# loki-stack (deprecated)
+
+> **⚠️ Deprecated.** This chart is deprecated and is not one of KubeAid's documented log
+> monitoring options. KubeAid standardizes logs and traces on the **OpenTelemetry Collector →
+> [OpenObserve](../openobserve/README.md)** path by default, with
+> [Graylog](../graylog/README.md) and [OpenSearch + Kibana](../opensearch/README.md) as
+> supported alternatives.
+>
+> The chart remains in the repository for existing clusters but will not receive further
+> updates. See [Monitoring in KubeAid](../../docs/monitoring.md) for the current options.
+
+## What this chart does
+
+`loki-stack` wraps the upstream
+[`grafana/loki-stack`](https://grafana.github.io/helm-charts) chart (Loki plus a log shipper)
+for centralized log storage and querying via Grafana.
+
+## Migrating off loki-stack
+
+Point your log collector (OpenTelemetry Collector or Fluent Bit) at
+[OpenObserve](../openobserve/README.md) instead. OpenObserve stores logs, metrics, and traces
+in a single backend on object storage and integrates with `kube-prometheus`; see
+[Monitoring in KubeAid](../../docs/monitoring.md).


### PR DESCRIPTION
## What

Marks the **filebeat** and **loki-stack** charts as deprecated and documents the migration path.

KubeAid standardizes on:
- **Collection:** OpenTelemetry Collector (default), with Fluent Bit as a lightweight logs-only alternative
- **Logs/traces storage:** OpenObserve (default), with Graylog and OpenSearch + Kibana as documented alternatives (see `docs/monitoring.md`)

Neither `filebeat` nor `loki-stack` appears in `docs/monitoring.md`'s log-monitoring options:
- `filebeat` is the Elastic Beats-era shipper, superseded by the OTel Collector / Fluent Bit
- `loki-stack` is not part of the documented options

## Changes

- Add a `README.md` with a deprecation notice + migration guidance to each chart
- Set the Helm `deprecated: true` flag in each `Chart.yaml`
- Bump chart patch versions (filebeat `1.0.0` → `1.0.1`, loki-stack `0.1.0` → `0.1.1`)

Both charts remain in the repo for existing clusters but will not receive further updates.

## Notes / open question

OpenObserve's OSS edition is **AGPL-3.0**; **OpenSearch (Apache-2.0)** is intentionally kept as the non-copyleft fallback. If we later want to reduce the log-backend matrix further, `opensearch` is the one to keep for procurement-sensitive users — flagging in case we want to state that stance in `docs/monitoring.md` in a follow-up.