### PR TITLE
Default openobserve-collector exporter to in-cluster router

### DIFF
--- a/argocd-helm-charts/openobserve/Chart.yaml
+++ b/argocd-helm-charts/openobserve/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openobserve
-version: 0.13.4
+version: 0.13.5
 # We disabling the updates for openobserve, since there's no upstream
 # support for dex OIDC connector configurations for enterprise.
 # It expects all the configurations to be passed as configmap, but passing

--- a/argocd-helm-charts/openobserve/charts/openobserve-collector/Chart.yaml
+++ b/argocd-helm-charts/openobserve/charts/openobserve-collector/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
   url: https://openobserve.ai
 name: openobserve-collector
 type: application
-version: 0.4.4
+version: 0.4.5

--- a/argocd-helm-charts/openobserve/charts/openobserve-collector/values.yaml
+++ b/argocd-helm-charts/openobserve/charts/openobserve-collector/values.yaml
@@ -3,12 +3,17 @@
 # Declare variables to be passed into your templates.
 
 exporters:
+  # Default to the in-cluster OpenObserve router so telemetry never leaves the cluster.
+  # Service DNS: <release>-router.<namespace>.svc.cluster.local:<ZO_HTTP_PORT> (default 5080),
+  # path /api/<org> (default org "default"). Override with your OpenObserve ingress URL if the
+  # collector runs outside the cluster. The otlphttp exporter appends /v1/logs|traces|metrics.
+  # Provide real credentials via the openobserve sealed secret, not inline here.
   otlphttp/openobserve:
-    endpoint: https://api.openobserve.ai/api/default/
+    endpoint: http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
     headers:
       Authorization: Basic YOUR_BASE64_ENCODED_AUTH
   otlphttp/openobserve_k8s_events:
-    endpoint: https://api.openobserve.ai/api/default/
+    endpoint: http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
     headers:
       Authorization: Basic CHANGEME_BASE64_ENCODED_AUTH
       stream-name: k8s_events


### PR DESCRIPTION
## Problem

The `openobserve-collector` chart shipped its default OTLP exporter endpoint as **OpenObserve Cloud**:

```yaml
otlphttp/openobserve:
  endpoint: https://api.openobserve.ai/api/default/
```

For KubeAid's self-hosted model this is the wrong default — once a real `Authorization` header is set, the agent DaemonSet and gateway would ship cluster logs/metrics/traces to OpenObserve's SaaS instead of the in-cluster instance.

## Fix

Point both exporters at the in-cluster OpenObserve router service so telemetry stays in-cluster by default:

```yaml
endpoint: http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
```

- `fullname` resolves to `openobserve` (release name contains the chart name) -> service `openobserve-router`
- `ZO_HTTP_PORT` default `5080`; org `default`; `otlphttp` appends `/v1/logs|traces|metrics`
- Operators override with their OpenObserve **ingress URL** when the collector runs off-cluster (see `example-values.yaml`)
- Credentials still come from the openobserve **sealed secret**, not inline — placeholder auth left in place intentionally

Bumps `openobserve-collector` 0.4.4 -> 0.4.5 and `openobserve` 0.13.4 -> 0.13.5.