### PR TITLE
feat(netbird): derive the cluster + access groups from clusterName

### DIFF
--- a/argocd-helm-charts/netbird-operator/Chart.yaml
+++ b/argocd-helm-charts/netbird-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: netbird-operator
 description: NetBird Kubernetes Operator
 type: application
-version: 0.1.13
+version: 0.2.0
 dependencies:
   - name: netbird-operator
     repository: oci://ghcr.io/netbirdio/helm-charts

--- a/argocd-helm-charts/netbird-operator/templates/_helpers.tpl
+++ b/argocd-helm-charts/netbird-operator/templates/_helpers.tpl
@@ -1,5 +1,10 @@
-{{- /* Name of the shared cluster group: explicit `group`, else the
-     ClusterProxy clusterName, else the router name. */}}
+{{- /* This cluster's identity on the NetBird Management — the router + proxy
+     names and the two chart-created groups all derive from it. */ -}}
+{{- define "kubeaid.netbirdClusterName" -}}
+{{- required "netbird-operator: clusterName is required when networkRouter or clusterProxy is enabled — this cluster's unique, lowercase name on the NetBird Management (it replaced the old group:, networkRouter.name and clusterProxy.clusterName keys)." .Values.clusterName -}}
+{{- end -}}
+
+{{- /* Group holding this cluster's peers + resources (policy destination). */ -}}
 {{- define "kubeaid.netbirdClusterGroup" -}}
-{{- .Values.group | default .Values.clusterProxy.clusterName | default .Values.networkRouter.name -}}
+{{- printf "k8s-%s" (include "kubeaid.netbirdClusterName" .) -}}
 {{- end -}}

--- a/argocd-helm-charts/netbird-operator/templates/cluster-proxy.yaml
+++ b/argocd-helm-charts/netbird-operator/templates/cluster-proxy.yaml
@@ -10,7 +10,7 @@
      The proxy GRANTS nothing — it impersonates. Authorization still comes from
      your own RBAC bound to the NetBird users/groups the proxy stamps. */}}
 {{- if .Values.clusterProxy.enabled }}
-{{- $name := required "clusterProxy.clusterName is required when clusterProxy.enabled=true — it becomes the proxy's mesh DNS label and kube-context" .Values.clusterProxy.clusterName }}
+{{- $name := include "kubeaid.netbirdClusterName" . }}
 {{- $sa := .Values.clusterProxy.serviceAccountName }}
 apiVersion: v1
 kind: ServiceAccount

--- a/argocd-helm-charts/netbird-operator/templates/extra-groups.yaml
+++ b/argocd-helm-charts/netbird-operator/templates/extra-groups.yaml
@@ -1,0 +1,12 @@
+{{- /* Extra groups this cluster owns, one Group CR each — the entry is used
+     verbatim as both the object and NetBird group name. */}}
+{{- range .Values.groups }}
+---
+apiVersion: netbird.io/v1alpha1
+kind: Group
+metadata:
+  name: {{ . }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  name: {{ . | quote }}
+{{- end }}

--- a/argocd-helm-charts/netbird-operator/templates/group.yaml
+++ b/argocd-helm-charts/netbird-operator/templates/group.yaml
@@ -1,12 +1,22 @@
-{{- /* Creates the shared cluster group. The ClusterProxy and every
-     NetworkResource without its own groups join it. Grant access by
-     pointing a NetBird policy at this group. */}}
+{{- /* The cluster's two derived groups. k8s-<clusterName>: this cluster's peers +
+     resources (policy destination). k8s-<clusterName>-access: the humans allowed
+     to reach them (policy source) — add users + point a dashboard policy at it. */}}
 {{- if or .Values.networkRouter.enabled .Values.clusterProxy.enabled }}
+{{- $cluster := include "kubeaid.netbirdClusterGroup" . }}
+{{- $access := printf "%s-access" $cluster }}
 apiVersion: netbird.io/v1alpha1
 kind: Group
 metadata:
-  name: {{ include "kubeaid.netbirdClusterGroup" . }}
+  name: {{ $cluster }}
   namespace: {{ .Release.Namespace }}
 spec:
-  name: {{ include "kubeaid.netbirdClusterGroup" . }}
+  name: {{ $cluster | quote }}
+---
+apiVersion: netbird.io/v1alpha1
+kind: Group
+metadata:
+  name: {{ $access }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  name: {{ $access | quote }}
 {{- end }}

--- a/argocd-helm-charts/netbird-operator/templates/network-resources.yaml
+++ b/argocd-helm-charts/netbird-operator/templates/network-resources.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: {{ .namespace | default $.Release.Namespace }}
 spec:
   networkRouterRef:
-    name: {{ $.Values.networkRouter.name }}
+    name: {{ include "kubeaid.netbirdClusterName" $ }}
     namespace: {{ $.Release.Namespace }}
   serviceRef:
     name: {{ .service }}

--- a/argocd-helm-charts/netbird-operator/templates/network-router.yaml
+++ b/argocd-helm-charts/netbird-operator/templates/network-router.yaml
@@ -11,7 +11,7 @@
 apiVersion: netbird.io/v1alpha1
 kind: NetworkRouter
 metadata:
-  name: {{ .Values.networkRouter.name }}
+  name: {{ include "kubeaid.netbirdClusterName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   dnsZoneRef:

--- a/argocd-helm-charts/netbird-operator/templates/oncall-rbac.yaml
+++ b/argocd-helm-charts/netbird-operator/templates/oncall-rbac.yaml
@@ -1,0 +1,19 @@
+{{- /* On-call access. When enabled, binds the k8s Group `oncall` (the impersonated
+     NetBird oncall group) to cluster-admin, cluster-wide — standing full write,
+     secrets and exec included. Intended for a tiny, fully-trusted rotation. */}}
+{{- with .Values.clusterProxy.oncall }}
+{{- if and $.Values.clusterProxy.enabled .enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oncall
+subjects:
+  - kind: Group
+    name: oncall
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/netbird-operator/values.yaml
+++ b/argocd-helm-charts/netbird-operator/values.yaml
@@ -22,13 +22,14 @@ netbird-operator:
         operator: In
         values: ["true"]
 
-# NetBird group representing access to this cluster. The ClusterProxy and
-# every NetworkResource without its own `groups` join it, so one NetBird
-# policy targeting this group grants a user the cluster's kube-API proxy
-# and exposed Services. The chart creates the group. Empty defaults to
-# clusterProxy.clusterName, else networkRouter.name — keep it unique per
-# cluster.
-group: ""
+# This cluster's identity on the NetBird Management — unique, lowercase DNS label
+# (e.g. kbm-acme-com). Names the router + proxy and derives the two chart-created
+# groups: k8s-<clusterName> (peers/resources) and k8s-<clusterName>-access (users).
+clusterName: ""
+
+# Extra NetBird groups this cluster OWNS — one Group CR each, rare. Declare a
+# group from ONE cluster only — a duplicate wedges the operator on HTTP 409.
+groups: []
 
 # New-gen NetBird Networks wiring (NetworkRouter + NetworkResource,
 # netbird.io/v1alpha1) — the successor to the deprecated NBRoutingPeer.
@@ -38,7 +39,6 @@ group: ""
 # and set the zone in the cluster's values overlay.
 networkRouter:
   enabled: false
-  name: cluster-router
   # Domain of an EXISTING NetBird DNS zone (create it in the Mgmt
   # dashboard first), e.g. "staging.mesh.acme.com". required-checked by the
   # template when enabled.
@@ -49,7 +49,7 @@ networkRouter:
 
 # One entry per Service to expose. Fields: name (CR name), namespace (the
 # Service's own namespace), service (the Service name), groups (optional
-# NetBird groups to join — omit to join the shared cluster `group`).
+# NetBird groups to join — omit to join the cluster group k8s-<clusterName>).
 networkResources: []
 # - name: kube-api
 #   namespace: default
@@ -70,15 +70,17 @@ networkResources: []
 # impersonates, it does not itself grant any access.
 clusterProxy:
   enabled: false
-  # Unique per cluster — becomes the proxy's mesh DNS label and kube-context.
-  # required-checked by the template when enabled.
-  clusterName: ""
   # SA the proxy impersonates through; the chart also creates the matching
   # ClusterRole + ClusterRoleBinding granting it impersonate on users/groups.
   serviceAccountName: clusterproxy
   # In-cluster apiserver URL — the default sidesteps cert-SAN/hostname issues
   # since the proxy never leaves the cluster network to reach the apiserver.
   apiServer: https://kubernetes.default.svc.cluster.local
+  # On-call access. When enabled, binds the k8s Group `oncall` (the impersonated
+  # NetBird `oncall` group) to cluster-admin, cluster-wide. Standing full write —
+  # intended for a tiny, fully-trusted on-call rotation (1-2 people).
+  oncall:
+    enabled: false
   # RBAC for the NetBird identities reached through the proxy. The proxy
   # impersonates the caller's NetBird user + groups but grants nothing itself —
   # each entry binds a subject to a ClusterRole so it actually gets access.


### PR DESCRIPTION
One identity knob. A top-level `clusterName:` derives everything the wrapper names:

```yaml
clusterName: kbm-acme-com   # unique per cluster on the NetBird Management
groups: []                  # optional extra groups this cluster owns
```

- Two chart-created Group CRs: **`k8s-<clusterName>`** — this cluster's peers + resources (the ClusterProxy, routing peer and NetworkResources join it; policy *destination*) — and **`k8s-<clusterName>-access`** — the humans allowed to reach them (policy *source*).
- The NetworkRouter and ClusterProxy are named after `clusterName` too, so clusters stop defaulting to the shared `cluster-router` name, which collides on a shared Management.
- `groups:` is a flat list of extra groups this cluster owns, one Group CR each, entries used verbatim.
- `clusterProxy.oncall.enabled: true` binds the impersonated k8s Group `oncall` to cluster-admin, cluster-wide — the on-call rotation is 1–2 fully-trusted engineers.

**Removed keys** — old overlays fail loudly via the required-`clusterName` error, which names them:

| old | new |
|---|---|
| `group: k8s-<cluster>` | `clusterName: <cluster>` |
| `groups: {cluster, extra}` | `groups: [...]` (extras only) |
| `networkRouter.name` | derived |
| `clusterProxy.clusterName` | derived |

**Still manual per cluster** (the operator has no Policy CRD — NBPolicy is deprecated): add users to `k8s-<name>-access`, and create one one-way dashboard policy `k8s-<name>-access → k8s-<name>`. That single policy covers both the proxy peer and the routed resources (verified against NetBird v0.72.4 source: peer ACLs come from group policies, resource routes from policies whose destination groups contain the resource).

**Rollout notes**
- The operator's Group reconciler is create-only (no adopt path): a hand-made group named `k8s-<cluster>-access` must be deleted (members and policy references detached first) before this chart reaches that cluster, or its operator wedges permanently on HTTP 409.
- Ships in lockstep with kubeaid-cli `feat/netbird-groups-schema`, which emits the new schema; live overlays migrate per-cluster together with their targetRevision bump.

Chart `0.1.13` → `0.2.0`.
