### PR TITLE
fix(netbird-operator): add trailing slash to the Kubernetes API server URL

### DIFF
--- a/argocd-helm-charts/netbird-operator/values.yaml
+++ b/argocd-helm-charts/netbird-operator/values.yaml
@@ -75,7 +75,7 @@ clusterProxy:
   serviceAccountName: clusterproxy
   # In-cluster apiserver URL — the default sidesteps cert-SAN/hostname issues
   # since the proxy never leaves the cluster network to reach the apiserver.
-  apiServer: https://kubernetes.default.svc.cluster.local
+  apiServer: https://kubernetes.default.svc.cluster.local/
   # On-call access. When enabled, binds the k8s Group `oncall` (the impersonated
   # NetBird `oncall` group) to cluster-admin, cluster-wide. Standing full write —
   # intended for a tiny, fully-trusted on-call rotation (1-2 people).


### PR DESCRIPTION
This prevents `trailing slash` from getting added to the URL of each request we send to the Kubernetes API server via NetBird Operator's ClusterProxy (and thus `kubeseal` secret encryption command to not fail).

[Here is the relevant code](https://github.com/kubernetes/apimachinery/blob/52ed2791fbb9c442e41b7d856ad916753092316d/pkg/util/proxy/upgradeaware.go#L196) from the Kubernetes API server codebase.