### PR TITLE
Disable OpenObserve infra-metrics + move collector overrides to the wrapper layer

### DIFF
--- a/argocd-helm-charts/openobserve/Chart.yaml
+++ b/argocd-helm-charts/openobserve/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openobserve
-version: 0.13.5
+version: 0.13.6
 # We disabling the updates for openobserve, since there's no upstream
 # support for dex OIDC connector configurations for enterprise.
 # It expects all the configurations to be passed as configmap, but passing

--- a/argocd-helm-charts/openobserve/charts/openobserve-collector/Chart.yaml
+++ b/argocd-helm-charts/openobserve/charts/openobserve-collector/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
   url: https://openobserve.ai
 name: openobserve-collector
 type: application
-version: 0.4.5
+version: 0.4.4

--- a/argocd-helm-charts/openobserve/charts/openobserve-collector/values.yaml
+++ b/argocd-helm-charts/openobserve/charts/openobserve-collector/values.yaml
@@ -3,17 +3,12 @@
 # Declare variables to be passed into your templates.
 
 exporters:
-  # Default to the in-cluster OpenObserve router so telemetry never leaves the cluster.
-  # Service DNS: <release>-router.<namespace>.svc.cluster.local:<ZO_HTTP_PORT> (default 5080),
-  # path /api/<org> (default org "default"). Override with your OpenObserve ingress URL if the
-  # collector runs outside the cluster. The otlphttp exporter appends /v1/logs|traces|metrics.
-  # Provide real credentials via the openobserve sealed secret, not inline here.
   otlphttp/openobserve:
-    endpoint: http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
+    endpoint: https://api.openobserve.ai/api/default/
     headers:
       Authorization: Basic YOUR_BASE64_ENCODED_AUTH
   otlphttp/openobserve_k8s_events:
-    endpoint: http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
+    endpoint: https://api.openobserve.ai/api/default/
     headers:
       Authorization: Basic CHANGEME_BASE64_ENCODED_AUTH
       stream-name: k8s_events

--- a/argocd-helm-charts/openobserve/values.yaml
+++ b/argocd-helm-charts/openobserve/values.yaml
@@ -29,3 +29,34 @@ openobserve:
         tag: 12-debian-12-r30
         pullPolicy: IfNotPresent
         digest: ""
+
+# OpenObserve stores logs, traces and k8s/security events.
+# Infra metrics and alerting stay in kube-prometheus.
+openobserve-collector:
+  exporters:
+    otlphttp/openobserve:
+      endpoint: http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
+    otlphttp/openobserve_k8s_events:
+      endpoint: http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
+
+  # Logs only. node-exporter and kubelet/cAdvisor already feed Prometheus.
+  agent:
+    receivers:
+      hostmetrics: null
+      kubeletstats: null
+    service:
+      pipelines:
+        metrics: null
+
+  # Traces, k8s events, and the trace-derived servicegraph service map.
+  gateway:
+    receivers:
+      prometheus: null
+    service:
+      pipelines:
+        metrics:
+          receivers: [servicegraph]
+
+  # kube-prometheus already ships kube-state-metrics.
+  kube-state-metrics:
+    enabled: false


### PR DESCRIPTION
## Why

Two things, both rooted in one rule: **`<app>/charts/` is the vendored upstream subchart and must not carry local customization** — a re-vendor silently drops it. Customization belongs in the **first-layer wrapper** (`argocd-helm-charts/openobserve/values.yaml`).

1. **OpenObserve must not ingest infra metrics.** Metrics + alerting live only in kube-prometheus.
2. **PR #72's endpoint fix slipped into the upstream subchart** — it would have reverted to OpenObserve Cloud (`api.openobserve.ai`) on the next re-vendor, silently shipping cluster telemetry off-cluster.

## Changes

### 1. Wrapper overrides (first layer) — `openobserve/values.yaml`

```yaml
openobserve-collector:
  exporters:                                  # pinned here so it survives re-vendoring
    otlphttp/openobserve:
      endpoint: http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
    otlphttp/openobserve_k8s_events:
      endpoint: http://openobserve-router.openobserve.svc.cluster.local:5080/api/default
  agent:                                      # logs-only
    receivers: {hostmetrics: null, kubeletstats: null}
    service: {pipelines: {metrics: null}}
  gateway:                                    # traces + k8s events + service map
    receivers: {prometheus: null}
    service:
      pipelines:
        metrics:
          receivers: [servicegraph]
  kube-state-metrics:
    enabled: false
```

- **Agent → logs-only.** `hostmetrics` + `kubeletstats` dropped (duplicated node-exporter / kubelet-cAdvisor).
- **Gateway → traces + k8s events, plus the service map.** The `prometheus` scrape and the `otlp` metrics receiver are dropped (real infra metrics). **The `servicegraph` connector is KEPT** — it's derived from traces (service map / RED metrics), exists nowhere in Prometheus, and is part of the tracing experience. The metrics pipeline is narrowed to `receivers: [servicegraph]`; the traces pipeline is untouched and still feeds the connector.
- **Bundled kube-state-metrics disabled** — kube-prometheus already ships KSM.

Uses Helm `null`-coalescing to delete upstream keys — the convention already used here (e.g. `cert-manager.io/issuer: null`).

### 2. Subchart restored to pristine upstream (second layer)

Reverts PR #72's edits to `charts/openobserve-collector/`: exporter endpoints back to `https://api.openobserve.ai/api/default/`, chart version back to `0.4.4`. **Net runtime behaviour is unchanged** — the collector still exports to the in-cluster router; the setting just lives in the layer that persists.

## Metric coverage is unaffected

| Signal | Prometheus source |
|---|---|
| node/host CPU·mem·disk·net | node-exporter |
| per-pod/container usage | kubelet `/metrics/cadvisor` |
| k8s object state | kube-state-metrics |

Wrapper chart bumped 0.13.5 → 0.13.6.