### PR TITLE
fix(prometheus): prevent flapping cert_expiry alert due to long scrpe interval

### DIFF
--- a/argocd-helm-charts/prometheus-linuxaid/rules/cert_expiry.yaml
+++ b/argocd-helm-charts/prometheus-linuxaid/rules/cert_expiry.yaml
@@ -1,14 +1,15 @@
 groups:
   - name: monitor::domains
     rules:
-    - alert: monitor::domains::cert_expiry
-      expr: |
-        probe_ssl_earliest_cert_expiry - time() < on (certname, domain) 86400 * threshold::monitor::domains::cert_expiry_days
-        and on(certname) obmondo_monitoring{alert_id="monitor::domains::cert_expiry"} > 0
-      for: 15m
-      labels:
-        severity: critical
-        alert_id: monitor::domains::cert_expiry
-      annotations:
-        summary: "SSL certificate will expire soon for domain **{{ $labels.domain }}**"
-        description: Blackbox exporter on {{ $labels.certname }}, domain {{ $labels.domain }} certificate expires in {{ .Value | humanizeDuration }}
+      - alert: monitor::domains::cert_expiry
+        expr: |
+          (last_over_time(probe_ssl_earliest_cert_expiry[1d]) - time()) < on(certname, domain) (86400 * threshold::monitor::domains::cert_expiry_days)
+          and on(certname) obmondo_monitoring{alert_id="monitor::domains::cert_expiry"} > 0
+          and on(certname, domain) last_over_time(probe_success[1d]) == 1
+        for: 0m
+        labels:
+          severity: critical
+          alert_id: monitor::domains::cert_expiry
+        annotations:
+          summary: "SSL certificate will expire soon for domain **{{ $labels.domain }}**"
+          description: Blackbox exporter on {{ $labels.certname }}, domain {{ $labels.domain }} certificate expires in {{ .Value | humanizeDuration }}


### PR DESCRIPTION
The `monitor::domains::cert_expiry` alert was failing to fire consistently because the Prometheus scrape interval (12h) was significantly longer than the alert duration (15m), causing the metric to be missing during most evaluation cycles.

This change ensures reliable alerting without requiring more frequent scrapes:
- Uses `last_over_time()` for the certificate expiry metric to maintain the last known state between long scrape intervals.
- Adds a staleness guard using `probe_success` to ensure alerts only fire based on data that has been successfully scraped within the last 24 hours.
- Sets alert duration to `0m`, as the `last_over_time` logic provides the necessary stability.

Signed-off-by: Sidharth Jawale <sidharth@obmondo.com>