### PR TITLE
kubeaid-agent: collect packagesign snapshot fact

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/values.yaml
@@ -30,6 +30,7 @@ appConfig:
       - domain
       - obmondo_customer
       - obmondo_system
+      - snapshot
     runKubeAidPuppetSync: false
 
   kubeaidUpdate:


### PR DESCRIPTION
Adds the `snapshot` fact to the default facts list the kubeaid-agent pulls from PuppetDB and forwards to the Obmondo API. The fact carries the packagesign snapshot dates (newline-joined, newest first) from the customer repo hosts; the Obmondo API uses it to pin the linuxaid snapshot for a whole update cycle.

ref: EnableIT/obmondo-api-go#2582 (gitea)