### PR TITLE
fix(kube-prometheus): have a variable for taking the Traefik pod name as input

### DIFF
--- a/build/kube-prometheus/build.sh
+++ b/build/kube-prometheus/build.sh
@@ -27,7 +27,7 @@ basedir="$(dirname "$(realpath "${0}")")"
 
 function _exit() {
   if ! ((debug)); then
-    if [ -v tmpdir ] && [ -d "${tmpdir}" ]; then
+    if [ -n "${tmpdir+x}" ] && [ -d "${tmpdir}" ]; then
       rm -rf "${tmpdir}"
     fi
   fi
@@ -110,7 +110,6 @@ if ! [[ "${cluster_dir}" ]]; then
   exit 2
 fi
 
-
 # Find the vars.jsonnet file in the cluster directory
 # With CAPI, folder name can differ from cluster name
 cluster_jsonnet=$(find "${cluster_dir}" -maxdepth 1 -name "*-vars.jsonnet" -type f | head -n 1)
@@ -143,8 +142,8 @@ if ! ((ignore_pinned_version)); then
   argocd_app_file="${cluster_dir%/}/argocd-apps/templates/kube-prometheus.yaml"
   pinned_version=''
   if [[ -f "${argocd_app_file}" ]]; then
-    pinned_version=$(gojsontoyaml -yamltojson <"${argocd_app_file}" 2>/dev/null \
-      | jq -r '.metadata.labels["kubeaid.io/version"] // ""' 2>/dev/null || echo '')
+    pinned_version=$(gojsontoyaml -yamltojson <"${argocd_app_file}" 2>/dev/null |
+      jq -r '.metadata.labels["kubeaid.io/version"] // ""' 2>/dev/null || echo '')
   fi
 
   case "${pinned_version}" in

--- a/build/kube-prometheus/common-template.jsonnet
+++ b/build/kube-prometheus/common-template.jsonnet
@@ -234,7 +234,7 @@ local kp =
             from: [{
               podSelector: {
                 matchLabels: {
-                  'app.kubernetes.io/name': 'traefik',
+                  'app.kubernetes.io/name': vars.traefik_pod_name,
                 },
               },
               namespaceSelector: {
@@ -385,7 +385,7 @@ local kp =
                 },
                 podSelector: {
                   matchLabels: {
-                    'app.kubernetes.io/name': 'traefik',
+                    'app.kubernetes.io/name': vars.traefik_pod_name,
                   },
                 },
               }],
@@ -695,7 +695,7 @@ local kp =
                 },
                 podSelector: {
                   matchLabels: {
-                    'app.kubernetes.io/name': 'traefik',
+                    'app.kubernetes.io/name': vars.traefik_pod_name,
                   },
                 },
               }],

--- a/build/kube-prometheus/lib/default_vars.libsonnet
+++ b/build/kube-prometheus/lib/default_vars.libsonnet
@@ -97,6 +97,11 @@
   alertmanager_ingress_annotations: {
     'cert-manager.io/cluster-issuer': 'letsencrypt',
   },
+  // app.kubernetes.io/name carried by the Traefik pods that serve the
+  // monitoring ingresses. Clusters running Traefik under a differently-named
+  // Helm release (e.g. traefik-private) must override this, otherwise the
+  // NetworkPolicies below never match and requests time out with a 504.
+  traefik_pod_name: 'traefik',
   addMixins: {
     ceph: false,
     'argo-cd': true,


### PR DESCRIPTION
For one of our customers, we have multiple `Traefik` instances deployed in a cluster. Each instance has a different name. And so does the corresponding pods of that deployed instance.