### PR TITLE
chore(backup-exporter): point chart at obmondo/backup-exporter:v1.0.5

### DIFF
--- a/argocd-helm-charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: A Helm chart for the Obmondo Backup Exporter — reports PostgreSQL (CNPG logical and WAL) and Velero backup health by reading object storage directly, as Prometheus metrics and a JSON API.
 type: application
-version: 0.1.0
-appVersion: "v1.0.4"
+version: 0.1.1
+appVersion: "v1.0.5"

--- a/argocd-helm-charts/backup-exporter/values.yaml
+++ b/argocd-helm-charts/backup-exporter/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: ghcr.io/obmondo/obmondo-backup-exporter
+  repository: ghcr.io/obmondo/backup-exporter
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag. Left empty so it follows the chart appVersion, which


### PR DESCRIPTION
The published image was renamed from obmondo/obmondo-backup-exporter to obmondo/backup-exporter and v1.0.5 was cut. Update image.repository and appVersion (tag stays empty so it follows appVersion), and bump the chart version to 0.1.1.