### PR TITLE
Add kubearmor chart (eBPF + LSM runtime enforcement)

### DIFF
--- a/argocd-helm-charts/kubearmor/Chart.lock
+++ b/argocd-helm-charts/kubearmor/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kubearmor-operator
+  repository: https://kubearmor.github.io/charts
+  version: v1.7.4
+digest: sha256:72e7119e0c2fc53648258ffd31547548ba8a966b950761a65c764883322855c7
+generated: "2026-07-12T00:00:00Z"

--- a/argocd-helm-charts/kubearmor/Chart.yaml
+++ b/argocd-helm-charts/kubearmor/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: kubearmor
+version: 1.0.0
+# See latest chart versions here: https://kubearmor.github.io/charts/index.yaml
+# (upstream: https://github.com/kubearmor/KubeArmor)
+dependencies:
+  - name: kubearmor-operator
+    version: v1.7.4
+    repository: https://kubearmor.github.io/charts

--- a/argocd-helm-charts/kubearmor/README.md
+++ b/argocd-helm-charts/kubearmor/README.md
@@ -1,0 +1,80 @@
+# KubeArmor
+
+[KubeArmor](https://kubearmor.io) is a CNCF runtime-security engine (by AccuKnox)
+that uses **eBPF** for observability and **Linux Security Modules** (AppArmor,
+BPF-LSM, SELinux) for **inline enforcement** on Kubernetes. It runs as a
+DaemonSet and can restrict process execution, file access, network, and
+capabilities per workload — denying an operation *at the LSM hook before it
+runs*, rather than reacting after the fact.
+
+It complements the [`tetragon`](../tetragon) chart:
+
+| | Tetragon | KubeArmor |
+| - | - | - |
+| Strength | Security **observability** / forensics (eBPF events) | **Inline enforcement** / workload hardening (LSM) |
+| Enforcement | `SIGKILL` after detection | LSM denies the operation before it executes |
+| Policy CRD | `TracingPolicy` | `KubeArmorPolicy` (+ least-privilege auto-discovery) |
+
+Pick per cluster by goal: Tetragon for deep observability alongside Cilium;
+KubeArmor for preventive hardening and compliance posture. Running both is
+possible but usually unnecessary.
+
+Upstream chart: [kubearmor-operator](https://github.com/kubearmor/KubeArmor)
+(installed via the operator, which deploys KubeArmor from a `KubeArmorConfig`).
+
+## Prerequisites
+
+- A Linux Security Module on every node. **BPF-LSM** needs kernel >= 5.7 booted
+  with `lsm=...,bpf`; otherwise KubeArmor uses **AppArmor** or **SELinux** where
+  available. On managed clusters, confirm the node OS ships one of these.
+- KubeArmor runs privileged (host mounts, eBPF/LSM access) per the operator.
+
+## Behaviour
+
+- **Observability-first by default.** All postures ship as `audit`: violations
+  are logged, nothing is blocked. Nothing is enforced until you opt in.
+- **Enforcement is opt-in.** Set a posture to `block` (below) and/or apply a
+  `KubeArmorPolicy` / `KubeArmorHostPolicy` with `Block` actions:
+
+  ```yaml
+  # values.yaml
+  kubearmor-operator:
+    kubearmorConfig:
+      defaultFilePosture: block
+      defaultNetworkPosture: block
+  ```
+
+  ```sh
+  kubectl apply -f my-kubearmor-policy.yaml
+  karmor logs           # stream alerts/telemetry (via the relay)
+  ```
+
+## Shipping events to OpenObserve
+
+With `enableStdOutAlerts: true` (the default here), KubeArmor's relay prints
+policy-violation alerts to its container **stdout**. Because those become
+ordinary pod logs, the existing `openobserve-collector` **agent DaemonSet**
+(which tails `/var/log/pods`) picks them up and ships them to OpenObserve — no
+KubeArmor-side configuration required.
+
+```
+KubeArmor relay ── enableStdOutAlerts ──► stdout ( = /var/log/pods )
+                                             │
+                                             ▼
+   openobserve-collector agent DaemonSet (filelog receiver)
+                                             │  otlphttp exporter
+                                             ▼
+                          in-cluster OpenObserve router
+```
+
+Enable `enableStdOutLogs: true` for full visibility telemetry (higher volume).
+To route security events to a different/remote OpenObserve, add a second
+exporter + namespace-filtered pipeline in the `openobserve-collector` values —
+KubeArmor itself is unchanged.
+
+## Configuration
+
+Operator values live under the `kubearmor-operator` key; override them in your
+cluster's values file. See the
+[upstream operator values](https://github.com/kubearmor/KubeArmor/blob/main/deployments/helm/KubeArmorOperator/values.yaml)
+and the [KubeArmor docs](https://docs.kubearmor.io/).

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/.helmignore
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/Chart.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: v1.7.4
+description: A Helm chart for kubearmor operator
+name: kubearmor-operator
+type: application
+version: v1.7.4

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/README.md
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/README.md
@@ -1,0 +1,141 @@
+# Install KubeArmorOperator
+
+Install KubeArmorOperator using the official `kubearmor` Helm chart repo. Also see [values](#values) for your respective environment.
+
+```bash
+helm repo add kubearmor https://kubearmor.github.io/charts
+helm repo update kubearmor
+helm upgrade --install kubearmor-operator kubearmor/kubearmor-operator -n kubearmor --create-namespace
+```
+
+Install KubeArmorOperator using Helm charts locally (for testing)
+
+```bash
+cd deployments/helm/KubeArmorOperator
+helm upgrade --install kubearmor-operator . -n kubearmor --create-namespace
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| kubearmorOperator.name | string | kubearmor-operator | name of the operator's deployment |
+| kubearmorOperator.image.repository | string | kubearmor/kubearmor-operator | image repository to pull KubeArmorOperator from |
+| kubearmorOperator.image.tag | string | latest | KubeArmorOperator image tag |
+| kubearmorOperator.imagePullPolicy | string | IfNotPresent | pull policy for operator image |
+| kubearmorOperator.socketFile | string | "" | absolute path to the CRI socket file (e.g., /var/run/containerd/containerd.sock). If not set, the operator will auto-detect the CRI socket |
+| kubearmorOperator.podLabels | object | {} | additional pod labels |
+| kubearmorOperator.podAnnotations | object | {} | additional pod annotations |
+| kubearmorOperator.resources | object | {} | operator container resources |
+| kubearmorOperator.podSecurityContext | object | {} | pod security context |
+| kubearmorOperator.securityContext | object | {} | operator container security context |
+| kubearmorConfig | object | [values.yaml](values.yaml) | KubeArmor default configurations |
+| kubearmorOperator.annotateResource | bool | false | flag to control RBAC permissions conditionally, use `--annotateResource=<value>` arg as well to pass the same value to operator configuration |
+| autoDeploy | bool | false | Auto deploy KubeArmor with default configurations |
+
+The operator needs a `KubeArmorConfig` object in order to create resources related to KubeArmor. A default config is present in Helm `values.yaml` which can be overridden during Helm install. To install KubeArmor with default configuration use `--set autoDeploy=true` flag with helm install/upgrade command. It is possible to specify configuration even after KubeArmor resources have been installed by directly editing the created `KubeArmorConfig` CR.
+
+By Default the helm does not deploys the default KubeArmor Configurations (KubeArmorConfig CR) and once installed, the operator waits for the user to create a `KubeArmorConfig` object.
+## KubeArmorConfig specification
+
+```yaml
+apiVersion: operator.kubearmor.com/v1
+kind: KubeArmorConfig
+metadata:
+    labels:
+        app.kubernetes.io/name: kubearmorconfig
+        app.kubernetes.io/instance: kubearmorconfig-sample
+        app.kubernetes.io/part-of: kubearmoroperator
+        app.kubernetes.io/managed-by: kustomize
+        app.kubernetes.io/created-by: kubearmoroperator
+    name: [config name]
+    namespace: [namespace name]
+spec:
+    # default global posture
+    defaultCapabilitiesPosture: audit|block                    # DEFAULT - audit
+    defaultFilePosture: audit|block                            # DEFAULT - audit
+    defaultNetworkPosture: audit|block                         # DEFAULT - audit
+
+    enableStdOutLogs: [show stdout logs for relay server]      # DEFAULT - false
+    enableStdOutAlerts: [show stdout alerts for relay server]  # DEFAULT - false
+    enableStdOutMsgs: [show stdout messages for relay server]  # DEFAULT - false 
+
+    # default visibility configuration
+    defaultVisibility: [comma separated: process|file|network] # DEFAULT - process,network
+
+    # optionally drop the Resource field (full cmdline) from process visibility logs
+    dropResourceFromProcessLogs: false                         # DEFAULT - false
+
+    # enabling NRI
+    # Naming convention for kubearmor daemonset in case of NRI will be effective only when initially NRI is available & enabled. 
+    # In case snitch service account token is already present before its deployment, the naming convention won't show NRI, 
+    # it will be based on the runtime present. This happens because operator won't get KubearmorConfig event(initially).
+    enableNRI: [true|false] # DEFAULT - false
+
+    # KubeArmor image and pull policy
+    kubearmorImage:
+        image: [image-repo:tag]                                # DEFAULT - kubearmor/kubearmor:stable
+        imagePullPolicy: [image pull policy]                   # DEFAULT - Always
+
+    # KubeArmor init image and pull policy
+    kubearmorInitImage:
+        image: [image-repo:tag]                                # DEFAULT - kubearmor/kubearmor-init:stable
+        imagePullPolicy: [image pull policy]                   # DEFAULT - Always
+
+    # KubeArmor relay image and pull policy
+    kubearmorRelayImage:
+        image: [image-repo:tag]                                # DEFAULT - kubearmor/kubearmor-relay-server:latest
+        imagePullPolicy: [image pull policy]                   # DEFAULT - Always
+
+    # KubeArmor controller image and pull policy
+    kubearmorControllerImage:
+        image: [image-repo:tag]                                # DEFAULT - kubearmor/kubearmor-controller:latest
+        imagePullPolicy: [image pull policy]                   # DEFAULT - Always
+
+    # kube-rbac-proxy image and pull policy
+    kubeRbacProxyImage:
+        image: [image-repo:tag]                                # DEFAULT - gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        imagePullPolicy: [image pull policy]                   # DEFAULT - Always
+```
+
+## Verify if all the resources are up and running
+If a valid configuration is received, the operator will deploy jobs to your nodes to get the environment information and then start installing KubeArmor components.
+
+Once done, the following resources related to KubeArmor will exist in your cluster:
+```
+$ kubectl get all -n kubearmor -l kubearmor-app
+NAME                                        READY   STATUS      RESTARTS   AGE
+pod/kubearmor-operator-66fbff5559-qb7dh     1/1     Running     0          11m
+pod/kubearmor-relay-557dfcc57b-c8t55        1/1     Running     0          2m53s
+pod/kubearmor-controller-7879755b58-t4v8m   2/2     Running     0          2m53s
+pod/kubearmor-snitch-lglbd-z92gb            0/1     Completed   0          31s
+pod/kubearmor-bpf-docker-d4651-r5n7q        1/1     Running     0          30s
+
+NAME                                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)     AGE
+service/kubearmor-controller-metrics-service   ClusterIP   10.43.241.84    <none>        8443/TCP    2m53s
+service/kubearmor                              ClusterIP   10.43.216.156   <none>        32767/TCP   2m53s
+
+NAME                                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                                                                                                                                                                       AGE
+daemonset.apps/kubearmor-bpf-docker-d4651   1         1         1       1            1           kubearmor.io/btf=yes,kubearmor.io/enforcer=bpf,kubearmor.io/runtime=docker,kubearmor.io/socket=run_docker.sock,kubernetes.io/os=linux   30s
+
+NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/kubearmor-operator     1/1     1            1           11m
+deployment.apps/kubearmor-relay        1/1     1            1           2m53s
+deployment.apps/kubearmor-controller   1/1     1            1           2m53s
+
+NAME                                              DESIRED   CURRENT   READY   AGE
+replicaset.apps/kubearmor-operator-66fbff5559     1         1         1       11m
+replicaset.apps/kubearmor-relay-557dfcc57b        1         1         1       2m53s
+replicaset.apps/kubearmor-controller-7879755b58   1         1         1       2m53s
+
+NAME                               COMPLETIONS   DURATION   AGE
+job.batch/kubearmor-snitch-lglbd   1/1           3s         11m
+```
+
+## Uninstall the Operator
+
+Uninstalling the Operator will also uninstall KubeArmor from all your nodes. To uninstall, just run:
+
+```bash
+helm uninstall kubearmor-operator -n kubearmor
+```

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/crds/operator.kubearmor.com_kubearmorconfigs.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/crds/operator.kubearmor.com_kubearmorconfigs.yaml
@@ -1,0 +1,1554 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kubearmorconfigs.operator.kubearmor.com
+spec:
+  group: operator.kubearmor.com
+  names:
+    kind: KubeArmorConfig
+    listKind: KubeArmorConfigList
+    plural: kubearmorconfigs
+    singular: kubearmorconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KubeArmorConfig is the Schema for the KubeArmorConfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeArmorConfigSpec defines the desired state of KubeArmorConfig
+            properties:
+              adapters:
+                properties:
+                  elasticsearch:
+                    properties:
+                      alertsIndex:
+                        type: string
+                      auth:
+                        properties:
+                          allowInsecureTLS:
+                            type: boolean
+                          caCertKey:
+                            type: string
+                          caCertSecretName:
+                            type: string
+                          passwordKey:
+                            type: string
+                          secretName:
+                            type: string
+                          usernameKey:
+                            type: string
+                        type: object
+                      enabled:
+                        type: boolean
+                      url:
+                        type: string
+                    type: object
+                type: object
+              alertThrottling:
+                type: boolean
+              matchArgs:
+                type: boolean
+              controllerPort:
+                type: integer
+              defaultCapabilitiesPosture:
+                enum:
+                - audit
+                - block
+                type: string
+              defaultFilePosture:
+                enum:
+                - audit
+                - block
+                type: string
+              defaultNetworkPosture:
+                enum:
+                - audit
+                - block
+                type: string
+              defaultVisibility:
+                type: string
+              dropResourceFromProcessLogs:
+                type: boolean
+              enableNRI:
+                type: boolean
+              enableStdOutAlerts:
+                type: boolean
+              enableStdOutLogs:
+                type: boolean
+              enableStdOutMsgs:
+                type: boolean
+              globalEnv:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              globalImagePullSecrets:
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              globalNodeSelector:
+                additionalProperties:
+                  type: string
+                type: object
+              globalTolerations:
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              kubeRbacProxyImage:
+                description: 'Deprecated: This type would be removed in one of the
+                  upcoming releases.'
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    default: Always
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              kubearmorControllerImage:
+                description: ImageSpec defines the image specifications
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    default: Always
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              kubearmorImage:
+                description: ImageSpec defines the image specifications
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    default: Always
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              kubearmorInitImage:
+                description: ImageSpec defines the image specifications
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    default: Always
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              kubearmorRelayImage:
+                description: ImageSpec defines the image specifications
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    default: Always
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              maxAlertPerSec:
+                type: integer
+              recommendedPolicies:
+                properties:
+                  enable:
+                    type: boolean
+                  excludePolicy:
+                    items:
+                      type: string
+                    type: array
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          enum:
+                          - namespace
+                          - label
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              seccompEnabled:
+                type: boolean
+              throttleSec:
+                type: integer
+              tls:
+                properties:
+                  enable:
+                    default: false
+                    type: boolean
+                  extraDnsNames:
+                    items:
+                      type: string
+                    type: array
+                  extraIpAddresses:
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+          status:
+            description: KubeArmorConfigStatus defines the observed state of KubeArmorConfig
+            properties:
+              message:
+                type: string
+              phase:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/NOTES.txt
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/NOTES.txt
@@ -1,0 +1,12 @@
+{{- if not .Values.kubearmorOperator.annotateExisting }}
+⚠️  WARNING: Pre-existing pods will not be annotated. Policy enforcement for already existing pods on Apparmor nodes will not work.  
+  • To check enforcer present on nodes use:
+    ➤ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.kubearmor\.io/enforcer}{"\n"}{end}' 
+  • To annotate existing pods use: 
+    ➤ helm upgrade --install {{ .Values.kubearmorOperator.name }} kubearmor/kubearmor-operator -n kubearmor --create-namespace --set annotateExisting=true  
+    Our controller will automatically rollout restart deployments during the Helm upgrade to force the admission controller to add annotations.  
+  • Alternatively, if you prefer manual control, you can restart your deployments yourself:
+    ➤ kubectl rollout restart deployment <deployment> -n <namespace>
+{{- end }}
+ℹ️  Your release is named {{ .Release.Name }}.
+💙 Thank you for installing KubeArmor.

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/clusterrole-binding-rbac.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/clusterrole-binding-rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-clusterrole-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.kubearmorOperator.name }}-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-kubearmor-clusterrole-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.kubearmorOperator.name }}-manage-kubearmor-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-controller-clusterrole-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.kubearmorOperator.name }}-manage-controller-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-relay-clusterrole-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.kubearmorOperator.name }}-manage-relay-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}   

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/clusterrole-rbac.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/clusterrole-rbac.yaml
@@ -1,0 +1,206 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - create
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - operator.kubearmor.com
+  resources:
+  - kubearmorconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.kubearmor.com
+  resources:
+  - kubearmorconfigs/status
+  verbs:
+  - get
+  - patch
+  - update  
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-kubearmor-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if .Values.kubearmorOperator.annotateResource }}
+  - patch
+  - update
+  {{- end }}
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if .Values.kubearmorOperator.annotateResource }}
+  - patch
+  - update
+  {{- end }}
+- apiGroups:
+  - security.kubearmor.com
+  resources:
+  - kubearmorpolicies
+  - kubearmorclusterpolicies
+  - kubearmorhostpolicies
+  - kubearmornetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- nonResourceURLs:
+  - /apis
+  - /apis/*
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-relay-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-controller-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - list
+  - watch
+  - update
+{{- if .Values.kubearmorOperator.annotateExisting }}
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  - replicasets
+  verbs:
+  - get
+  - update
+{{- end }}
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch   
+- apiGroups:
+  - security.kubearmor.com
+  resources:
+  - kubearmorpolicies
+  - kubearmorclusterpolicies
+  - kubearmorhostpolicies
+  - kubearmornetworkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.kubearmor.com
+  resources:
+  - kubearmorpolicies/status
+  - kubearmorclusterpolicies/status
+  - kubearmorhostpolicies/status
+  - kubearmornetworkpolicies/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/deployment.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    kubearmor-app: {{ .Values.kubearmorOperator.name }}
+spec:
+  selector:
+    matchLabels:
+      kubearmor-app: {{ .Values.kubearmorOperator.name }}
+  template:
+    metadata:
+      labels:
+        kubearmor-app: {{ .Values.kubearmorOperator.name }}
+      {{- with .Values.kubearmorOperator.podLabels }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kubearmorOperator.podAnnotations }}
+      annotations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.kubearmorOperator.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}      
+      {{- if .Values.kubearmorOperator.image.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml .Values.kubearmorOperator.image.imagePullSecrets | nindent 8 }}
+
+      {{- else if .Values.registry.secretName }}
+      imagePullSecrets:
+        - name: {{ .Values.registry.secretName }}
+      {{- end }}
+      {{- if .Values.kubearmorOperator.tolerations }}
+      tolerations: 
+        {{- toYaml .Values.kubearmorOperator.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubearmorOperator.nodeSelector }}
+      nodeSelector: 
+        {{- .Values.kubearmorOperator.nodeSelector | toYaml | nindent 8}}
+      {{- end }}
+      containers:
+      - name: {{ .Values.kubearmorOperator.name }}
+        env:
+        - name: KUBEARMOR_OPERATOR_NS
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- if .Values.kubearmorOperator.enableOCIHooks }}
+        - name: KUBEARMOR_OCI_HOOKS
+          value: "yes"
+        {{- end }}
+        {{- if .Values.imagePinning -}}
+          {{- include "pinnedImages" .Values.kubearmor | trim | nindent 8 }}
+        {{- end }}
+        {{- if .Values.kubearmorOperator.env -}}
+          {{- .Values.kubearmorOperator.env | toYaml | nindent 8 }}
+        {{- end }}
+        image: {{ include "operatorImage" . }}
+        imagePullPolicy: {{ .Values.kubearmorOperator.imagePullPolicy }}
+        args:
+        - --annotateExisting={{ .Values.kubearmorOperator.annotateExisting }}
+        - --annotateResource={{ .Values.kubearmorOperator.annotateResource }}
+        {{- if .Values.kubearmorOperator.socketFile }}
+        - --socket-file={{ .Values.kubearmorOperator.socketFile }}
+        {{- end }}
+        {{- if .Values.kubearmorOperator.image.imagePullSecrets }}
+        - --image-pull-secrets={{ .Values.kubearmorOperator.image.imagePullSecrets | toJson }}
+
+        {{- else if .Values.registry.secretName }}
+        - --image-pull-secrets={{ list (dict "name" .Values.registry.secretName) | toJson }}
+        {{- end }}
+        {{- if .Values.kubearmorOperator.args -}}
+          {{- toYaml .Values.kubearmorOperator.args | trim | nindent 8 }}
+        {{- end }}
+        {{- with .Values.kubearmorOperator.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.kubearmorOperator.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      serviceAccountName: {{ .Values.kubearmorOperator.name }}
+  

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/helpers.tpl
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/helpers.tpl
@@ -1,0 +1,22 @@
+{{- define "pinnedImages" }}
+- name: RELATED_IMAGE_KUBEARMOR_SNITCH
+  value: "{{ .repo }}/{{.images.kubearmorSnitch.image}}:{{.images.kubearmorSnitch.tag}}"
+- name: RELATED_IMAGE_KUBEARMOR
+  value: "{{ .repo }}/{{.images.kubearmor.image}}:{{.images.kubearmor.tag}}"
+- name: RELATED_IMAGE_KUBEARMOR_INIT
+  value: "{{ .repo }}/{{.images.kubearmorInit.image}}:{{.images.kubearmorInit.tag}}"
+- name: RELATED_IMAGE_KUBEARMOR_RELAY_SERVER
+  value: "{{ .repo }}/{{.images.kubearmorRelay.image}}:{{.images.kubearmorRelay.tag}}"
+- name: RELATED_IMAGE_KUBEARMOR_CONTROLLER
+  value: "{{ .repo }}/{{.images.kubearmorController.image}}:{{.images.kubearmorController.tag}}"
+{{- end }}
+
+{{- define "operatorImage" }}
+{{- if .Values.imagePinning }}
+{{- printf "%s/%s:%s" .Values.kubearmor.repo .Values.kubearmor.images.kubearmorOperator.image .Values.kubearmor.images.kubearmorOperator.tag }}
+{{- else if eq .Values.kubearmorOperator.image.tag "" }}
+{{- printf "%s:%s" .Values.kubearmorOperator.image.repository .Chart.Version }}
+{{- else }}
+{{- printf "%s:%s" .Values.kubearmorOperator.image.repository .Values.kubearmorOperator.image.tag }}
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/ka-config.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/ka-config.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.autoDeploy }}
+apiVersion: operator.kubearmor.com/v1
+kind: KubeArmorConfig
+metadata:
+    annotations:
+        "helm.sh/hook": post-install,post-upgrade
+    labels:
+        app.kubernetes.io/name: kubearmorconfig
+        app.kubernetes.io/instance: kubearmorconfig-sample
+        app.kubernetes.io/part-of: kubearmoroperator
+        app.kubernetes.io/managed-by: kustomize
+        app.kubernetes.io/created-by: kubearmoroperator
+    name: kubearmor-default
+    namespace: {{ .Release.Namespace }}
+spec:
+    {{- toYaml .Values.kubearmorConfig | nindent 4}}
+{{- end}}

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/role-rbac.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/role-rbac.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - list
+  - get
+  - create
+  - delete
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - batch
+  verbs:
+  - get
+  - create
+  - delete
+  resources:
+  - jobs
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - get  
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-controller-leader-election-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-snitch-job-role
+  namespace: {{ .Release.Namespace }}
+rules:
+# to handle snitch mounts dynamically  
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list  
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - create
+  - delete  
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-tls-secrets-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+  - delete
+  resourceNames:
+  - {{ .Values.tlsSecrets.kubearmorCa }}
+  - {{ .Values.tlsSecrets.kubearmorClient }}
+  - {{ .Values.tlsSecrets.relayServer }}
+  - {{ .Values.tlsSecrets.controllerWebhook }}
+# cannot restric create by resource name, https://kubernetes.io/docs/reference/access-authn-authz/rbac/  
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/rolebindng-rbac.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/rolebindng-rbac.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-tls-secrets-rolebinding
+  namespace: {{.Release.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.kubearmorOperator.name }}-tls-secrets-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-snitch-job-rolebinding
+  namespace: {{.Release.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.kubearmorOperator.name }}-manage-snitch-job-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-controller-leader-election-rolebinding
+  namespace: {{.Release.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.kubearmorOperator.name }}-manage-controller-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}-rolebinding
+  namespace: {{.Release.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.kubearmorOperator.name }}-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}  

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/serviceaccount.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.kubearmorOperator.name }}
+  namespace: {{ .Release.Namespace }}

--- a/argocd-helm-charts/kubearmor/charts/kubearmor-operator/values.yaml
+++ b/argocd-helm-charts/kubearmor/charts/kubearmor-operator/values.yaml
@@ -1,0 +1,78 @@
+autoDeploy: false
+# operator will deploy pinned images for each application
+imagePinning: false
+  
+# To use existing secret updated {registry.secretName} with your secret name.
+registry: 
+  secretName: ""
+
+# pinned images
+kubearmor:
+  repo: kubearmor
+  images:
+    kubearmor:
+      image: kubearmor
+      tag: stable
+    kubearmorInit:
+      image: kubearmor-init
+      tag: stable
+    kubearmorRelay:
+      image: kubearmor-relay-server
+      tag: latest
+    kubearmorController:
+      image: kubearmor-controller
+      tag: latest
+    kubearmorSnitch:
+      image: kubearmor-snitch
+      tag: latest
+    kubearmorOperator:
+      image: kubearmor-operator
+      tag: latest
+
+# in case if image pinning is disabled
+kubearmorOperator:
+  enableOCIHooks: false
+  annotateResource: false
+  annotateExisting: false
+  name: kubearmor-operator
+  # If not set, the operator will auto-detect the CRI socket
+  socketFile: ""
+  image:
+    repository: docker.io/kubearmor/kubearmor-operator
+    tag: ""
+    # Optional, but if there are a lot of image pulls required, Docker might be rate-limited. So, it's good to add pull secrets for production.
+    imagePullSecrets: []
+  imagePullPolicy: IfNotPresent
+  args: []
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
+  resources: {} 
+  podLabels: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  env: []
+  nodeSelector: {}
+
+kubearmorConfig:
+  defaultCapabilitiesPosture: audit
+  defaultFilePosture: audit
+  defaultNetworkPosture: audit
+  defaultVisibility: process,network
+  enableStdOutLogs: false
+  enableStdOutAlerts: false
+  enableStdOutMsgs: false
+  seccompEnabled: false
+  alertThrottling: true
+  maxAlertPerSec: 10
+  throttleSec: 30
+  matchArgs: true
+
+# DO NOT CHANGE THIS VALUES 
+# changing these values will require code changes with the operator
+# these secret names should match with the secrets managed by the operator
+tlsSecrets:
+  kubearmorCa: kubearmor-ca
+  kubearmorClient: kubearmor-client-certs
+  relayServer: kubearmor-relay-server-certs
+  controllerWebhook: kubearmor-controller-webhook-server-cert

--- a/argocd-helm-charts/kubearmor/values.yaml
+++ b/argocd-helm-charts/kubearmor/values.yaml
@@ -1,0 +1,41 @@
+# KubeArmor is deployed through its operator: this chart installs the operator,
+# which then rolls out KubeArmor (DaemonSet + relay + controller) from a
+# KubeArmorConfig CR. Values for the operator live under the `kubearmor-operator`
+# key below. Upstream defaults are kept except where noted.
+#
+# Notes:
+# - KubeArmor uses eBPF for observability and Linux Security Modules (AppArmor,
+#   BPF-LSM, SELinux) for INLINE enforcement. Unlike Tetragon (kill-after-detect),
+#   KubeArmor can deny an operation at the LSM hook before it runs. See the
+#   tetragon chart for the observability-first sibling; the two are complementary.
+# - Every node needs a working LSM. BPF-LSM needs kernel >= 5.7 with lsm=bpf
+#   enabled; otherwise KubeArmor falls back to AppArmor/SELinux where present.
+#
+# Shipping events to OpenObserve (see README.md):
+# - enableStdOutAlerts prints policy-violation alerts to the relay pod's stdout,
+#   so the openobserve-collector agent DaemonSet (tails /var/log/pods) ships them
+#   to the in-cluster OpenObserve. Enable enableStdOutLogs for full visibility
+#   telemetry (much higher volume). No collector change is needed for the default.
+
+kubearmor-operator:
+  # Roll out KubeArmor automatically via a KubeArmorConfig (post-install hook).
+  autoDeploy: true
+
+  kubearmorConfig:
+    # Observability-first defaults: "audit" logs violations but does NOT block.
+    # Switch a posture to "block" for inline enforcement once policies are tuned.
+    defaultFilePosture: audit
+    defaultNetworkPosture: audit
+    defaultCapabilitiesPosture: audit
+    defaultVisibility: process,network
+
+    # Send alerts to stdout so the OpenObserve collector picks them up.
+    enableStdOutAlerts: true
+    enableStdOutLogs: false
+    enableStdOutMsgs: false
+
+    # Alert throttling (upstream defaults).
+    alertThrottling: true
+    maxAlertPerSec: 10
+    throttleSec: 30
+    matchArgs: true


### PR DESCRIPTION
## What

Adds `argocd-helm-charts/kubearmor` — installs [KubeArmor](https://kubearmor.io) via its operator (`kubearmor-operator` v1.7.4, vendored as a subchart, same pattern as the tetragon chart).

KubeArmor is a CNCF runtime-security engine (AccuKnox) that uses **eBPF** for observability and **Linux Security Modules** (AppArmor, BPF-LSM, SELinux) for **inline enforcement** — it can deny an operation *at the LSM hook before it runs*, rather than reacting after the fact.

## Why (vs the tetragon chart)

They're complementary — pick per cluster by goal:

| | Tetragon (#73) | KubeArmor (this) |
|---|---|---|
| Strength | Security **observability** / forensics | **Inline enforcement** / hardening |
| Enforcement | `SIGKILL` after detection | LSM denies before the op runs |
| Policy | `TracingPolicy` | `KubeArmorPolicy` (+ least-privilege auto-discovery) |
| Fit | pairs with the Cilium CNI | any LSM-capable kernel |

Requested after a peer suggested KubeArmor; shipping it as an **opt-in** alternative for enforcement/compliance-driven clusters, alongside Tetragon for observability.

## Defaults

- `autoDeploy: true` → operator rolls out KubeArmor from a `KubeArmorConfig` (post-install hook)
- **Observability-first:** all postures `audit` (log, don't block); enforcement is opt-in via a `block` posture or a `KubeArmorPolicy`
- `enableStdOutAlerts: true` → relay alerts hit stdout → the `openobserve-collector` agent DaemonSet ships them to OpenObserve (no extra wiring; matches the Tetragon flow)

## Prerequisites

- An LSM per node: **BPF-LSM** (kernel >= 5.7, booted `lsm=...,bpf`) or AppArmor/SELinux
- Runs privileged (host mounts, eBPF/LSM) per the operator

## Notes

- Metrics/alerting remain on kube-prometheus; this only adds a security-event source into OpenObserve (logs/traces backend). No metrics involved.