### PR TITLE
Add tetragon chart (eBPF security observability)

### DIFF
--- a/argocd-helm-charts/tetragon/Chart.lock
+++ b/argocd-helm-charts/tetragon/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: tetragon
+  repository: https://helm.cilium.io/
+  version: 1.7.0
+digest: sha256:02b0afa48cd105d3fcd0bf33bb10d577afc09dbe5f52122ae3f19d0e3fc38902
+generated: "2026-07-11T23:45:28.951893336+05:30"

--- a/argocd-helm-charts/tetragon/Chart.yaml
+++ b/argocd-helm-charts/tetragon/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: tetragon
+version: 1.0.0
+# See latest chart versions here: https://helm.cilium.io/index.yaml
+# (upstream: https://github.com/cilium/tetragon)
+dependencies:
+  - name: tetragon
+    version: 1.7.0
+    repository: https://helm.cilium.io/

--- a/argocd-helm-charts/tetragon/README.md
+++ b/argocd-helm-charts/tetragon/README.md
@@ -44,3 +44,55 @@ All values are kept at upstream defaults; override them under the `tetragon:`
 key in your cluster's values file. See the
 [upstream values](https://github.com/cilium/tetragon/blob/main/install/kubernetes/tetragon/values.yaml)
 and the [Tetragon docs](https://tetragon.io/docs/) for details.
+
+## Shipping events to OpenObserve
+
+Tetragon defaults to `export.mode: "stdout"`: an `export-stdout` sidecar tails the
+JSON export file (`/var/run/cilium/tetragon/tetragon.log`) and prints each event to
+the container's **stdout**. Because those events become ordinary pod logs, the
+existing `openobserve-collector` **agent DaemonSet** (which already tails
+`/var/log/pods`) picks them up and ships them to OpenObserve — no Tetragon-side
+configuration required.
+
+### Default: local, in-cluster OpenObserve
+
+```
+Tetragon DaemonSet
+  ├─ tetragon        → writes JSON events to /var/run/cilium/tetragon/tetragon.log
+  └─ export-stdout   → tails the file → stdout ( = /var/log/pods )
+                                          │
+                                          ▼
+     openobserve-collector agent DaemonSet (filelog receiver)
+                                          │  otlphttp exporter
+                                          ▼
+                       in-cluster OpenObserve router
+       http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
+```
+
+This is the default: security events land in the same local OpenObserve as the rest
+of the cluster telemetry.
+
+### Routing to a different or remote OpenObserve
+
+*Where* the events land is decided by the OTel Collector's exporter, not by Tetragon.
+To send security events to a separate (or internet-facing) OpenObserve — e.g. a
+central SIEM-style instance — while application logs stay local, add a second
+exporter and a routing/filter pipeline in the `openobserve-collector` values that
+selects the Tetragon namespace, for example:
+
+```yaml
+exporters:
+  otlphttp/openobserve_security:
+    endpoint: https://openobserve.security.example.com/api/default
+    headers:
+      Authorization: Basic <base64-auth>   # from a sealed secret
+      stream-name: tetragon
+service:
+  pipelines:
+    logs/tetragon:
+      receivers: [filelog/std]
+      processors: [memory_limiter, k8sattributes, batch]   # + a filter on k8s.namespace.name
+      exporters: [otlphttp/openobserve_security]
+```
+
+Tetragon itself is unchanged; only the collector's exporter/pipeline differs.

--- a/argocd-helm-charts/tetragon/README.md
+++ b/argocd-helm-charts/tetragon/README.md
@@ -1,0 +1,46 @@
+# Tetragon
+
+[Tetragon](https://tetragon.io) is a CNCF project (by Isovalent/Cilium) that
+uses eBPF for security observability and runtime enforcement on Kubernetes. It
+runs as a DaemonSet and surfaces process execution, network activity and file
+access as low-overhead kernel events, and can optionally enforce policy in the
+kernel (for example killing a process that violates a rule).
+
+Upstream chart: [https://helm.cilium.io/](https://github.com/cilium/tetragon) (sources: [https://github.com/cilium/tetragon](https://github.com/cilium/tetragon))
+
+## Prerequisites
+
+- A Linux kernel with BTF and eBPF support on every node
+  (kernel >= 5.4 with `CONFIG_DEBUG_INFO_BTF=y`). Most modern distro kernels
+  ship this; check `/sys/kernel/btf/vmlinux` exists on the node.
+- Tetragon runs on the host network and mounts host paths; it needs the
+  privileges granted by the upstream chart's DaemonSet.
+
+## Usage
+
+- Installed as-is, Tetragon is **observability-only**: it emits process,
+  network and file events (JSON export + gRPC). Nothing is blocked.
+- Inspect events from a node with the `tetra` CLI:
+
+  ```sh
+  kubectl exec -n <namespace> ds/tetragon -c tetragon -- \
+    tetra getevents -o compact
+  ```
+
+- **Enforcement is opt-in.** Apply a `TracingPolicy` (cluster-wide) or
+  `TracingPolicyNamespaced` with enforcement actions (e.g. `Sigkill`,
+  `Override`) to block behaviour at runtime:
+
+  ```sh
+  kubectl apply -f my-tracing-policy.yaml
+  ```
+
+  Tetragon integrates naturally with Cilium (same vendor), which KubeAid
+  already uses as the CNI.
+
+## Configuration
+
+All values are kept at upstream defaults; override them under the `tetragon:`
+key in your cluster's values file. See the
+[upstream values](https://github.com/cilium/tetragon/blob/main/install/kubernetes/tetragon/values.yaml)
+and the [Tetragon docs](https://tetragon.io/docs/) for details.

--- a/argocd-helm-charts/tetragon/charts/tetragon/.helmignore
+++ b/argocd-helm-charts/tetragon/charts/tetragon/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.github/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/argocd-helm-charts/tetragon/charts/tetragon/Chart.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+appVersion: 1.7.0
+description: Helm chart for Tetragon
+icon: https://tetragon.io/images/tetragon-shield.png
+name: tetragon
+type: application
+version: 1.7.0

--- a/argocd-helm-charts/tetragon/charts/tetragon/LICENSE
+++ b/argocd-helm-charts/tetragon/charts/tetragon/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} Authors of Tetragon
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/argocd-helm-charts/tetragon/charts/tetragon/README.md
+++ b/argocd-helm-charts/tetragon/charts/tetragon/README.md
@@ -1,0 +1,165 @@
+# tetragon
+
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+
+Helm chart for Tetragon
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| crds.installMethod | string | `"operator"` | Method for installing CRDs. Supported values are: "operator", "helm" and "none". The "operator" method allows for fine-grained control over which CRDs are installed and by default doesn't perform CRD downgrades. These can be configured in tetragonOperator section. The "helm" method always installs all CRDs for the chart version. |
+| daemonSetAnnotations | object | `{}` |  |
+| daemonSetLabelsOverride | object | `{}` |  |
+| dnsPolicy | string | `"Default"` | DNS policy for Tetragon pods.  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
+| enabled | bool | `true` |  |
+| export | object | `{"filenames":["tetragon.log"],"mode":"stdout","resources":{},"securityContext":{},"stdout":{"argsOverride":[],"commandOverride":[],"enabledArgs":true,"enabledCommand":true,"envFromSecrets":[],"extraEnv":[],"extraEnvFrom":[],"extraVolumeMounts":[],"image":{"override":null,"repository":"quay.io/cilium/hubble-export-stdout","tag":"v1.1.1"}}}` | Tetragon events export settings |
+| export.stdout.envFromSecrets | list | `[]` | A simplified way to add secret references to envFrom. Can be specified either as a string (just the secret name) or as an object with additional parameters. Example: envFromSecrets:   - my-simple-secret   - name: my-optional-secret     optional: true |
+| export.stdout.extraEnv | list | `[]` | Extra environment variables to add to the export-stdout container. Example: extraEnv:   - name: FOO     value: bar   - name: SECRET_KEY     valueFrom:       secretKeyRef:         name: my-secret         key: secret-key |
+| export.stdout.extraEnvFrom | list | `[]` | Extra envFrom sources to add to the export-stdout container. This allows adding any type of envFrom source (configMapRef, secretRef, etc.). Example: extraEnvFrom:   - configMapRef:       name: my-config-map   - secretRef:       name: my-secret       optional: true |
+| exportDirectory | string | `"/var/run/cilium/tetragon"` | Directory to put Tetragon JSON export files. |
+| extraConfigmapMounts | list | `[]` |  |
+| extraHostPathMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| hostNetwork | bool | `true` | Configures whether Tetragon pods run on the host network.  IMPORTANT: Tetragon must be on the host network for the process visibility to function properly. |
+| imagePullPolicy | string | `"IfNotPresent"` |  |
+| imagePullSecrets | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podLabelsOverride | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| priorityClassName | string | `""` |  |
+| rthooks | object | `{"annotations":{},"enabled":false,"extraHookArgs":{},"extraLabels":{},"extraVolumeMounts":[],"failAllowNamespaces":"","image":{"override":null,"repository":"quay.io/cilium/tetragon-rthooks","tag":"v0.8"},"installDir":"/opt/tetragon","interface":"","nameOverride":"","nriHook":{"nriSocket":"/var/run/nri/nri.sock"},"ociHooks":{"hooksPath":"/usr/share/containers/oci/hooks.d"},"podAnnotations":{},"podSecurityContext":{},"priorityClassName":"","resources":{},"serviceAccount":{"name":""}}` | Method for installing Tetagon rthooks (tetragon-rthooks) daemonset The tetragon-rthooks daemonset is responsible for installing run-time hooks on the host. See: https://tetragon.io/docs/concepts/runtime-hooks |
+| rthooks.annotations | object | `{}` | Annotations for the Tetragon rthooks daemonset |
+| rthooks.enabled | bool | `false` | Enable the Tetragon rthooks daemonset |
+| rthooks.extraHookArgs | object | `{}` | extra args to pass to tetragon-oci-hook |
+| rthooks.extraLabels | object | `{}` | Extra labels for the Tetrargon rthooks daemonset |
+| rthooks.extraVolumeMounts | list | `[]` | Extra volume mounts to add to the oci-hook-setup init container |
+| rthooks.failAllowNamespaces | string | `""` | Comma-separated list of namespaces to allow Pod creation for, in case tetragon-oci-hook fails to reach Tetragon agent. The namespace Tetragon is deployed in is always added as an exception and must not be added again. |
+| rthooks.image | object | `{"override":null,"repository":"quay.io/cilium/tetragon-rthooks","tag":"v0.8"}` | image for the Tetragon rthooks pod |
+| rthooks.installDir | string | `"/opt/tetragon"` | installDir is the host location where the tetragon-oci-hook binary will be installed |
+| rthooks.interface | string | `""` | Method to use for installing  rthooks. Values:     "oci-hooks":       Add an apppriate file to "/usr/share/containers/oci/hooks.d". Use this with CRI-O.       See https://github.com/containers/common/blob/main/pkg/hooks/docs/oci-hooks.5.md       for more details.       Specific configuration for this interface can be found under "ociHooks".     "nri-hook":      Install the hook via NRI. Use this with containerd. Requires NRI being enabled.      see: https://github.com/containerd/containerd/blob/main/docs/NRI.md.      Specific configuration for this interface can be found under "nriHook".  |
+| rthooks.nameOverride | string | `""` | tetragon-rthooks name override |
+| rthooks.nriHook | object | `{"nriSocket":"/var/run/nri/nri.sock"}` | configuration for the "nri-hook" interface |
+| rthooks.nriHook.nriSocket | string | `"/var/run/nri/nri.sock"` | path to NRI socket |
+| rthooks.ociHooks | object | `{"hooksPath":"/usr/share/containers/oci/hooks.d"}` | configuration for "oci-hooks" interface |
+| rthooks.ociHooks.hooksPath | string | `"/usr/share/containers/oci/hooks.d"` | directory to install .json file for running the hook |
+| rthooks.podAnnotations | object | `{}` | Pod annotations for the Tetrargon rthooks pod |
+| rthooks.podSecurityContext | object | `{}` | security context for the Tetrargon rthooks pod |
+| rthooks.priorityClassName | string | `""` | priorityClassName for the Tetrargon rthooks pod |
+| rthooks.resources | object | `{}` | resources for the the oci-hook-setup init container |
+| rthooks.serviceAccount | object | `{"name":""}` | rthooks service account. |
+| selectorLabelsOverride | object | `{}` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceLabelsOverride | object | `{}` |  |
+| tetragon.argsOverride | list | `[]` | Override the arguments. For advanced users only. |
+| tetragon.btf | string | `""` |  |
+| tetragon.cgidmap | object | `{"enabled":false}` | Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for pod association. This feature depends on cri being enabled. |
+| tetragon.clusterName | string | `""` | Name of the cluster where Tetragon is installed. Tetragon uses this value to set the cluster_name field in GetEventsResponse messages. |
+| tetragon.commandOverride | list | `[]` | Override the command. For advanced users only. |
+| tetragon.cri | object | `{"enabled":false,"socketHostPath":""}` | Configure tetragon pod so that it can contact the CRI running on the host |
+| tetragon.cri.socketHostPath | string | `""` | path of the CRI socket on the host. This will typically be "/run/containerd/containerd.sock" for containerd or "/var/run/crio/crio.sock"  for crio. |
+| tetragon.debug | bool | `false` | If you want to run Tetragon in debug mode change this value to true |
+| tetragon.enableK8sAPI | bool | `true` | Access Kubernetes API to associate Tetragon events with Kubernetes pods. |
+| tetragon.enableKeepSensorsOnExit | bool | `false` | Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone. |
+| tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |
+| tetragon.enablePolicyFilter | bool | `true` | Enable policy filter. This is required for K8s namespace and pod-label filtering. |
+| tetragon.enablePolicyFilterCgroupMap | bool | `false` | Enable policy filter cgroup map. |
+| tetragon.enablePolicyFilterDebug | bool | `false` | Enable policy filter debug messages. |
+| tetragon.enableProcessCred | bool | `false` | Enable Capabilities visibility in exec and kprobe events. |
+| tetragon.enableProcessNs | bool | `false` | Enable Namespaces visibility in exec and kprobe events. |
+| tetragon.enabled | bool | `true` |  |
+| tetragon.eventCacheRetries | int | `15` | Configure the number of retries in tetragon's event cache. |
+| tetragon.eventCacheRetryDelay | int | `2` | Configure the delay (in seconds) between retires in tetragon's event cache. |
+| tetragon.exportAllowList | string | `"{\"event_set\":[\"PROCESS_EXEC\", \"PROCESS_EXIT\", \"PROCESS_KPROBE\", \"PROCESS_UPROBE\", \"PROCESS_TRACEPOINT\", \"PROCESS_LSM\"]}"` | Allowlist for JSON export. For example, to export only process_connect events from the default namespace:  exportAllowList: |   {"namespace":["default"],"event_set":["PROCESS_EXEC"]} |
+| tetragon.exportDenyList | string | `"{\"health_check\":true}\n{\"namespace\":[\"\", \"cilium\", \"kube-system\"]}"` | Denylist for JSON export **(for file sinks only; does not filter gRPC output)**. For example, to exclude exec events that look similar to Kubernetes health checks and all the events from kube-system namespace and the host:  exportDenyList: |   {"health_check":true}   {"namespace":["kube-system",""]}  |
+| tetragon.exportFileCompress | bool | `false` | Compress rotated JSON export files. |
+| tetragon.exportFileMaxBackups | int | `5` | Number of rotated files to retain. |
+| tetragon.exportFileMaxSizeMB | int | `10` | Size in megabytes at which to rotate JSON export files. |
+| tetragon.exportFilePerm | string | `"600"` | JSON export file permissions as a string. Typically it's either "600" (to restrict access to owner) or "640"/"644" (to allow read access by logs collector or another agent). |
+| tetragon.exportFilename | string | `"tetragon.log"` | JSON export filename. Set it to an empty string to disable JSON export altogether. |
+| tetragon.exportRateLimit | int | `-1` | Rate-limit event export (events per minute), Set to -1 to export all events. |
+| tetragon.extraArgs | object | `{}` |  |
+| tetragon.extraEnv | list | `[]` |  |
+| tetragon.extraVolumeMounts | list | `[]` |  |
+| tetragon.fieldFilters | string | `""` | Filters to include or exclude fields from Tetragon events. Without any filters, all fields are included by default. The presence of at least one inclusion filter implies default-exclude (i.e. any fields that don't match an inclusion filter will be excluded). Field paths are expressed using dot notation like "a.b.c" and multiple field paths can be separated by commas like "a.b.c,d,e.f". An optional "event_set" may be specified to apply the field filter to a specific set of events.  For example, to exclude the "parent" field from all events and include the "process" field in PROCESS_KPROBE events while excluding all others:  fieldFilters: |   {"fields": "parent", "action": "EXCLUDE"}   {"event_set": ["PROCESS_KPROBE"], "fields": "process", "action": "INCLUDE"}  |
+| tetragon.gops.address | string | `"localhost"` | The address at which to expose gops. |
+| tetragon.gops.enabled | bool | `true` | Whether to enable exposing gops server. |
+| tetragon.gops.port | int | `8118` | The port at which to expose gops. |
+| tetragon.grpc.address | string | `"unix:///var/run/tetragon/tetragon.sock"` | The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock |
+| tetragon.grpc.enabled | bool | `true` | Whether to enable exposing Tetragon gRPC. |
+| tetragon.healthGrpc.enabled | bool | `true` | Whether to enable health gRPC server. |
+| tetragon.healthGrpc.interval | int | `10` | The interval at which to check the health of the agent. |
+| tetragon.healthGrpc.port | int | `6789` | The port at which to expose health gRPC. |
+| tetragon.hostProcPath | string | `"/proc"` | Location of the host proc filesystem in the runtime environment. If the runtime runs in the host, the path is /proc. Exceptions to this are environments like kind, where the runtime itself does not run on the host. |
+| tetragon.image.override | string | `nil` |  |
+| tetragon.image.repository | string | `"quay.io/cilium/tetragon"` |  |
+| tetragon.image.tag | string | `"v1.7.0"` |  |
+| tetragon.livenessProbe | object | `{}` | Overrides the default livenessProbe for the tetragon container. |
+| tetragon.nameOverride | string | `""` |  |
+| tetragon.podAnnotations.enabled | bool | `false` |  |
+| tetragon.pprof.address | string | `"localhost"` | The address at which to expose pprof. |
+| tetragon.pprof.enabled | bool | `false` | Whether to enable exposing pprof server. |
+| tetragon.pprof.port | int | `6060` | The port at which to expose pprof. |
+| tetragon.processAncestors.enabled | string | `""` | Comma-separated list of process event types to enable ancestors for. Supported event types are: base, kprobe, tracepoint, loader, uprobe, lsm, usdt. Unknown event types will be ignored. Type "base" is required by all other supported event types for correct reference counting. Set it to "" to disable ancestors completely. |
+| tetragon.processCacheGCInterval | string | `"30s"` | Configure the interval (suffixed with s for seconds, m for minutes, etc) for the process cache garbage collector. |
+| tetragon.processCacheSize | int | `65536` | Tetragon puts processes in an LRU cache. The cache is used to find ancestors for subsequently exec'ed processes. |
+| tetragon.prometheus.address | string | `""` | The address at which to expose metrics. Set it to "" to expose on all available interfaces. |
+| tetragon.prometheus.enabled | bool | `true` | Whether to enable exposing Tetragon metrics. |
+| tetragon.prometheus.metricsLabelFilter | string | `"namespace,workload,pod,binary"` | Comma-separated list of enabled metrics labels. The configurable labels are: namespace, workload, pod, binary. Unknown labels will be ignored. Removing some labels from the list might help reduce the metrics cardinality if needed. |
+| tetragon.prometheus.port | int | `2112` | The port at which to expose metrics. |
+| tetragon.prometheus.serviceMonitor.enabled | bool | `false` | Whether to create a 'ServiceMonitor' resource targeting the tetragon pods. |
+| tetragon.prometheus.serviceMonitor.extraLabels | object | `{}` | Extra labels to be added on the Tetragon ServiceMonitor. |
+| tetragon.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
+| tetragon.prometheus.serviceMonitor.scrapeInterval | string | `"60s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
+| tetragon.redactionFilters | string | `""` | Filters to redact secrets from the args fields in Tetragon events. To perform redactions, redaction filters define RE2 regular expressions in the `redact` field. Any capture groups in these RE2 regular expressions are redacted and replaced with "*****".  For more control, you can select which binary or binaries should have their arguments redacted with the `binary_regex` field.  NOTE: This feature uses RE2 as its regular expression library. Make sure that you follow RE2 regular expression guidelines as you may observe unexpected results otherwise. More information on RE2 syntax can be found [here](https://github.com/google/re2/wiki/Syntax).  NOTE: When writing regular expressions in JSON, it is important to escape backslash characters. For instance `\Wpasswd\W?` would be written as `{"redact": "\\Wpasswd\\W?"}`.  As a concrete example, the following will redact all passwords passed to processes with the "--password" argument:    {"redact": ["--password(?:\\s+|=)(\\S*)"]}  Now, an event which contains the string "--password=foo" would have that string replaced with "--password=*****".  Suppose we also see some passwords passed via the -p shorthand for a specific binary, foo. We can also redact these as follows:    {"binary_regex": ["(?:^|/)foo$"], "redact": ["-p(?:\\s+|=)(\\S*)"]}  With both of the above redaction filters in place, we are now redacting all password arguments. |
+| tetragon.resources | object | `{}` |  |
+| tetragon.securityContext.privileged | bool | `true` |  |
+| tetragon.usePerfRingBuffer | bool | `false` |  |
+| tetragonOperator.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels."app.kubernetes.io/name" | string | `"tetragon-operator"` |  |
+| tetragonOperator.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"kubernetes.io/hostname"` |  |
+| tetragonOperator.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
+| tetragonOperator.annotations | object | `{}` | Annotations for the Tetragon Operator Deployment. |
+| tetragonOperator.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | securityContext for the Tetragon Operator Deployment Pod container. |
+| tetragonOperator.enabled | bool | `true` | Enables the Tetragon Operator. |
+| tetragonOperator.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment. |
+| tetragonOperator.extraPodLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment Pods. |
+| tetragonOperator.extraVolumeMounts | list | `[]` |  |
+| tetragonOperator.extraVolumes | list | `[]` | Extra volumes for the Tetragon Operator Deployment. |
+| tetragonOperator.failoverLease | object | `{"enabled":false,"leaseDuration":"15s","leaseRenewDeadline":"5s","leaseRetryPeriod":"2s","namespace":""}` | Lease handling for an automated failover when running multiple replicas |
+| tetragonOperator.failoverLease.enabled | bool | `false` | Enable lease failover functionality |
+| tetragonOperator.failoverLease.leaseDuration | string | `"15s"` | If a lease is not renewed for X duration, the current leader is considered dead, a new leader is picked |
+| tetragonOperator.failoverLease.leaseRenewDeadline | string | `"5s"` | The interval at which the leader will renew the lease |
+| tetragonOperator.failoverLease.leaseRetryPeriod | string | `"2s"` | The timeout between retries if renewal fails |
+| tetragonOperator.failoverLease.namespace | string | `""` | Kubernetes Namespace in which the Lease resource is created. Defaults to the namespace where Tetragon is deployed in, if it's empty. |
+| tetragonOperator.forceUpdateCRDs | bool | `false` |  |
+| tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.7.0"}` | tetragon-operator image. |
+| tetragonOperator.nameOverride | string | `""` | The name of the Tetragon Operator deployment. |
+| tetragonOperator.nodeSelector | object | `{}` | Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules. |
+| tetragonOperator.podAnnotations | object | `{}` | Annotations for the Tetragon Operator Deployment Pods. |
+| tetragonOperator.podInfo.enabled | bool | `false` | Enables the PodInfo CRD and the controller that reconciles PodInfo custom resources. |
+| tetragonOperator.podSecurityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pods. |
+| tetragonOperator.priorityClassName | string | `""` | priorityClassName for the Tetragon Operator Deployment Pods. |
+| tetragonOperator.prometheus.address | string | `""` | The address at which to expose Tetragon Operator metrics. Set it to "" to expose on all available interfaces. |
+| tetragonOperator.prometheus.enabled | bool | `true` | Enables the Tetragon Operator metrics. |
+| tetragonOperator.prometheus.port | int | `2113` | The port at which to expose metrics. |
+| tetragonOperator.prometheus.serviceMonitor.enabled | bool | `false` | Whether to create a 'ServiceMonitor' resource targeting the tetragonOperator pods. |
+| tetragonOperator.prometheus.serviceMonitor.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator ServiceMonitor. |
+| tetragonOperator.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
+| tetragonOperator.prometheus.serviceMonitor.scrapeInterval | string | `"60s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
+| tetragonOperator.replicas | int | `1` | Number of replicas to run for the tetragon-operator deployment |
+| tetragonOperator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | resources for the Tetragon Operator Deployment Pod container. |
+| tetragonOperator.securityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pod container. (DEPRECATED: Use containerSecurityContext instead. TODO: Remove in v1.6.0) |
+| tetragonOperator.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | tetragon-operator service account. |
+| tetragonOperator.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | resources for the Tetragon Operator Deployment update strategy |
+| tetragonOperator.tolerations | list | `[]` |  |
+| tetragonOperator.tracingPolicy.enabled | bool | `true` | Enables the TracingPolicy and TracingPolicyNamespaced CRD creation. |
+| tolerations[0].operator | string | `"Exists"` |  |
+| updateStrategy | object | `{}` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/argocd-helm-charts/tetragon/charts/tetragon/crds-yaml/cilium.io_podinfo.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/crds-yaml/cilium.io_podinfo.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: podinfo.cilium.io
+spec:
+  group: cilium.io
+  names:
+    kind: PodInfo
+    listKind: PodInfoList
+    plural: podinfo
+    shortNames:
+    - tgpi
+    singular: podinfo
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PodInfo is the Scheme for the Podinfo API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              hostNetwork:
+                description: |-
+                  Host networking requested for this pod. Use the host's network namespace.
+                  If this option is set, the ports that will be used must be specified.
+                type: boolean
+              nodeName:
+                description: NodeName is the name of the node that the pod is schduled
+                  to run on.
+                type: string
+            type: object
+          status:
+            properties:
+              podIP:
+                description: |-
+                  IP address allocated to the pod. Routable at least within the cluster.
+                  Empty if not yet allocated.
+                type: string
+              podIPs:
+                description: List of Ip addresses allocated to the pod. 0th entry
+                  must be same as PodIP.
+                items:
+                  properties:
+                    IP:
+                      description: IP is an IP address (IPv4 or IPv6) assigned to
+                        the pod
+                      type: string
+                  type: object
+                type: array
+            type: object
+          workloadObject:
+            description: Workload that created this pod.
+            properties:
+              name:
+                description: Name of the object.
+                type: string
+              namespace:
+                description: Namespace of this object.
+                type: string
+            type: object
+          workloadType:
+            description: Workload type (e.g. "Deployment", "Daemonset") that created
+              this pod.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/argocd-helm-charts/tetragon/charts/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -1,0 +1,6333 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: tracingpolicies.cilium.io
+spec:
+  group: cilium.io
+  names:
+    categories:
+    - tetragon
+    kind: TracingPolicy
+    listKind: TracingPolicyList
+    plural: tracingpolicies
+    shortNames:
+    - tgtp
+    singular: tracingpolicy
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Tracing policy specification.
+            properties:
+              containerSelector:
+                description: |-
+                  ContainerSelector selects containers that this policy applies to.
+                  A map of container fields will be constructed in the same way as a map of labels.
+                  The name of the field represents the label "key", and the value of the field - label "value".
+                  Currently, only the "name" field is supported.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              enforcers:
+                description: A enforcer spec.
+                items:
+                  properties:
+                    calls:
+                      description: Calls where enforcer is executed in
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - calls
+                  type: object
+                type: array
+              fentries:
+                description: A list of fentry specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - sockaddr_un
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
+              hostSelector:
+                description: |-
+                  HostSelector selects hosts that this policy applies to.
+                  For now only ~ (none) and {} (all) is supported.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              kprobes:
+                description: A list of kprobe specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - sockaddr_un
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
+              lists:
+                description: A list of list specs.
+                items:
+                  properties:
+                    name:
+                      description: Name of the list
+                      type: string
+                    pattern:
+                      description: Pattern for 'generated' lists.
+                      type: string
+                    type:
+                      description: Indicates the type of the list values.
+                      enum:
+                      - syscalls
+                      - generated_syscalls
+                      - generated_ftrace
+                      type: string
+                    validated:
+                      description: List was validated
+                      type: boolean
+                    values:
+                      description: Values of the list
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+              loader:
+                description: Enable loader events
+                type: boolean
+              lsmhooks:
+                description: A list of uprobe specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    hook:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - hook
+                  type: object
+                type: array
+              options:
+                description: A list of overloaded options
+                items:
+                  properties:
+                    name:
+                      description: Name of the option
+                      type: string
+                    value:
+                      description: Value of the option
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              podSelector:
+                description: PodSelector selects pods that this policy applies to
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              selectorsMacros:
+                additionalProperties:
+                  description: |-
+                    KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                    results of MatchPIDs and MatchArgs are ANDed.
+                  properties:
+                    macros:
+                      description: |-
+                        A list of macros names, defined in spec.selectorsMacros.
+                        Filters specified in macros will be appended to corresponding filters of the selector.
+                      items:
+                        type: string
+                      type: array
+                    matchActions:
+                      description: A list of actions to execute when this selector
+                        matches
+                      items:
+                        properties:
+                          action:
+                            description: |-
+                              Action to execute.
+                              NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                              be removed in version 1.5.
+                            enum:
+                            - Post
+                            - FollowFD
+                            - UnfollowFD
+                            - Sigkill
+                            - CopyFD
+                            - Override
+                            - GetUrl
+                            - DnsLookup
+                            - NoPost
+                            - Signal
+                            - TrackSock
+                            - UntrackSock
+                            - NotifyEnforcer
+                            - CleanupEnforcerNotification
+                            - Set
+                            type: string
+                          argError:
+                            description: error value for override action
+                            format: int32
+                            type: integer
+                          argFd:
+                            description: An arg index for the fd for fdInstall action
+                            format: int32
+                            type: integer
+                          argFqdn:
+                            description: A FQDN to lookup for the dnsLookup action
+                            type: string
+                          argIndex:
+                            description: An arg index for the set action
+                            format: int32
+                            type: integer
+                          argName:
+                            description: An arg index for the filename for fdInstall
+                              action
+                            format: int32
+                            type: integer
+                          argRegs:
+                            description: An arg value for the regs action
+                            items:
+                              type: string
+                            type: array
+                          argSig:
+                            description: A signal number for signal action
+                            format: int32
+                            type: integer
+                          argSock:
+                            description: An arg index for the sock for trackSock and
+                              untrackSock actions
+                            format: int32
+                            type: integer
+                          argUrl:
+                            description: A URL for the getUrl action
+                            type: string
+                          argValue:
+                            description: An arg value for the set action
+                            format: int32
+                            type: integer
+                          imaHash:
+                            description: |-
+                              Enable collection of file hashes from integrity subsystem.
+                              Only valid with the post action.
+                            type: boolean
+                          kernelStackTrace:
+                            description: Enable kernel stack trace export. Only valid
+                              with the post action.
+                            type: boolean
+                          rateLimit:
+                            description: |-
+                              A time period within which repeated messages will not be posted. Can be
+                              specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                              or hours ('h' suffix). Only valid with the post action.
+                            type: string
+                          rateLimitScope:
+                            description: |-
+                              The scope of the provided rate limit argument. Can be "thread" (default),
+                              "process" (all threads for the same process), or "global". If "thread" is
+                              selected then rate limiting applies per thread; if "process" is selected
+                              then rate limiting applies per process; if "global" is selected then rate
+                              limiting applies regardless of which process or thread caused the action.
+                              Only valid with the post action and with a rateLimit specified.
+                            type: string
+                          userStackTrace:
+                            description: Enable user stack trace export. Only valid
+                              with the post action.
+                            type: boolean
+                        required:
+                        - action
+                        type: object
+                      type: array
+                    matchArgs:
+                      description: A list of argument filters. MatchArgs are ANDed.
+                      items:
+                        properties:
+                          args:
+                            description: Position of the operator arguments (in spec
+                              file) to apply fhe filter to.
+                            items:
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type: array
+                          index:
+                            description: Position of the argument (in function prototype)
+                              to apply fhe filter to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - Equal
+                            - NotEqual
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            - GreaterThan
+                            - LessThan
+                            - GT
+                            - LT
+                            - Mask
+                            - SPort
+                            - NotSPort
+                            - SPortPriv
+                            - NotSportPriv
+                            - DPort
+                            - NotDPort
+                            - DPortPriv
+                            - NotDPortPriv
+                            - SAddr
+                            - NotSAddr
+                            - DAddr
+                            - NotDAddr
+                            - Protocol
+                            - Family
+                            - State
+                            - InMap
+                            - NotInMap
+                            - CapabilitiesGained
+                            - InRange
+                            - NotInRange
+                            - SubString
+                            - SubStringIgnCase
+                            - CelExpr
+                            - FileType
+                            - NotFileType
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        type: object
+                      type: array
+                    matchBinaries:
+                      description: A list of binary exec name filters.
+                      items:
+                        properties:
+                          followChildren:
+                            default: false
+                            description: In addition to binaries, match children processes
+                              of specified binaries.
+                            type: boolean
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - In
+                            - NotIn
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      maxItems: 1
+                      type: array
+                    matchCapabilities:
+                      description: A list of capabilities and IDs
+                      items:
+                        properties:
+                          isNamespaceCapability:
+                            default: false
+                            description: Indicates whether these caps are namespace
+                              caps.
+                            type: boolean
+                          operator:
+                            description: Namespace selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          type:
+                            default: Effective
+                            description: Type of capabilities
+                            enum:
+                            - Effective
+                            - Inheritable
+                            - Permitted
+                            type: string
+                          values:
+                            description: Capabilities to match.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchCapabilityChanges:
+                      description: IDs for capabilities changes
+                      items:
+                        properties:
+                          isNamespaceCapability:
+                            default: false
+                            description: Indicates whether these caps are namespace
+                              caps.
+                            type: boolean
+                          operator:
+                            description: Namespace selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          type:
+                            default: Effective
+                            description: Type of capabilities
+                            enum:
+                            - Effective
+                            - Inheritable
+                            - Permitted
+                            type: string
+                          values:
+                            description: Capabilities to match.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchData:
+                      description: A list of argument filters. MatchData are ANDed.
+                      items:
+                        properties:
+                          args:
+                            description: Position of the operator arguments (in spec
+                              file) to apply fhe filter to.
+                            items:
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type: array
+                          index:
+                            description: Position of the argument (in function prototype)
+                              to apply fhe filter to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - Equal
+                            - NotEqual
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            - GreaterThan
+                            - LessThan
+                            - GT
+                            - LT
+                            - Mask
+                            - SPort
+                            - NotSPort
+                            - SPortPriv
+                            - NotSportPriv
+                            - DPort
+                            - NotDPort
+                            - DPortPriv
+                            - NotDPortPriv
+                            - SAddr
+                            - NotSAddr
+                            - DAddr
+                            - NotDAddr
+                            - Protocol
+                            - Family
+                            - State
+                            - InMap
+                            - NotInMap
+                            - CapabilitiesGained
+                            - InRange
+                            - NotInRange
+                            - SubString
+                            - SubStringIgnCase
+                            - CelExpr
+                            - FileType
+                            - NotFileType
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        type: object
+                      type: array
+                    matchNamespaceChanges:
+                      description: IDs for namespace changes
+                      items:
+                        properties:
+                          operator:
+                            description: Namespace selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          values:
+                            description: Namespace types (e.g., Mnt, Pid) to match.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchNamespaces:
+                      description: A list of namespaces and IDs
+                      items:
+                        properties:
+                          namespace:
+                            description: Namespace selector name.
+                            enum:
+                            - Uts
+                            - Ipc
+                            - Mnt
+                            - Pid
+                            - PidForChildren
+                            - Net
+                            - Time
+                            - TimeForChildren
+                            - Cgroup
+                            - User
+                            type: string
+                          operator:
+                            description: Namespace selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          values:
+                            description: Namespace IDs (or host_ns for host namespace)
+                              of namespaces to match.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - namespace
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchPIDs:
+                      description: A list of process ID filters. MatchPIDs are ANDed.
+                      items:
+                        properties:
+                          followForks:
+                            default: false
+                            description: Matches any descendant processes of the matching
+                              PIDs.
+                            type: boolean
+                          isNamespacePID:
+                            default: false
+                            description: Indicates whether PIDs are namespace PIDs.
+                            type: boolean
+                          operator:
+                            description: PID selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          values:
+                            description: Process IDs to match.
+                            items:
+                              format: int32
+                              type: integer
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchParentBinaries:
+                      description: A list of process parent exec name filters.
+                      items:
+                        properties:
+                          followChildren:
+                            default: false
+                            description: In addition to binaries, match children processes
+                              of specified binaries.
+                            type: boolean
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - In
+                            - NotIn
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      maxItems: 1
+                      type: array
+                    matchReturnActions:
+                      description: A list of actions to execute when MatchReturnArgs
+                        selector matches
+                      items:
+                        properties:
+                          action:
+                            description: |-
+                              Action to execute.
+                              NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                              be removed in version 1.5.
+                            enum:
+                            - Post
+                            - FollowFD
+                            - UnfollowFD
+                            - Sigkill
+                            - CopyFD
+                            - Override
+                            - GetUrl
+                            - DnsLookup
+                            - NoPost
+                            - Signal
+                            - TrackSock
+                            - UntrackSock
+                            - NotifyEnforcer
+                            - CleanupEnforcerNotification
+                            - Set
+                            type: string
+                          argError:
+                            description: error value for override action
+                            format: int32
+                            type: integer
+                          argFd:
+                            description: An arg index for the fd for fdInstall action
+                            format: int32
+                            type: integer
+                          argFqdn:
+                            description: A FQDN to lookup for the dnsLookup action
+                            type: string
+                          argIndex:
+                            description: An arg index for the set action
+                            format: int32
+                            type: integer
+                          argName:
+                            description: An arg index for the filename for fdInstall
+                              action
+                            format: int32
+                            type: integer
+                          argRegs:
+                            description: An arg value for the regs action
+                            items:
+                              type: string
+                            type: array
+                          argSig:
+                            description: A signal number for signal action
+                            format: int32
+                            type: integer
+                          argSock:
+                            description: An arg index for the sock for trackSock and
+                              untrackSock actions
+                            format: int32
+                            type: integer
+                          argUrl:
+                            description: A URL for the getUrl action
+                            type: string
+                          argValue:
+                            description: An arg value for the set action
+                            format: int32
+                            type: integer
+                          imaHash:
+                            description: |-
+                              Enable collection of file hashes from integrity subsystem.
+                              Only valid with the post action.
+                            type: boolean
+                          kernelStackTrace:
+                            description: Enable kernel stack trace export. Only valid
+                              with the post action.
+                            type: boolean
+                          rateLimit:
+                            description: |-
+                              A time period within which repeated messages will not be posted. Can be
+                              specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                              or hours ('h' suffix). Only valid with the post action.
+                            type: string
+                          rateLimitScope:
+                            description: |-
+                              The scope of the provided rate limit argument. Can be "thread" (default),
+                              "process" (all threads for the same process), or "global". If "thread" is
+                              selected then rate limiting applies per thread; if "process" is selected
+                              then rate limiting applies per process; if "global" is selected then rate
+                              limiting applies regardless of which process or thread caused the action.
+                              Only valid with the post action and with a rateLimit specified.
+                            type: string
+                          userStackTrace:
+                            description: Enable user stack trace export. Only valid
+                              with the post action.
+                            type: boolean
+                        required:
+                        - action
+                        type: object
+                      type: array
+                    matchReturnArgs:
+                      description: A list of argument filters. MatchArgs are ANDed.
+                      items:
+                        properties:
+                          args:
+                            description: Position of the operator arguments (in spec
+                              file) to apply fhe filter to.
+                            items:
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type: array
+                          index:
+                            description: Position of the argument (in function prototype)
+                              to apply fhe filter to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - Equal
+                            - NotEqual
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            - GreaterThan
+                            - LessThan
+                            - GT
+                            - LT
+                            - Mask
+                            - SPort
+                            - NotSPort
+                            - SPortPriv
+                            - NotSportPriv
+                            - DPort
+                            - NotDPort
+                            - DPortPriv
+                            - NotDPortPriv
+                            - SAddr
+                            - NotSAddr
+                            - DAddr
+                            - NotDAddr
+                            - Protocol
+                            - Family
+                            - State
+                            - InMap
+                            - NotInMap
+                            - CapabilitiesGained
+                            - InRange
+                            - NotInRange
+                            - SubString
+                            - SubStringIgnCase
+                            - CelExpr
+                            - FileType
+                            - NotFileType
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        type: object
+                      type: array
+                  type: object
+                description: |-
+                  SelectorsMacros is used to define selectors macros, which can be used
+                  in probes/hooks selectors by their names.
+                type: object
+              tracepoints:
+                description: A list of tracepoint specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    event:
+                      description: Tracepoint event
+                      type: string
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    raw:
+                      description: Enable raw tracepoint arguments
+                      type: boolean
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    subsystem:
+                      description: Tracepoint subsystem
+                      type: string
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - event
+                  - subsystem
+                  type: object
+                type: array
+              uprobes:
+                description: A list of uprobe specs.
+                items:
+                  properties:
+                    addrs:
+                      description: List of the traced addresses
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    btfPath:
+                      description: path for a BTF file for the traced binary
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    offsets:
+                      description: List of the traced offsets
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    path:
+                      description: Name of the traced binary
+                      type: string
+                    refCtrOffsets:
+                      description: List of the traced ref_ctr_offsets
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - sockaddr_un
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    symbols:
+                      description: List of the traced symbols
+                      items:
+                        type: string
+                      type: array
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - path
+                  type: object
+                type: array
+              usdts:
+                description: A list of usdt specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    btfPath:
+                      description: path for a BTF file for the traced binary
+                      type: string
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    name:
+                      description: Usdt name
+                      type: string
+                    path:
+                      description: Name of the traced binary
+                      type: string
+                    provider:
+                      description: Usdt provider name
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - name
+                  - path
+                  - provider
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/argocd-helm-charts/tetragon/charts/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1,0 +1,6336 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: tracingpoliciesnamespaced.cilium.io
+spec:
+  group: cilium.io
+  names:
+    categories:
+    - tetragon
+    kind: TracingPolicyNamespaced
+    listKind: TracingPolicyNamespacedList
+    plural: tracingpoliciesnamespaced
+    shortNames:
+    - tgtpn
+    singular: tracingpolicynamespaced
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Tracing policy specification.
+            properties:
+              containerSelector:
+                description: |-
+                  ContainerSelector selects containers that this policy applies to.
+                  A map of container fields will be constructed in the same way as a map of labels.
+                  The name of the field represents the label "key", and the value of the field - label "value".
+                  Currently, only the "name" field is supported.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              enforcers:
+                description: A enforcer spec.
+                items:
+                  properties:
+                    calls:
+                      description: Calls where enforcer is executed in
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - calls
+                  type: object
+                type: array
+              fentries:
+                description: A list of fentry specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - sockaddr_un
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
+              hostSelector:
+                description: |-
+                  HostSelector selects hosts that this policy applies to.
+                  For now only ~ (none) and {} (all) is supported.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              kprobes:
+                description: A list of kprobe specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - sockaddr_un
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
+              lists:
+                description: A list of list specs.
+                items:
+                  properties:
+                    name:
+                      description: Name of the list
+                      type: string
+                    pattern:
+                      description: Pattern for 'generated' lists.
+                      type: string
+                    type:
+                      description: Indicates the type of the list values.
+                      enum:
+                      - syscalls
+                      - generated_syscalls
+                      - generated_ftrace
+                      type: string
+                    validated:
+                      description: List was validated
+                      type: boolean
+                    values:
+                      description: Values of the list
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+              loader:
+                description: Enable loader events
+                type: boolean
+              lsmhooks:
+                description: A list of uprobe specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    hook:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - hook
+                  type: object
+                type: array
+              options:
+                description: A list of overloaded options
+                items:
+                  properties:
+                    name:
+                      description: Name of the option
+                      type: string
+                    value:
+                      description: Value of the option
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              podSelector:
+                description: PodSelector selects pods that this policy applies to
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              selectorsMacros:
+                additionalProperties:
+                  description: |-
+                    KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                    results of MatchPIDs and MatchArgs are ANDed.
+                  properties:
+                    macros:
+                      description: |-
+                        A list of macros names, defined in spec.selectorsMacros.
+                        Filters specified in macros will be appended to corresponding filters of the selector.
+                      items:
+                        type: string
+                      type: array
+                    matchActions:
+                      description: A list of actions to execute when this selector
+                        matches
+                      items:
+                        properties:
+                          action:
+                            description: |-
+                              Action to execute.
+                              NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                              be removed in version 1.5.
+                            enum:
+                            - Post
+                            - FollowFD
+                            - UnfollowFD
+                            - Sigkill
+                            - CopyFD
+                            - Override
+                            - GetUrl
+                            - DnsLookup
+                            - NoPost
+                            - Signal
+                            - TrackSock
+                            - UntrackSock
+                            - NotifyEnforcer
+                            - CleanupEnforcerNotification
+                            - Set
+                            type: string
+                          argError:
+                            description: error value for override action
+                            format: int32
+                            type: integer
+                          argFd:
+                            description: An arg index for the fd for fdInstall action
+                            format: int32
+                            type: integer
+                          argFqdn:
+                            description: A FQDN to lookup for the dnsLookup action
+                            type: string
+                          argIndex:
+                            description: An arg index for the set action
+                            format: int32
+                            type: integer
+                          argName:
+                            description: An arg index for the filename for fdInstall
+                              action
+                            format: int32
+                            type: integer
+                          argRegs:
+                            description: An arg value for the regs action
+                            items:
+                              type: string
+                            type: array
+                          argSig:
+                            description: A signal number for signal action
+                            format: int32
+                            type: integer
+                          argSock:
+                            description: An arg index for the sock for trackSock and
+                              untrackSock actions
+                            format: int32
+                            type: integer
+                          argUrl:
+                            description: A URL for the getUrl action
+                            type: string
+                          argValue:
+                            description: An arg value for the set action
+                            format: int32
+                            type: integer
+                          imaHash:
+                            description: |-
+                              Enable collection of file hashes from integrity subsystem.
+                              Only valid with the post action.
+                            type: boolean
+                          kernelStackTrace:
+                            description: Enable kernel stack trace export. Only valid
+                              with the post action.
+                            type: boolean
+                          rateLimit:
+                            description: |-
+                              A time period within which repeated messages will not be posted. Can be
+                              specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                              or hours ('h' suffix). Only valid with the post action.
+                            type: string
+                          rateLimitScope:
+                            description: |-
+                              The scope of the provided rate limit argument. Can be "thread" (default),
+                              "process" (all threads for the same process), or "global". If "thread" is
+                              selected then rate limiting applies per thread; if "process" is selected
+                              then rate limiting applies per process; if "global" is selected then rate
+                              limiting applies regardless of which process or thread caused the action.
+                              Only valid with the post action and with a rateLimit specified.
+                            type: string
+                          userStackTrace:
+                            description: Enable user stack trace export. Only valid
+                              with the post action.
+                            type: boolean
+                        required:
+                        - action
+                        type: object
+                      type: array
+                    matchArgs:
+                      description: A list of argument filters. MatchArgs are ANDed.
+                      items:
+                        properties:
+                          args:
+                            description: Position of the operator arguments (in spec
+                              file) to apply fhe filter to.
+                            items:
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type: array
+                          index:
+                            description: Position of the argument (in function prototype)
+                              to apply fhe filter to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - Equal
+                            - NotEqual
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            - GreaterThan
+                            - LessThan
+                            - GT
+                            - LT
+                            - Mask
+                            - SPort
+                            - NotSPort
+                            - SPortPriv
+                            - NotSportPriv
+                            - DPort
+                            - NotDPort
+                            - DPortPriv
+                            - NotDPortPriv
+                            - SAddr
+                            - NotSAddr
+                            - DAddr
+                            - NotDAddr
+                            - Protocol
+                            - Family
+                            - State
+                            - InMap
+                            - NotInMap
+                            - CapabilitiesGained
+                            - InRange
+                            - NotInRange
+                            - SubString
+                            - SubStringIgnCase
+                            - CelExpr
+                            - FileType
+                            - NotFileType
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        type: object
+                      type: array
+                    matchBinaries:
+                      description: A list of binary exec name filters.
+                      items:
+                        properties:
+                          followChildren:
+                            default: false
+                            description: In addition to binaries, match children processes
+                              of specified binaries.
+                            type: boolean
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - In
+                            - NotIn
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      maxItems: 1
+                      type: array
+                    matchCapabilities:
+                      description: A list of capabilities and IDs
+                      items:
+                        properties:
+                          isNamespaceCapability:
+                            default: false
+                            description: Indicates whether these caps are namespace
+                              caps.
+                            type: boolean
+                          operator:
+                            description: Namespace selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          type:
+                            default: Effective
+                            description: Type of capabilities
+                            enum:
+                            - Effective
+                            - Inheritable
+                            - Permitted
+                            type: string
+                          values:
+                            description: Capabilities to match.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchCapabilityChanges:
+                      description: IDs for capabilities changes
+                      items:
+                        properties:
+                          isNamespaceCapability:
+                            default: false
+                            description: Indicates whether these caps are namespace
+                              caps.
+                            type: boolean
+                          operator:
+                            description: Namespace selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          type:
+                            default: Effective
+                            description: Type of capabilities
+                            enum:
+                            - Effective
+                            - Inheritable
+                            - Permitted
+                            type: string
+                          values:
+                            description: Capabilities to match.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchData:
+                      description: A list of argument filters. MatchData are ANDed.
+                      items:
+                        properties:
+                          args:
+                            description: Position of the operator arguments (in spec
+                              file) to apply fhe filter to.
+                            items:
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type: array
+                          index:
+                            description: Position of the argument (in function prototype)
+                              to apply fhe filter to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - Equal
+                            - NotEqual
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            - GreaterThan
+                            - LessThan
+                            - GT
+                            - LT
+                            - Mask
+                            - SPort
+                            - NotSPort
+                            - SPortPriv
+                            - NotSportPriv
+                            - DPort
+                            - NotDPort
+                            - DPortPriv
+                            - NotDPortPriv
+                            - SAddr
+                            - NotSAddr
+                            - DAddr
+                            - NotDAddr
+                            - Protocol
+                            - Family
+                            - State
+                            - InMap
+                            - NotInMap
+                            - CapabilitiesGained
+                            - InRange
+                            - NotInRange
+                            - SubString
+                            - SubStringIgnCase
+                            - CelExpr
+                            - FileType
+                            - NotFileType
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        type: object
+                      type: array
+                    matchNamespaceChanges:
+                      description: IDs for namespace changes
+                      items:
+                        properties:
+                          operator:
+                            description: Namespace selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          values:
+                            description: Namespace types (e.g., Mnt, Pid) to match.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchNamespaces:
+                      description: A list of namespaces and IDs
+                      items:
+                        properties:
+                          namespace:
+                            description: Namespace selector name.
+                            enum:
+                            - Uts
+                            - Ipc
+                            - Mnt
+                            - Pid
+                            - PidForChildren
+                            - Net
+                            - Time
+                            - TimeForChildren
+                            - Cgroup
+                            - User
+                            type: string
+                          operator:
+                            description: Namespace selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          values:
+                            description: Namespace IDs (or host_ns for host namespace)
+                              of namespaces to match.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - namespace
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchPIDs:
+                      description: A list of process ID filters. MatchPIDs are ANDed.
+                      items:
+                        properties:
+                          followForks:
+                            default: false
+                            description: Matches any descendant processes of the matching
+                              PIDs.
+                            type: boolean
+                          isNamespacePID:
+                            default: false
+                            description: Indicates whether PIDs are namespace PIDs.
+                            type: boolean
+                          operator:
+                            description: PID selector operator.
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                          values:
+                            description: Process IDs to match.
+                            items:
+                              format: int32
+                              type: integer
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchParentBinaries:
+                      description: A list of process parent exec name filters.
+                      items:
+                        properties:
+                          followChildren:
+                            default: false
+                            description: In addition to binaries, match children processes
+                              of specified binaries.
+                            type: boolean
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - In
+                            - NotIn
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      maxItems: 1
+                      type: array
+                    matchReturnActions:
+                      description: A list of actions to execute when MatchReturnArgs
+                        selector matches
+                      items:
+                        properties:
+                          action:
+                            description: |-
+                              Action to execute.
+                              NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                              be removed in version 1.5.
+                            enum:
+                            - Post
+                            - FollowFD
+                            - UnfollowFD
+                            - Sigkill
+                            - CopyFD
+                            - Override
+                            - GetUrl
+                            - DnsLookup
+                            - NoPost
+                            - Signal
+                            - TrackSock
+                            - UntrackSock
+                            - NotifyEnforcer
+                            - CleanupEnforcerNotification
+                            - Set
+                            type: string
+                          argError:
+                            description: error value for override action
+                            format: int32
+                            type: integer
+                          argFd:
+                            description: An arg index for the fd for fdInstall action
+                            format: int32
+                            type: integer
+                          argFqdn:
+                            description: A FQDN to lookup for the dnsLookup action
+                            type: string
+                          argIndex:
+                            description: An arg index for the set action
+                            format: int32
+                            type: integer
+                          argName:
+                            description: An arg index for the filename for fdInstall
+                              action
+                            format: int32
+                            type: integer
+                          argRegs:
+                            description: An arg value for the regs action
+                            items:
+                              type: string
+                            type: array
+                          argSig:
+                            description: A signal number for signal action
+                            format: int32
+                            type: integer
+                          argSock:
+                            description: An arg index for the sock for trackSock and
+                              untrackSock actions
+                            format: int32
+                            type: integer
+                          argUrl:
+                            description: A URL for the getUrl action
+                            type: string
+                          argValue:
+                            description: An arg value for the set action
+                            format: int32
+                            type: integer
+                          imaHash:
+                            description: |-
+                              Enable collection of file hashes from integrity subsystem.
+                              Only valid with the post action.
+                            type: boolean
+                          kernelStackTrace:
+                            description: Enable kernel stack trace export. Only valid
+                              with the post action.
+                            type: boolean
+                          rateLimit:
+                            description: |-
+                              A time period within which repeated messages will not be posted. Can be
+                              specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                              or hours ('h' suffix). Only valid with the post action.
+                            type: string
+                          rateLimitScope:
+                            description: |-
+                              The scope of the provided rate limit argument. Can be "thread" (default),
+                              "process" (all threads for the same process), or "global". If "thread" is
+                              selected then rate limiting applies per thread; if "process" is selected
+                              then rate limiting applies per process; if "global" is selected then rate
+                              limiting applies regardless of which process or thread caused the action.
+                              Only valid with the post action and with a rateLimit specified.
+                            type: string
+                          userStackTrace:
+                            description: Enable user stack trace export. Only valid
+                              with the post action.
+                            type: boolean
+                        required:
+                        - action
+                        type: object
+                      type: array
+                    matchReturnArgs:
+                      description: A list of argument filters. MatchArgs are ANDed.
+                      items:
+                        properties:
+                          args:
+                            description: Position of the operator arguments (in spec
+                              file) to apply fhe filter to.
+                            items:
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            type: array
+                          index:
+                            description: Position of the argument (in function prototype)
+                              to apply fhe filter to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          operator:
+                            description: Filter operation.
+                            enum:
+                            - Equal
+                            - NotEqual
+                            - Prefix
+                            - NotPrefix
+                            - Postfix
+                            - NotPostfix
+                            - GreaterThan
+                            - LessThan
+                            - GT
+                            - LT
+                            - Mask
+                            - SPort
+                            - NotSPort
+                            - SPortPriv
+                            - NotSportPriv
+                            - DPort
+                            - NotDPort
+                            - DPortPriv
+                            - NotDPortPriv
+                            - SAddr
+                            - NotSAddr
+                            - DAddr
+                            - NotDAddr
+                            - Protocol
+                            - Family
+                            - State
+                            - InMap
+                            - NotInMap
+                            - CapabilitiesGained
+                            - InRange
+                            - NotInRange
+                            - SubString
+                            - SubStringIgnCase
+                            - CelExpr
+                            - FileType
+                            - NotFileType
+                            type: string
+                          values:
+                            description: Value to compare the argument against.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        type: object
+                      type: array
+                  type: object
+                description: |-
+                  SelectorsMacros is used to define selectors macros, which can be used
+                  in probes/hooks selectors by their names.
+                type: object
+              tracepoints:
+                description: A list of tracepoint specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    event:
+                      description: Tracepoint event
+                      type: string
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    raw:
+                      description: Enable raw tracepoint arguments
+                      type: boolean
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    subsystem:
+                      description: Tracepoint subsystem
+                      type: string
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - event
+                  - subsystem
+                  type: object
+                type: array
+              uprobes:
+                description: A list of uprobe specs.
+                items:
+                  properties:
+                    addrs:
+                      description: List of the traced addresses
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    btfPath:
+                      description: path for a BTF file for the traced binary
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    offsets:
+                      description: List of the traced offsets
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    path:
+                      description: Name of the traced binary
+                      type: string
+                    refCtrOffsets:
+                      description: List of the traced ref_ctr_offsets
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - sockaddr_un
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    symbols:
+                      description: List of the traced symbols
+                      items:
+                        type: string
+                      type: array
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - path
+                  type: object
+                type: array
+              usdts:
+                description: A list of usdt specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - sockaddr_un
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    btfPath:
+                      description: path for a BTF file for the traced binary
+                      type: string
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    name:
+                      description: Usdt name
+                      type: string
+                    path:
+                      description: Name of the traced binary
+                      type: string
+                    provider:
+                      description: Usdt provider name
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            maxItems: 1
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - name
+                  - path
+                  - provider
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: TracingPolicyNamespaced should have a null spec.hostSelector.
+          rule: '!has(self.spec.hostSelector)'
+    served: true
+    storage: true

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/_container_export_stdout.tpl
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/_container_export_stdout.tpl
@@ -1,0 +1,57 @@
+{{- define "container.export.stdout" -}}
+- name: {{include "container.export.stdout.name" .}}
+  image: "{{ if .Values.export.stdout.image.override }}{{ .Values.export.stdout.image.override }}{{ else }}{{ .Values.export.stdout.image.repository }}:{{ .Values.export.stdout.image.tag }}{{ end }}"
+  imagePullPolicy: {{ .Values.imagePullPolicy }}
+  terminationMessagePolicy: FallbackToLogsOnError
+  {{- with .Values.export.stdout.extraEnv }}
+  env:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $envFrom := list }}
+  {{- with .Values.export.stdout.extraEnvFrom }}
+    {{- $envFrom = concat $envFrom . }}
+  {{- end }}
+  {{- range $item := .Values.export.stdout.envFromSecrets }}
+    {{- if kindIs "map" $item }}
+      {{- $sr := dict "name" ($item.name | default "") }}
+      {{- if hasKey $item "optional" }}
+        {{- $_ := set $sr "optional" $item.optional }}
+      {{- end }}
+      {{- $envFrom = append $envFrom (dict "secretRef" $sr) }}
+    {{- else }}
+      {{- $envFrom = append $envFrom (dict "secretRef" (dict "name" $item)) }}
+    {{- end }}
+  {{- end }}
+  {{- if gt (len $envFrom) 0 }}
+  envFrom:
+    {{- toYaml $envFrom | nindent 4 }}
+  {{- end }}
+  securityContext:
+    {{- toYaml .Values.export.securityContext | nindent 4 }}
+  resources:
+    {{- toYaml .Values.export.resources | nindent 4 }}
+{{- if .Values.export.stdout.enabledCommand }}  
+  command:
+  {{- with .Values.export.stdout.commandOverride }}
+  {{- toYaml . | nindent 3 }}
+  {{- else }}
+    - hubble-export-stdout
+  {{- end }}
+{{- end}}
+{{- if .Values.export.stdout.enabledArgs }}  
+  args:
+  {{- with .Values.export.stdout.argsOverride }}
+  {{- toYaml . | nindent 3 }}
+  {{- else }}
+  {{- range .Values.export.filenames }}
+    - {{ $.Values.exportDirectory }}/{{ . }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+  volumeMounts:
+    - name: export-logs
+      mountPath: {{ .Values.exportDirectory }}
+      {{- with .Values.export.stdout.extraVolumeMounts }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}      
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/_container_rthooks.tpl
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/_container_rthooks.tpl
@@ -1,0 +1,43 @@
+{{- define "container.tetragon-rthooks" -}}
+- name: tetragon-rthooks
+  image: "{{ if .Values.rthooks.image.override }}{{ .Values.rthooks.image.override }}{{ else }}{{ .Values.rthooks.image.repository }}:{{ .Values.rthooks.image.tag }}{{ end }}"
+  terminationMessagePolicy: FallbackToLogsOnError
+  imagePullPolicy: {{ .Values.imagePullPolicy }}
+  command:
+    - tetragon-oci-hook-setup
+    - install
+    - --interface={{ include "rthooksInterface" .  | required "rtooks.interface needs to be correctly defined" }}
+    - --local-install-dir={{  include "container.tetragonOCIHookSetup.installPath" . }}
+    - --host-install-dir={{ .Values.rthooks.installDir }}
+    - --oci-hooks.local-dir={{ include "container.tetragonOCIHookSetup.hooksPath" . }}
+    - --daemonize
+    - hook-args
+    - --grpc-address={{ .Values.tetragon.grpc.address }}
+    - --fail-allow-namespaces
+    - {{ if .Values.rthooks.failAllowNamespaces }}{{ printf "%s,%s" .Release.Namespace .Values.rthooks.failAllowNamespaces }}{{ else }}{{ .Release.Namespace }}{{ end }}
+   {{- range $key, $value := .Values.rthooks.extraHookArgs }}
+   {{- if eq nil $value }}
+    - --{{ $key }}
+   {{- else }}
+    - --{{ $key }}={{ $value }}
+  {{- end }}
+  {{- end }}
+  volumeMounts:
+    {{- with .Values.rthooks.extraVolumeMounts }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    - name: oci-hook-install-path
+      mountPath: {{  include "container.tetragonOCIHookSetup.installPath" . }}
+{{- if (eq .Values.rthooks.interface "oci-hooks") }}
+    - name: oci-hooks-path
+      mountPath: {{  include "container.tetragonOCIHookSetup.hooksPath" . }}
+{{- end }}
+{{- if (eq .Values.rthooks.interface "nri-hook") }}
+    - name: nri-socket-path
+      mountPath: {{ .Values.rthooks.nriHook.nriSocket }}
+{{- end }}
+{{- with .Values.rthooks.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end -}}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/_container_tetragon.tpl
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/_container_tetragon.tpl
@@ -1,0 +1,84 @@
+{{- define "container.tetragon" -}}
+- name: {{ include "container.tetragon.name" . }}
+  securityContext:
+    {{- toYaml .Values.tetragon.securityContext | nindent 4 }}
+  image: "{{ if .Values.tetragon.image.override }}{{ .Values.tetragon.image.override }}{{ else }}{{ .Values.tetragon.image.repository }}:{{ .Values.tetragon.image.tag | default .Chart.AppVersion }}{{ end }}"
+  imagePullPolicy: {{ .Values.imagePullPolicy }}
+  terminationMessagePolicy: FallbackToLogsOnError
+{{- with .Values.tetragon.commandOverride }}
+  command:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+  args:
+    - --config-dir=/etc/tetragon/tetragon.conf.d/
+{{- with .Values.tetragon.argsOverride }}
+  {{- toYaml . | nindent 2 }}
+{{- else }}
+{{- range $key, $value := .Values.tetragon.extraArgs }}
+{{- if $value }}
+    - --{{ $key }}={{ $value }}
+{{- else }}
+    - --{{ $key }}
+{{- end }}
+{{- end }}
+{{- end }}
+  volumeMounts:
+    {{- with .Values.tetragon.extraVolumeMounts }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    - mountPath: /etc/tetragon/tetragon.conf.d/
+      name: tetragon-config
+      readOnly: true
+    - mountPath: /sys/fs/bpf
+      mountPropagation: Bidirectional
+      name: bpf-maps
+    - mountPath: "/var/run/cilium"
+      name: cilium-run
+    - mountPath: "/var/run/tetragon"
+      name: tetragon-run
+    - mountPath: {{ .Values.exportDirectory }}
+      name: export-logs
+    - mountPath: "/procRoot"
+      name: host-proc
+{{- if and (.Values.tetragon.cri.enabled) (.Values.tetragon.cri.socketHostPath) }}
+    - mountPath: {{ quote .Values.tetragon.cri.socketHostPath }}
+      name: cri-socket
+{{- end }}
+{{- range .Values.extraHostPathMounts }}
+    - name: {{ .name }}
+      mountPath: {{ .mountPath }}
+      readOnly: {{ .readOnly }}
+{{- if .mountPropagation }}
+      mountPropagation: {{ .mountPropagation }}
+{{- end }}
+{{- end }}
+{{- range .Values.extraConfigmapMounts }}
+    - name: {{ .name }}
+      mountPath: {{ .mountPath }}
+      readOnly: {{ .readOnly }}
+{{- end }}
+    {{- include "tetragon.volumemounts.extra" . | nindent 4 }}
+  env:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+            fieldPath: spec.nodeName
+{{- if .Values.tetragon.extraEnv }}
+  {{- toYaml .Values.tetragon.extraEnv | nindent 4 }}
+{{- end }}
+{{- with .Values.tetragon.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.tetragon.livenessProbe }}
+  livenessProbe:
+  {{- toYaml .Values.tetragon.livenessProbe | nindent 4 }}
+{{- else if .Values.tetragon.healthGrpc.enabled }}
+  livenessProbe:
+     timeoutSeconds: 60
+     grpc:
+      port: {{ .Values.tetragon.healthGrpc.port }}
+      service: "liveness"
+{{- end -}}
+{{- end -}}
+

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/_extensions.tpl
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/_extensions.tpl
@@ -1,0 +1,17 @@
+{{- define "configmap.extra" -}}{{- end }}
+
+{{- define "volumes.extra" -}}{{- end }}
+
+{{- define "tetragon.volumemounts.extra" -}}{{- end }}
+
+{{- define "initcontainers.extra" -}}{{- end }}
+
+{{- define "containers.extra" -}}{{- end }}
+
+{{- define "clusterrole.extra" -}}{{- end }}
+
+{{- define "role.extra" -}}{{- end }}
+
+{{- define "operatorconfigmap.extra" -}}{{- end }}
+
+{{- define "operatorclusterrole.extra" -}}{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/_helpers.tpl
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/_helpers.tpl
@@ -1,0 +1,142 @@
+{{/*
+Resources names
+*/}}
+{{- define "tetragon.name" -}}
+{{- default .Release.Name .Values.tetragon.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "tetragon.configMapName" -}}
+{{- printf "%s-config" (include "tetragon.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "tetragon.clusterRole" -}}
+{{- include "tetragon.name" . }}
+{{- end }}
+
+{{- define "tetragon.role" -}}
+{{- include "tetragon.name" . }}
+{{- end }}
+
+{{- define "tetragon-operator.name" -}}
+{{- default (printf "%s-operator" .Release.Name) .Values.tetragonOperator.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "tetragon-operator.clusterRole" -}}
+{{- include "tetragon-operator.name" . }}
+{{- end }}
+
+{{- define "tetragon-operator.roleBindingName" -}}
+{{- printf "%s-rolebinding" (include "tetragon-operator.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "tetragon-operator.configMapName" -}}
+{{- printf "%s-config" (include "tetragon-operator.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "tetragon-rthooks.name" -}}
+{{- default (printf "%s-rthooks" .Release.Name) .Values.rthooks.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "commonLabels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: {{ .Chart.Name }}
+{{- end }}
+
+{{- define "tetragon.labels" -}}
+{{ include "tetragon.selectorLabels" . }}
+{{ include "commonLabels" . }}
+app.kubernetes.io/component: agent
+{{- end }}
+{{- define "tetragon-operator.labels" -}}
+{{ include "tetragon-operator.selectorLabels" . }}
+{{ include "commonLabels" . }}
+app.kubernetes.io/component: operator
+{{- end }}
+{{- define "tetragon-rthooks.labels" -}}
+{{ include "tetragon-rthooks.selectorLabels" . }}
+{{ include "commonLabels" . }}
+app.kubernetes.io/component: rthooks
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tetragon.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- define "tetragon-operator.selectorLabels" -}}
+app.kubernetes.io/name: "tetragon-operator"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- define "tetragon-rthooks.selectorLabels" -}}
+app.kubernetes.io/name: "tetragon-rthooks"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "container.export.stdout.name" -}}
+{{- print "export-stdout" -}}
+{{- end }}
+
+{{- define "container.tetragon.name" -}}
+{{- print "tetragon" -}}
+{{- end }}
+
+{{/*
+ServiceAccounts
+*/}}
+{{- define "tetragon.serviceAccount" -}}
+{{- if .Values.serviceAccount.name -}}
+{{- printf "%s" .Values.serviceAccount.name -}}
+{{- else -}}
+{{- include "tetragon.name" . -}}
+{{- end -}}
+{{- end }}
+
+{{- define "tetragon-operator.serviceAccount" -}}
+{{- if .Values.tetragonOperator.serviceAccount.name -}}
+{{- printf  "%s" .Values.tetragonOperator.serviceAccount.name -}}
+{{- else -}}
+{{- printf  "%s-service-account" (include "tetragon-operator.name" .) -}}
+{{- end -}}
+{{- end }}
+
+{{- define "container.tetragonOCIHookSetup.installPath" -}}
+{{- print "/hostInstall" -}}
+{{- end }}
+
+{{- define "container.tetragonOCIHookSetup.hooksPath" -}}
+{{- print "/hostHooks" -}}
+{{- end }}
+
+{{/*
+Runtime-hooks
+*/}}
+
+{{- define "rthooksInterface" -}}
+{{ $iface := .Values.rthooks.interface }}
+{{- if (eq $iface "oci-hooks") -}}
+	oci-hooks
+{{- else if (eq $iface "nri-hook") -}}
+	nri-hook
+{{- else -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+rthooks affinity: when rthooks.affinity is explicitly set (including {}),
+use it as-is. Otherwise fall back to the top-level .Values.affinity.
+*/}}
+{{- define "tetragon-rthooks.affinity" -}}
+{{- if hasKey .Values.rthooks "affinity" -}}
+{{- toYaml .Values.rthooks.affinity -}}
+{{- else -}}
+{{- toYaml .Values.affinity -}}
+{{- end -}}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/clusterrole.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/clusterrole.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.serviceAccount.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon.clusterRole" . }}
+  labels:
+  {{- include "tetragon.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - nodes
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - podinfo
+      - tracingpolicies
+      - tracingpoliciesnamespaced
+    verbs:
+      - get
+      - list
+      - watch
+  # We need to split out the create permission and enforce it without resourceNames since
+  # the name would not be known at resource creation time
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  {{- include "clusterrole.extra" . | nindent 2 }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/clusterrolebinding.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.serviceAccount.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon.clusterRole" . }}
+  labels:
+  {{- include "tetragon.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "tetragon.clusterRole" . }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "tetragon.serviceAccount" . }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/crds.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if eq .Values.crds.installMethod "helm" }}
+{{- range $path, $_ := .Files.Glob "crds-yaml/*.yaml" }}
+---
+{{ $.Files.Get $path }}
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/daemonset.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/daemonset.yaml
@@ -1,0 +1,120 @@
+{{- if .Values.tetragon.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  {{- with .Values.daemonSetAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+  {{- with .Values.daemonSetLabelsOverride}}
+    {{- toYaml . | nindent 4 }}
+  {{- else }}
+    {{- include "tetragon.labels" . | nindent 4 }}
+  {{- end }}
+  name: {{ include "tetragon.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+    {{- with .Values.selectorLabelsOverride }}
+      {{- toYaml . | nindent 6 }}
+    {{- else }}
+      {{- include "tetragon.selectorLabels" . | nindent 6 }}
+    {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ toJson .Values.tetragon | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+      {{- with .Values.podLabelsOverride }}
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+        {{- include "tetragon.labels" . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tetragon.serviceAccount" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+      {{- include "initcontainers.extra" . | nindent 6 }}
+      containers:
+{{- if eq .Values.export.mode "stdout" }}
+      {{- include "container.export.stdout" . | nindent 6 -}}
+{{- end }}
+      {{- include "container.tetragon" . | nindent 6 -}}
+      {{- include "containers.extra" . | nindent 6 -}}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      terminationGracePeriodSeconds: 1
+      volumes:
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+      - name: tetragon-run
+        hostPath:
+          path: /var/run/tetragon
+          type: DirectoryOrCreate
+      - name: export-logs
+        hostPath:
+          path: {{ .Values.exportDirectory }}
+          type: DirectoryOrCreate
+      - name: tetragon-config
+        configMap:
+          name: {{ include "tetragon.configMapName" . }}
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+      - name: host-proc
+        hostPath:
+          path: {{ .Values.tetragon.hostProcPath }}
+          type: Directory
+{{- if and (.Values.tetragon.cri.enabled) (.Values.tetragon.cri.socketHostPath) }}
+      - name: cri-socket
+        hostPath:
+          path: {{ quote .Values.tetragon.cri.socketHostPath }}
+          type: Socket
+{{- end }}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- range .Values.extraHostPathMounts }}
+      - name: {{ .name }}
+        hostPath:
+          path: {{ .mountPath }}
+{{- end }}
+      {{- include "volumes.extra" . | nindent 6 }}
+{{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_clusterrole.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_clusterrole.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.tetragonOperator.enabled .Values.serviceAccount.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon-operator.clusterRole" . }}
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - podinfo
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  {{- if eq .Values.crds.installMethod "operator" }}
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+  {{- end }}
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    resourceNames:
+      - tracingpolicies.cilium.io
+      - tracingpoliciesnamespaced.cilium.io
+      - podinfo.cilium.io
+    verbs:
+      - update
+      - get
+      - list
+      - watch
+  {{- include "operatorclusterrole.extra" . | nindent 2 }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_clusterrolebinding.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.tetragonOperator.enabled .Values.serviceAccount.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon-operator.roleBindingName" . }}
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "tetragon-operator.name" . }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "tetragon-operator.serviceAccount" . }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_configmap.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_configmap.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.tetragonOperator.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tetragon-operator.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+data:
+  {{- if eq .Values.crds.installMethod "operator" }}
+  skip-crd-creation: "false"
+  {{- else }}
+  skip-crd-creation: "true"
+  {{- end }}
+  skip-pod-info-crd: {{ not .Values.tetragonOperator.podInfo.enabled | quote }}
+  skip-tracing-policy-crd: {{ not .Values.tetragonOperator.tracingPolicy.enabled | quote }}
+  force-update-crds: {{ .Values.tetragonOperator.forceUpdateCRDs | quote }}
+  leader-election: {{ .Values.tetragonOperator.failoverLease.enabled | quote }}
+  leader-election-namespace: {{ .Values.tetragonOperator.failoverLease.namespace | quote }}
+  leader-election-lease-duration: {{ .Values.tetragonOperator.failoverLease.leaseDuration | quote }}
+  leader-election-renew-deadline: {{ .Values.tetragonOperator.failoverLease.leaseRenewDeadline | quote }}
+  leader-election-retry-period: {{ .Values.tetragonOperator.failoverLease.leaseRetryPeriod | quote }}
+  {{- include "operatorconfigmap.extra" . | nindent 2 }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_deployment.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_deployment.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.tetragonOperator.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{- with .Values.tetragonOperator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels: 
+    {{- include "tetragon-operator.labels" . | nindent 4 }}
+    {{- with .Values.tetragonOperator.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tetragon-operator.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tetragon-operator.selectorLabels" . | nindent 6 }}
+  replicas: {{ .Values.tetragonOperator.replicas }}
+  template:
+    metadata:
+      {{- with .Values.tetragonOperator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels: 
+        {{- include "tetragon-operator.labels" . | nindent 8 }}
+        {{- with .Values.tetragonOperator.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+      - name: {{ include "tetragon-operator.name" . }}
+        command:
+          - /usr/bin/tetragon-operator
+        args:
+          - serve
+          - --config-dir=/etc/tetragon/operator.conf.d/
+        {{- if .Values.tetragonOperator.prometheus.enabled }}
+          - --metrics-bind-address={{ .Values.tetragonOperator.prometheus.address }}:{{ .Values.tetragonOperator.prometheus.port }}
+        {{- end }}
+        image: "{{ if .Values.tetragonOperator.image.override }}{{ .Values.tetragonOperator.image.override }}{{ else }}{{ .Values.tetragonOperator.image.repository }}:{{ .Values.tetragonOperator.image.tag }}{{ end }}"
+        imagePullPolicy: {{ .Values.tetragonOperator.image.pullPolicy }}
+        volumeMounts:
+          - mountPath: /etc/tetragon/operator.conf.d/
+            name: tetragon-operator-config
+            readOnly: true
+          {{- with .Values.tetragonOperator.extraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- if .Values.tetragonOperator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.tetragonOperator.containerSecurityContext | nindent 10 }}
+        {{- else if .Values.tetragonOperator.securityContext }}
+        securityContext:
+          {{- toYaml .Values.tetragonOperator.securityContext | nindent 10 }}
+        {{- end }}
+        {{- if .Values.tetragonOperator.prometheus.enabled }}
+        ports:
+          - name: metrics
+            containerPort: {{ .Values.tetragonOperator.prometheus.port }}
+            protocol: TCP
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        {{- with .Values.tetragonOperator.resources }}
+        resources:
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
+      {{- with .Values.tetragonOperator.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tetragonOperator.priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tetragonOperator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tetragonOperator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tetragonOperator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tetragon-operator.serviceAccount" . }}
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: tetragon-operator-config
+          configMap:
+            name: {{ include "tetragon-operator.configMapName" . }}
+      {{- with .Values.tetragonOperator.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.tetragonOperator.strategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_role.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_role.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.tetragonOperator.enabled .Values.serviceAccount.create .Values.tetragonOperator.failoverLease.enabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon-operator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+rules:
+# For tetragon-operator running with multiple replicas
+#
+# Tetragon operator running in HA mode requires the use of ResourceLock for Leader Election
+# between multiple running instances.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+# A Lease changes will result in Kubernetes events. Thus, allow the operator ServiceAccount
+# to create them.
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_rolebinding.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.tetragonOperator.enabled .Values.serviceAccount.create .Values.tetragonOperator.failoverLease.enabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon-operator.roleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tetragon-operator.name" . }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "tetragon-operator.serviceAccount" . }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_service.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_service.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.tetragonOperator.enabled .Values.tetragonOperator.prometheus.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "tetragon-operator.name" . }}-metrics
+  labels: 
+    {{- include "tetragon-operator.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: metrics
+      port: {{ .Values.tetragonOperator.prometheus.port }}
+      targetPort: {{ .Values.tetragonOperator.prometheus.port }}
+      protocol: TCP
+  selector:
+    {{- include "tetragon-operator.selectorLabels" . | nindent 4 }}
+  type: ClusterIP
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_serviceaccount.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.tetragonOperator.enabled .Values.tetragonOperator.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tetragon-operator.serviceAccount" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon-operator.labels" . | nindent 4 }}
+  {{- with .Values.tetragonOperator.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_servicemonitor.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/operator_servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.tetragonOperator.enabled .Values.tetragonOperator.prometheus.enabled .Values.tetragonOperator.prometheus.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- with .Values.tetragonOperator.prometheus.serviceMonitor.labelsOverride}}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    {{- include "tetragon-operator.labels" . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.tetragonOperator.prometheus.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tetragon-operator.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: {{ .Values.tetragonOperator.prometheus.serviceMonitor.scrapeInterval }}
+      path: /metrics
+      port: metrics
+      relabelings:
+        - action: replace
+          replacement: ${1}
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "tetragon-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/role.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/role.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon.role" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon.labels" . | nindent 4 }}
+rules:
+  {{- include "role.extra" . | nindent 2 }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/rolebinding.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.serviceAccount.create }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon.role" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tetragon.role" . }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "tetragon.serviceAccount" . }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/rthooks-daemonset.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/rthooks-daemonset.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.rthooks.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  {{- with .Values.rthooks.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "tetragon-rthooks.labels" . | nindent 4 }}
+    {{- with .Values.rthooks.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tetragon-rthooks.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tetragon-rthooks.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ toJson .Values.rthooks | sha256sum }}
+      {{- with .Values.rthooks.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tetragon-rthooks.labels" . | nindent 8 }}
+        {{- with .Values.rthooks.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.rthooks.priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rthooks.serviceAccount.name }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      {{- with .Values.rthooks.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      {{- include "container.tetragon-rthooks" . | nindent 6 -}}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (include "tetragon-rthooks.affinity" . | fromYaml) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: oci-hook-install-path
+        hostPath:
+          path: {{ quote .Values.rthooks.installDir }}
+          type: DirectoryOrCreate
+{{- if (eq .Values.rthooks.interface "oci-hooks") }}
+      - name: oci-hooks-path
+        hostPath:
+          path: {{ quote .Values.rthooks.ociHooks.hooksPath }}
+          type: Directory
+{{- end }}
+{{- if (eq .Values.rthooks.interface "nri-hook") }}
+      - name: nri-socket-path
+        hostPath:
+          path: {{ quote .Values.rthooks.nriHook.nriSocket }}
+          type: Socket
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/service.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/service.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.tetragon.enabled .Values.tetragon.prometheus.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- with .Values.serviceLabelsOverride}}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    {{- include "tetragon.labels" . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tetragon.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: metrics
+      port: 2112
+      protocol: TCP
+      targetPort: {{ .Values.tetragon.prometheus.port }}
+  selector:
+    {{- with .Values.daemonSetLabelsOverride}}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    {{- include "tetragon.labels" . | nindent 4 }}
+    {{- end }}
+  type: ClusterIP
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/serviceaccount.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tetragon.serviceAccount" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/servicemonitor.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/servicemonitor.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.tetragon.enabled .Values.tetragon.prometheus.enabled .Values.tetragon.prometheus.serviceMonitor.enabled -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- with .Values.tetragon.prometheus.serviceMonitor.labelsOverride}}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    {{- include "tetragon.labels" . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.tetragon.prometheus.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tetragon.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: {{ .Values.tetragon.prometheus.serviceMonitor.scrapeInterval }}
+      path: /metrics
+      port: metrics
+      relabelings:
+        - action: replace
+          replacement: ${1}
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+        - action: replace
+          replacement: ${1}
+          sourceLabels:
+            - __meta_kubernetes_pod_name
+          targetLabel: tetragon_pod
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- with .Values.serviceLabelsOverride}}
+      {{- toYaml . | nindent 6 }}
+      {{- else }}
+      {{- include "tetragon.selectorLabels" . | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/templates/tetragon_configmap.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/templates/tetragon_configmap.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.tetragon.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tetragon.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon.labels" . | nindent 4 }}
+data:
+  cluster-name: {{ .Values.tetragon.clusterName | quote }}
+{{- if .Values.tetragon.btf }}
+  btf: {{ .Values.tetragon.btf }}
+{{- end }}
+  procfs: /procRoot
+  debug: {{ .Values.tetragon.debug | quote }}
+  enable-process-cred: {{ .Values.tetragon.enableProcessCred | quote }}
+  enable-process-ns: {{ .Values.tetragon.enableProcessNs | quote }}
+  enable-ancestors: {{ .Values.tetragon.processAncestors.enabled | quote }}
+  process-cache-size: {{ .Values.tetragon.processCacheSize | quote }}
+{{- if .Values.tetragon.exportFilename }}
+  export-filename: {{ .Values.exportDirectory}}/{{ .Values.tetragon.exportFilename }}
+  export-file-perm: {{ .Values.tetragon.exportFilePerm | quote }}
+  export-file-max-size-mb: {{ .Values.tetragon.exportFileMaxSizeMB | quote }}
+  export-file-max-backups: {{ .Values.tetragon.exportFileMaxBackups | quote }}
+  export-file-compress: {{ .Values.tetragon.exportFileCompress | quote }}
+  export-allowlist: |-
+{{- .Values.tetragon.exportAllowList | trim | nindent 4 }}
+  export-denylist: |-
+{{- .Values.tetragon.exportDenyList | trim | nindent 4 }}
+  field-filters: |-
+{{- .Values.tetragon.fieldFilters | trim | nindent 4 }}
+  redaction-filters: |-
+{{- .Values.tetragon.redactionFilters | trim | nindent 4 }}
+  export-rate-limit: {{ .Values.tetragon.exportRateLimit | quote }}
+{{- end }}
+{{- if .Values.tetragon.enableK8sAPI }}
+  enable-k8s-api: "true"
+{{- end }}
+{{- if .Values.tetragon.prometheus.enabled }}
+  metrics-server: {{ .Values.tetragon.prometheus.address }}:{{ .Values.tetragon.prometheus.port }}
+{{- else }}
+  metrics-server: ""
+{{- end }}
+{{- if .Values.tetragon.prometheus.enabled }}
+  metrics-label-filter: {{ .Values.tetragon.prometheus.metricsLabelFilter }}
+{{- end }}
+{{- if .Values.tetragon.grpc.enabled }}
+  server-address: {{ .Values.tetragon.grpc.address }}
+{{- else }}
+  server-address: ""
+{{- end }}
+{{- if .Values.tetragon.healthGrpc.enabled }}
+  health-server-address: :{{ .Values.tetragon.healthGrpc.port }}
+  health-server-interval: {{ .Values.tetragon.healthGrpc.interval | quote }}
+{{- else }}
+  health-server-address: ""
+{{- end }}
+{{- if .Values.tetragon.gops.enabled }}
+  gops-address: {{ .Values.tetragon.gops.address }}:{{ .Values.tetragon.gops.port }}
+{{- end }}
+{{- if .Values.tetragon.enablePolicyFilter }}
+  enable-policy-filter: "true"
+{{- end }}
+{{- if .Values.tetragon.enablePolicyFilterCgroupMap }}
+  enable-policy-filter-cgroup-map: "true"
+{{- end }}
+{{- if .Values.tetragon.enablePolicyFilterDebug }}
+  enable-policy-filter-debug: "true"
+{{- end }}
+{{- if .Values.tetragon.enableMsgHandlingLatency }}
+  enable-msg-handling-latency: "true"
+{{- end }}
+  enable-pod-info: {{ .Values.tetragonOperator.podInfo.enabled | quote }}
+  enable-tracing-policy-crd: {{ .Values.tetragonOperator.tracingPolicy.enabled | quote }}
+{{- if .Values.tetragon.pprof.enabled }}
+  pprof-address: {{ .Values.tetragon.pprof.address }}:{{ .Values.tetragon.pprof.port }}
+{{- end }}
+  event-cache-retries: {{ .Values.tetragon.eventCacheRetries | quote }}
+  event-cache-retry-delay: {{ .Values.tetragon.eventCacheRetryDelay | quote }}
+  {{- include "configmap.extra" . | nindent 2 }}
+{{- if .Values.tetragon.enableKeepSensorsOnExit }}
+  keep-sensors-on-exit: "true"
+  release-pinned-bpf: "false"
+{{- end }}
+  process-cache-gc-interval: {{ .Values.tetragon.processCacheGCInterval | quote }}
+  enable-cri: {{ .Values.tetragon.cri.enabled | quote }}
+{{- if and (.Values.tetragon.cri.enabled) (.Values.tetragon.cri.socketHostPath) }}
+  cri-endpoint: "unix://{{ .Values.tetragon.cri.socketHostPath }}"
+{{- end }}
+  enable-cgidmap: {{ .Values.tetragon.cgidmap.enabled | quote }}
+  enable-pod-annotations: {{ .Values.tetragon.podAnnotations.enabled | default "false" | quote }}
+  use-perf-ring-buffer: {{ .Values.tetragon.usePerfRingBuffer | default "false" | quote }}
+{{- end }}

--- a/argocd-helm-charts/tetragon/charts/tetragon/values.yaml
+++ b/argocd-helm-charts/tetragon/charts/tetragon/values.yaml
@@ -1,0 +1,477 @@
+# Global settings
+enabled: true
+imagePullSecrets: []
+# Tetragon agent settings
+priorityClassName: ""
+imagePullPolicy: IfNotPresent
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+podAnnotations: {}
+podSecurityContext: {}
+nodeSelector: {}
+tolerations:
+  - operator: Exists
+affinity: {}
+extraHostPathMounts: []
+extraConfigmapMounts: []
+daemonSetAnnotations: {}
+extraVolumes: []
+updateStrategy: {}
+podLabels: {}
+daemonSetLabelsOverride: {}
+selectorLabelsOverride: {}
+podLabelsOverride: {}
+serviceLabelsOverride: {}
+# -- DNS policy for Tetragon pods.
+#
+# https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy: Default
+# -- Directory to put Tetragon JSON export files.
+exportDirectory: "/var/run/cilium/tetragon"
+# -- Configures whether Tetragon pods run on the host network.
+#
+# IMPORTANT: Tetragon must be on the host network for the process visibility to
+# function properly.
+hostNetwork: true
+tetragon:
+  enabled: true
+  nameOverride: ""
+  image:
+    override: ~
+    repository: quay.io/cilium/tetragon
+    tag: v1.7.0
+  resources: {}
+  extraArgs: {}
+  extraEnv: []
+  # extraEnv:
+  #   - name: foo
+  #     value: bar
+  podAnnotations:
+    enabled: false
+  extraVolumeMounts: []
+  securityContext:
+    privileged: true
+  # -- Overrides the default livenessProbe for the tetragon container.
+  livenessProbe: {}
+  #  grpc:
+  #    port: 54321
+
+  # -- Tetragon puts processes in an LRU cache. The cache is used to find ancestors
+  # for subsequently exec'ed processes.
+  processCacheSize: 65536
+  # -- If you want to run Tetragon in debug mode change this value to true
+  debug: false
+  # -- JSON export filename. Set it to an empty string to disable JSON export altogether.
+  exportFilename: tetragon.log
+  # -- JSON export file permissions as a string. Typically it's either "600" (to restrict access to
+  # owner) or "640"/"644" (to allow read access by logs collector or another agent).
+  exportFilePerm: "600"
+  # -- Size in megabytes at which to rotate JSON export files.
+  exportFileMaxSizeMB: 10
+  # -- Number of rotated files to retain.
+  exportFileMaxBackups: 5
+  # -- Compress rotated JSON export files.
+  exportFileCompress: false
+  # -- Rate-limit event export (events per minute), Set to -1 to export all events.
+  exportRateLimit: -1
+  # -- Allowlist for JSON export. For example, to export only process_connect events from
+  # the default namespace:
+  #
+  # exportAllowList: |
+  #   {"namespace":["default"],"event_set":["PROCESS_EXEC"]}
+  exportAllowList: |-
+    {"event_set":["PROCESS_EXEC", "PROCESS_EXIT", "PROCESS_KPROBE", "PROCESS_UPROBE", "PROCESS_TRACEPOINT", "PROCESS_LSM"]}
+  # -- Denylist for JSON export **(for file sinks only; does not filter gRPC output)**. For example, to exclude exec events that look similar to
+  # Kubernetes health checks and all the events from kube-system namespace and the host:
+  #
+  # exportDenyList: |
+  #   {"health_check":true}
+  #   {"namespace":["kube-system",""]}
+  #
+  exportDenyList: |-
+    {"health_check":true}
+    {"namespace":["", "cilium", "kube-system"]}
+  # -- Filters to include or exclude fields from Tetragon events. Without any filters, all
+  # fields are included by default. The presence of at least one inclusion filter implies
+  # default-exclude (i.e. any fields that don't match an inclusion filter will be
+  # excluded). Field paths are expressed using dot notation like "a.b.c" and multiple
+  # field paths can be separated by commas like "a.b.c,d,e.f". An optional "event_set" may
+  # be specified to apply the field filter to a specific set of events.
+  #
+  # For example, to exclude the "parent" field from all events and include the "process"
+  # field in PROCESS_KPROBE events while excluding all others:
+  #
+  # fieldFilters: |
+  #   {"fields": "parent", "action": "EXCLUDE"}
+  #   {"event_set": ["PROCESS_KPROBE"], "fields": "process", "action": "INCLUDE"}
+  #
+  fieldFilters: ""
+  # -- Filters to redact secrets from the args fields in Tetragon events. To perform
+  # redactions, redaction filters define RE2 regular expressions in the `redact`
+  # field. Any capture groups in these RE2 regular expressions are redacted and
+  # replaced with "*****".
+  #
+  # For more control, you can select which binary or binaries should have their
+  # arguments redacted with the `binary_regex` field.
+  #
+  # NOTE: This feature uses RE2 as its regular expression library. Make sure that you follow
+  # RE2 regular expression guidelines as you may observe unexpected results otherwise.
+  # More information on RE2 syntax can be found [here](https://github.com/google/re2/wiki/Syntax).
+  #
+  # NOTE: When writing regular expressions in JSON, it is important to escape
+  # backslash characters. For instance `\Wpasswd\W?` would be written as
+  # `{"redact": "\\Wpasswd\\W?"}`.
+  #
+  # As a concrete example, the following will redact all passwords passed to
+  # processes with the "--password" argument:
+  #
+  #   {"redact": ["--password(?:\\s+|=)(\\S*)"]}
+  #
+  # Now, an event which contains the string "--password=foo" would have that
+  # string replaced with "--password=*****".
+  #
+  # Suppose we also see some passwords passed via the -p shorthand for a specific binary, foo.
+  # We can also redact these as follows:
+  #
+  #   {"binary_regex": ["(?:^|/)foo$"], "redact": ["-p(?:\\s+|=)(\\S*)"]}
+  #
+  # With both of the above redaction filters in place, we are now redacting all
+  # password arguments.
+  redactionFilters: ""
+  # -- Name of the cluster where Tetragon is installed. Tetragon uses this value
+  # to set the cluster_name field in GetEventsResponse messages.
+  clusterName: ""
+  # -- Access Kubernetes API to associate Tetragon events with Kubernetes pods.
+  enableK8sAPI: true
+  # -- Enable Capabilities visibility in exec and kprobe events.
+  enableProcessCred: false
+  # -- Enable Namespaces visibility in exec and kprobe events.
+  enableProcessNs: false
+  processAncestors:
+    # -- Comma-separated list of process event types to enable ancestors for.
+    # Supported event types are: base, kprobe, tracepoint, loader, uprobe, lsm, usdt. Unknown event types will be ignored.
+    # Type "base" is required by all other supported event types for correct reference counting.
+    # Set it to "" to disable ancestors completely.
+    enabled: ""
+  # -- Set --btf option to explicitly specify an absolute path to a btf file. For advanced users only.
+  btf: ""
+  # -- Override the command. For advanced users only.
+  commandOverride: []
+  # -- Override the arguments. For advanced users only.
+  argsOverride: []
+  prometheus:
+    # -- Whether to enable exposing Tetragon metrics.
+    enabled: true
+    # -- The address at which to expose metrics. Set it to "" to expose on all available interfaces.
+    address: ""
+    # -- The port at which to expose metrics.
+    port: 2112
+    # -- Comma-separated list of enabled metrics labels.
+    # The configurable labels are: namespace, workload, pod, binary. Unknown labels will be ignored.
+    # Removing some labels from the list might help reduce the metrics cardinality if needed.
+    metricsLabelFilter: "namespace,workload,pod,binary"
+    serviceMonitor:
+      # -- Whether to create a 'ServiceMonitor' resource targeting the tetragon pods.
+      enabled: false
+      # -- The set of labels to place on the 'ServiceMonitor' resource.
+      labelsOverride: {}
+      # -- Extra labels to be added on the Tetragon ServiceMonitor.
+      extraLabels: {}
+      # -- Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used.
+      scrapeInterval: 60s
+  grpc:
+    # -- Whether to enable exposing Tetragon gRPC.
+    enabled: true
+    # -- The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock
+    address: "unix:///var/run/tetragon/tetragon.sock"
+  gops:
+    # -- Whether to enable exposing gops server.
+    enabled: true
+    # -- The address at which to expose gops.
+    address: "localhost"
+    # -- The port at which to expose gops.
+    port: 8118
+  pprof:
+    # -- Whether to enable exposing pprof server.
+    enabled: false
+    # -- The address at which to expose pprof.
+    address: "localhost"
+    # -- The port at which to expose pprof.
+    port: 6060
+  # -- Enable policy filter. This is required for K8s namespace and pod-label filtering.
+  enablePolicyFilter: True
+  # -- Enable policy filter cgroup map.
+  enablePolicyFilterCgroupMap: false
+  # -- Enable policy filter debug messages.
+  enablePolicyFilterDebug: false
+  # -- Enable latency monitoring in message handling
+  enableMsgHandlingLatency: false
+  healthGrpc:
+    # -- Whether to enable health gRPC server.
+    enabled: true
+    # -- The port at which to expose health gRPC.
+    port: 6789
+    # -- The interval at which to check the health of the agent.
+    interval: 10
+  # -- Location of the host proc filesystem in the runtime environment. If the runtime runs in the
+  # host, the path is /proc. Exceptions to this are environments like kind, where the runtime itself
+  # does not run on the host.
+  hostProcPath: "/proc"
+  # -- Configure the number of retries in tetragon's event cache.
+  eventCacheRetries: 15
+  # -- Configure the delay (in seconds) between retires in tetragon's event cache.
+  eventCacheRetryDelay: 2
+  # -- Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone.
+  enableKeepSensorsOnExit: false
+  # -- Configure the interval (suffixed with s for seconds, m for minutes, etc) for the process cache garbage collector.
+  processCacheGCInterval: 30s
+  # -- Configure tetragon pod so that it can contact the CRI running on the host
+  cri:
+    enabled: false
+    # -- path of the CRI socket on the host. This will typically be
+    # "/run/containerd/containerd.sock" for containerd or "/var/run/crio/crio.sock"  for crio.
+    socketHostPath: ""
+  # -- Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for
+  # pod association. This feature depends on cri being enabled.
+  cgidmap:
+    enabled: false
+  usePerfRingBuffer: false
+# Tetragon Operator settings
+tetragonOperator:
+  # -- Enables the Tetragon Operator.
+  enabled: true
+  # -- The name of the Tetragon Operator deployment.
+  nameOverride: ""
+  # -- Number of replicas to run for the tetragon-operator deployment
+  replicas: 1
+  # -- Lease handling for an automated failover when running multiple replicas
+  failoverLease:
+    # -- Enable lease failover functionality
+    enabled: false
+    # -- Kubernetes Namespace in which the Lease resource is created. Defaults to the namespace where Tetragon is deployed in, if it's empty.
+    namespace: ""
+    # -- If a lease is not renewed for X duration, the current leader is considered dead, a new leader is picked
+    leaseDuration: 15s
+    # -- The interval at which the leader will renew the lease
+    leaseRenewDeadline: 5s
+    # -- The timeout between retries if renewal fails
+    leaseRetryPeriod: 2s
+  # -- Annotations for the Tetragon Operator Deployment.
+  annotations: {}
+  # -- Annotations for the Tetragon Operator Deployment Pods.
+  podAnnotations: {}
+  # -- Extra labels to be added on the Tetragon Operator Deployment.
+  extraLabels: {}
+  # -- Extra labels to be added on the Tetragon Operator Deployment Pods.
+  extraPodLabels: {}
+  # -- priorityClassName for the Tetragon Operator Deployment Pods.
+  priorityClassName: ""
+  # -- tetragon-operator service account.
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+  # -- securityContext for the Tetragon Operator Deployment Pods.
+  podSecurityContext: {}
+  # -- securityContext for the Tetragon Operator Deployment Pod container.
+  containerSecurityContext:
+    runAsUser: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - "ALL"
+  # -- securityContext for the Tetragon Operator Deployment Pod container. (DEPRECATED: Use containerSecurityContext instead. TODO: Remove in v1.6.0)
+  securityContext: {}
+  # -- resources for the Tetragon Operator Deployment Pod container.
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  # -- resources for the Tetragon Operator Deployment update strategy
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  # -- Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules.
+  nodeSelector: {}
+  tolerations: []
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: tetragon-operator
+  # -- tetragon-operator image.
+  image:
+    override: ~
+    repository: quay.io/cilium/tetragon-operator
+    tag: v1.7.0
+    pullPolicy: IfNotPresent
+  # -- Extra volumes for the Tetragon Operator Deployment.
+  extraVolumes: []
+  extraVolumeMounts: []
+  forceUpdateCRDs: false
+  podInfo:
+    # -- Enables the PodInfo CRD and the controller that reconciles PodInfo
+    # custom resources.
+    enabled: false
+  tracingPolicy:
+    # -- Enables the TracingPolicy and TracingPolicyNamespaced CRD creation.
+    enabled: true
+  prometheus:
+    # -- Enables the Tetragon Operator metrics.
+    enabled: true
+    # -- The address at which to expose Tetragon Operator metrics. Set it to "" to expose on all available interfaces.
+    address: ""
+    # -- The port at which to expose metrics.
+    port: 2113
+    serviceMonitor:
+      # -- Whether to create a 'ServiceMonitor' resource targeting the tetragonOperator pods.
+      enabled: false
+      # -- The set of labels to place on the 'ServiceMonitor' resource.
+      labelsOverride: {}
+      # -- Extra labels to be added on the Tetragon Operator ServiceMonitor.
+      extraLabels: {}
+      # -- Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used.
+      scrapeInterval: 60s
+# -- Tetragon events export settings
+export:
+  # "stdout". "" to disable.
+  mode: "stdout"
+  resources: {}
+  securityContext: {}
+  # filenames defines list of files for fluentd to tail and export.
+  filenames:
+    - tetragon.log
+  # stdout specific exporter settings
+  stdout:
+    # -- Extra environment variables to add to the export-stdout container.
+    # Example:
+    # extraEnv:
+    #   - name: FOO
+    #     value: bar
+    #   - name: SECRET_KEY
+    #     valueFrom:
+    #       secretKeyRef:
+    #         name: my-secret
+    #         key: secret-key
+    extraEnv: []
+    # -- Extra envFrom sources to add to the export-stdout container.
+    # This allows adding any type of envFrom source (configMapRef, secretRef, etc.).
+    # Example:
+    # extraEnvFrom:
+    #   - configMapRef:
+    #       name: my-config-map
+    #   - secretRef:
+    #       name: my-secret
+    #       optional: true
+    extraEnvFrom: []
+    # -- A simplified way to add secret references to envFrom.
+    # Can be specified either as a string (just the secret name) or as an object with additional parameters.
+    # Example:
+    # envFromSecrets:
+    #   - my-simple-secret
+    #   - name: my-optional-secret
+    #     optional: true
+    envFromSecrets: []
+    # * When enabledCommand=true and commandOverride is not set, the command inserted will be hubble-export-stdout.
+    #   This supports the default for the current deployment instructions to deploy stdout-export sidecar container.
+    # * When enabledCommand=true and commandOverride override is set, the command inserted will be the value of commandOverride.
+    #   This is useful for inserting another sidecar container that requires a command override.
+    # * When enabledCommand=false, no command will be specified in the manifest and container's default command will take over.
+    enabledCommand: true
+    # * When enabledArgs=true and argsOverride is not set, the args inserted will be the default ones for export-stdout.
+    # * When enabledArgs=true and argsOverride override is set, the args value inserted will be the value of argsOverride.
+    #   This is useful for inserting another sidecar container that requires args override.
+    # * When enabledArgs=false, no command will be specified in the manifest and container's default args value will take over.
+    enabledArgs: true
+    # specific manifest command to use
+    commandOverride: []
+    # specific manifest args to use
+    argsOverride: []
+    # Extra volume mounts to add to stdout export pod
+    extraVolumeMounts: []
+    image:
+      override: ~
+      repository: quay.io/cilium/hubble-export-stdout
+      tag: v1.1.1
+crds:
+  # -- Method for installing CRDs. Supported values are: "operator", "helm" and "none".
+  # The "operator" method allows for fine-grained control over which CRDs are installed and by
+  # default doesn't perform CRD downgrades. These can be configured in tetragonOperator section.
+  # The "helm" method always installs all CRDs for the chart version.
+  installMethod: "operator"
+# -- Method for installing Tetagon rthooks (tetragon-rthooks) daemonset
+# The tetragon-rthooks daemonset is responsible for installing run-time hooks on the host.
+# See: https://tetragon.io/docs/concepts/runtime-hooks
+rthooks:
+  # -- Enable the Tetragon rthooks daemonset
+  enabled: false
+  # -- tetragon-rthooks name override
+  nameOverride: ""
+  # -- Method to use for installing  rthooks. Values:
+  #
+  #    "oci-hooks":
+  #       Add an apppriate file to "/usr/share/containers/oci/hooks.d". Use this with CRI-O.
+  #       See https://github.com/containers/common/blob/main/pkg/hooks/docs/oci-hooks.5.md
+  #       for more details.
+  #       Specific configuration for this interface can be found under "ociHooks".
+  #
+  #    "nri-hook":
+  #      Install the hook via NRI. Use this with containerd. Requires NRI being enabled.
+  #      see: https://github.com/containerd/containerd/blob/main/docs/NRI.md.
+  #      Specific configuration for this interface can be found under "nriHook".
+  #
+  interface: ""
+  # -- Affinity for the Tetragon rthooks pod. If this key is omitted, the chart
+  # falls back to the top-level `affinity` value. Set it explicitly (including
+  # to `{}`) to override the top-level affinity for the rthooks DaemonSet only.
+  # affinity: {}
+  # -- Annotations for the Tetragon rthooks daemonset
+  annotations: {}
+  # -- Extra labels for the Tetrargon rthooks daemonset
+  extraLabels: {}
+  # -- Pod annotations for the Tetrargon rthooks pod
+  podAnnotations: {}
+  # -- priorityClassName for the Tetrargon rthooks pod
+  priorityClassName: ""
+  # -- security context for the Tetrargon rthooks pod
+  podSecurityContext: {}
+  # -- installDir is the host location where the tetragon-oci-hook binary will be installed
+  installDir: "/opt/tetragon"
+  # -- Comma-separated list of namespaces to allow Pod creation for, in case tetragon-oci-hook fails to reach Tetragon agent.
+  # The namespace Tetragon is deployed in is always added as an exception and must not be added again.
+  failAllowNamespaces: ""
+  # -- Extra volume mounts to add to the oci-hook-setup init container
+  extraVolumeMounts: []
+  # -- resources for the the oci-hook-setup init container
+  resources: {}
+  # -- extra args to pass to tetragon-oci-hook
+  extraHookArgs: {}
+  # -- configuration for "oci-hooks" interface
+  ociHooks:
+    # -- directory to install .json file for running the hook
+    hooksPath: "/usr/share/containers/oci/hooks.d"
+  # -- configuration for the "nri-hook" interface
+  nriHook:
+    # -- path to NRI socket
+    nriSocket: "/var/run/nri/nri.sock"
+  # -- image for the Tetragon rthooks pod
+  image:
+    override: ~
+    repository: quay.io/cilium/tetragon-rthooks
+    tag: v0.8
+  # -- rthooks service account.
+  serviceAccount:
+    name: ""

--- a/argocd-helm-charts/tetragon/values.yaml
+++ b/argocd-helm-charts/tetragon/values.yaml
@@ -1,0 +1,14 @@
+tetragon:
+  # Upstream defaults are kept as-is.
+  # See https://github.com/cilium/tetragon/blob/main/install/kubernetes/tetragon/values.yaml
+  #
+  # Notes:
+  # - Tetragon runs as a DaemonSet on the host network; every node needs a
+  #   Linux kernel with BTF and eBPF support (kernel >= 5.4, CONFIG_DEBUG_INFO_BTF=y).
+  # - Out of the box Tetragon is observability-only: it exports process,
+  #   network and file events as JSON. It ships no TracingPolicy by default.
+  # - Runtime enforcement (SIGKILL / Override actions) is opt-in — apply your
+  #   own TracingPolicy / TracingPolicyNamespaced CRs after install.
+  # - The gRPC and JSON event exporters feed hubble/tetra and can be scraped
+  #   by the existing observability stack.
+  {}

--- a/argocd-helm-charts/tetragon/values.yaml
+++ b/argocd-helm-charts/tetragon/values.yaml
@@ -11,4 +11,13 @@ tetragon:
   #   own TracingPolicy / TracingPolicyNamespaced CRs after install.
   # - The gRPC and JSON event exporters feed hubble/tetra and can be scraped
   #   by the existing observability stack.
+  #
+  # Shipping events to OpenObserve (see README.md):
+  # - export.mode defaults to "stdout": the export-stdout sidecar prints JSON events
+  #   to stdout, so the openobserve-collector agent DaemonSet (which tails
+  #   /var/log/pods) ships them to the in-cluster OpenObserve by default. No config
+  #   needed here.
+  # - To route events to a different or internet-facing OpenObserve, add a second
+  #   exporter + pipeline in the openobserve-collector values (filter on the Tetragon
+  #   namespace) — Tetragon itself is unchanged.
   {}


### PR DESCRIPTION
## What

Adds `argocd-helm-charts/tetragon` — a KubeAid chart wrapping the upstream [`cilium/tetragon`](https://github.com/cilium/tetragon) chart (1.7.0), following the vendored-subchart pattern used by the other observability charts.

[Tetragon](https://tetragon.io) is a CNCF/Isovalent project that uses **eBPF** for security observability and runtime enforcement. It runs as a DaemonSet and surfaces process execution, network activity, and file access as low-overhead kernel events. It complements the **Cilium** CNI KubeAid already ships, and sits at a different layer from the app/infra telemetry stack (kube-prometheus + OpenObserve).

## Behaviour

- **Observability-only by default** — exports process/network/file events as JSON + gRPC; ships **no** `TracingPolicy`, so nothing is blocked out of the box
- **Runtime enforcement is opt-in** — apply your own `TracingPolicy` / `TracingPolicyNamespaced` CRs after install for SIGKILL / Override actions
- CRDs vendored under `charts/tetragon/crds-yaml/` (`tracingpolicies`, `tracingpoliciesnamespaced`, `podinfo`)

## Prerequisites

- Linux kernel with BTF + eBPF on every node (kernel >= 5.4, `CONFIG_DEBUG_INFO_BTF=y`; check `/sys/kernel/btf/vmlinux`)
- Host network + host-path mounts per the upstream DaemonSet

## Follow-up (not in this PR)

Wire Tetragon's JSON/gRPC event export into **OpenObserve** as a security-event stream, so runtime-security events land alongside logs/metrics/traces.