### PR TITLE
fix(openvox): default customerid to linuxaid in puppet-agent RoleBinding

### DIFF
--- a/argocd-helm-charts/openvox/templates/puppet-agent-rolebinding.yaml
+++ b/argocd-helm-charts/openvox/templates/puppet-agent-rolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
-  namespace: monitoring-{{ .Values.customerid }}
+  namespace: monitoring-{{ .Values.customerid | default "linuxaid" }}


### PR DESCRIPTION
The prometheus-k8s RoleBinding's subject namespace was rendered as `monitoring-` (unresolvable) whenever .Values.customerid was unset, silently breaking Prometheus's RBAC access to services/endpoints/pods in the puppetserver namespace with no obvious error until scrape targets showed up empty.