### PR TITLE
fix: wrap licenseSecret in quotes and make it conditional in Mattermost installation template

### DIFF
--- a/argocd-helm-charts/mattermost-operator/templates/mattermost-installation.yaml
+++ b/argocd-helm-charts/mattermost-operator/templates/mattermost-installation.yaml
@@ -42,7 +42,9 @@ spec:
   mattermostEnv:
 {{ toYaml .Values.mattermost.mattermostEnv | indent 4 }}
   {{- end }}
-  licenseSecret: {{ .Values.mattermost.licenseSecret | default "null" }}
+  {{- if .Values.mattermost.licenseSecret }}
+  licenseSecret: {{ .Values.mattermost.licenseSecret | quote }}
+  {{- end }}
   database:
     external:
       secret: {{ .Values.mattermost.database.external.secret | default "db-credentials" }}


### PR DESCRIPTION
When syncing Mattermost with ArgoCD using server side apply getting the error below:

```
one or more objects failed to apply, reason: Mattermost.installation.mattermost.com "mattermost" is invalid: spec.licenseSecret: Invalid value: "null": spec.licenseSecret in body must be of type string: "null"
```

When licenseSecret is left empty "" (the default for team edition), Helm renders licenseSecret: null (unquoted). This fails Kubernetes schema validation because the CRD strictly expects a string.

This PR wraps licenseSecret in a conditional block to omit the field when empty, and wraps the output in quote to ensure it is always rendered as a string when present.