### PR TITLE
feat: update vuls chart

### DIFF
--- a/argocd-helm-charts/vuls-dictionary/Chart.yaml
+++ b/argocd-helm-charts/vuls-dictionary/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/argocd-helm-charts/vuls-dictionary/README.md
+++ b/argocd-helm-charts/vuls-dictionary/README.md
@@ -6,9 +6,11 @@ Helm chart for deploying [Vuls](https://github.com/future-architect/vuls), an ag
 
 Vuls uses a pre-built SQLite database ([vuls-nightly-db](https://github.com/vulsio/vuls-nightly-db)) that contains CVE, advisory, and detection data. The database (~7 GB uncompressed) is fetched once via init containers and cached on a PersistentVolume. The vuls server reads it locally at startup, so no outbound network access is needed at scan time.
 
-1. **Init containers** pull and decompress the database into `/vuls/vuls.db`
+1. **Init containers** pull and decompress the database into `/vuls-db/vuls.db`
 2. **Vuls server** starts on port 5515 with a config pointing at the local database
 3. **Clients** POST their installed package lists and receive vulnerability results
+
+The database is kept on its own PVC, separate from `/vuls/results`, so database refresh bursts do not consume result-storage headroom. Scan results can be pruned by an init container before the server starts. During migration from older chart versions, legacy `/vuls/vuls.db*` files are removed from the results PVC to reclaim space.
 
 ## Components
 
@@ -39,6 +41,8 @@ vulsServer:
 | `vuls2.image.repository` | Database OCI image | `ghcr.io/vulsio/vuls-nightly-db` |
 | `vuls2.image.tag` | Database image tag | `"0"` |
 | `vuls2.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `vuls2.dbPath` | Path to the decompressed SQLite DB | `/vuls-db/vuls.db` |
+| `vuls2.minDbSizeBytes` | Minimum valid DB size before fetch/decompress is skipped | `"5368709120"` |
 
 When enabled, two init containers run before the vuls server starts:
 1. **fetch-vuls2-db** -- pulls the compressed database via `oras`
@@ -55,9 +59,15 @@ Both init containers skip work if a valid database (>5 GB) already exists on the
 | `vulsServer.image.tag` | Vuls server image tag | `v0.38.6` |
 | `vulsServer.port` | Listen port | `5515` |
 | `vulsServer.resources` | Resource requests/limits | 50m/100m CPU, 256Mi/512Mi |
-| `vulsServer.resultsStorage.size` | PVC size for scan results and database | `15Gi` |
-| `vulsServer.resultsStorage.accessMode` | PVC access mode | `ReadWriteOnce` |
-| `vulsServer.resultsStorage.storageClass` | Storage class (empty = default) | `""` |
+| `vulsServer.resultsDir` | Directory where Vuls writes scan results | `/vuls/results` |
+| `vulsServer.databaseStorage.size` | PVC size for the vuls2 database | `25Gi` |
+| `vulsServer.databaseStorage.accessMode` | Database PVC access mode | `ReadWriteOnce` |
+| `vulsServer.databaseStorage.storageClass` | Database storage class (empty = default) | `""` |
+| `vulsServer.resultsStorage.size` | PVC size for scan results | `15Gi` |
+| `vulsServer.resultsStorage.accessMode` | Results PVC access mode | `ReadWriteOnce` |
+| `vulsServer.resultsStorage.storageClass` | Results storage class (empty = default) | `""` |
+| `vulsServer.resultRetention.enabled` | Prune old scan result directories at startup | `true` |
+| `vulsServer.resultRetention.maxAgeDays` | Delete result directories older than this many days | `60` |
 
 ### Vuls exporter
 

--- a/argocd-helm-charts/vuls-dictionary/ci/test-chart.sh
+++ b/argocd-helm-charts/vuls-dictionary/ci/test-chart.sh
@@ -56,33 +56,10 @@ echo ""
 # --- Default values ---
 run_test "default values render successfully"
 
-assert_present "default: CVE image tag is v0.16.0" "vuls/go-cve-dictionary:v0.16.0"
+assert_present "default: vuls DB PVC present" "db-pvc"
 assert_present "default: vuls-server deployment present" "vuls-server"
 assert_present "default: configmap present" "vuls-config"
 assert_present "default: results PVC present" "results-pvc"
-
-# --- PostgreSQL (CNPG) ---
-assert_present "postgresql: CNPG Cluster created" "kind: Cluster" \
-  --show-only templates/postgresql.yaml
-
-assert_present "postgresql: cluster name correct" "test-vuls-dictionary-pgsql"
-
-assert_present "postgresql: bootstrap database is vuls" "database: vuls"
-
-assert_present "postgresql: dbtype postgres in deployment" "dbtype" \
-  --show-only templates/deployment.yaml
-
-assert_present "postgresql: wait-for-postgres init container" "wait-for-postgres" \
-  --show-only templates/deployment.yaml
-
-assert_present "postgresql: pgsql-cve-app secret ref in deployment" "pgsql-cve-app" \
-  --show-only templates/deployment.yaml
-
-assert_present "postgresql: dbtype postgres in CVE cronjob" "dbtype" \
-  --show-only templates/cronjobs-cve.yaml
-
-assert_present "postgresql: dbtype postgres in CVE seed job" "dbtype" \
-  --show-only templates/job-cve-seed.yaml
 
 # --- vulsServer enabled ---
 run_test "vulsServer enabled renders successfully" \
@@ -100,15 +77,30 @@ assert_present "vulsServer: configmap created" "vuls-config" \
 assert_present "vulsServer: results PVC created" "results-pvc" \
   --set vulsServer.enabled=true
 
-assert_present "vulsServer: image is vuls/vuls:v0.38.6" "vuls/vuls:v0.38.6" \
+assert_present "vulsServer: db PVC created" "db-pvc" \
+  --set vulsServer.enabled=true
+
+assert_present "vulsServer: image is ghcr.io/obmondo/vuls:45714b6" "ghcr.io/obmondo/vuls:45714b6" \
   --set vulsServer.enabled=true
 
 assert_present "vulsServer: listens on port 5515" "containerPort: 5515" \
   --set vulsServer.enabled=true
 
-# --- config.toml URLs point to dictionary services ---
-assert_present "config.toml: CVE dict URL correct" "http://test-vuls-dictionary-dict-server:1323" \
-  --set vulsServer.enabled=true
+assert_present "vulsServer: vuls2 DB path is separate PVC" "Path = \"/vuls-db/vuls.db\"" \
+  --set vulsServer.enabled=true \
+  --show-only templates/configmap.yaml
+
+assert_present "vulsServer: cleanup init container present" "cleanup-vuls-results" \
+  --set vulsServer.enabled=true \
+  --show-only templates/deployment-vuls-server.yaml
+
+assert_present "vulsServer: legacy DB cleanup present" "removing legacy database file" \
+  --set vulsServer.enabled=true \
+  --show-only templates/deployment-vuls-server.yaml
+
+assert_present "vulsServer: DB fetch skips valid cache" "skipping fetch" \
+  --set vulsServer.enabled=true \
+  --show-only templates/deployment-vuls-server.yaml
 
 # --- Ingress variations ---
 run_test "ingress disabled (default)" \
@@ -198,14 +190,6 @@ assert_absent "vulsExporter no TLS: no cert_file in config" "cert_file" \
   --set vulsExporter.obmondo.url=https://api.obmondo.com \
   --show-only templates/configmap-vuls-exporter.yaml
 
-# --- Disable individual dictionaries ---
-run_test "CVE disabled renders successfully" \
-  --set cve.enabled=false
-
-assert_absent "CVE disabled: no CVE container in deployment" "vuls/go-cve-dictionary" \
-  --set cve.enabled=false \
-  --show-only templates/deployment.yaml
-
 # --- Custom values ---
 run_test "custom vuls-server port" \
   --set vulsServer.enabled=true \
@@ -222,6 +206,25 @@ run_test "custom results storage size" \
 assert_present "custom storage: 10Gi in results PVC" "storage: 10Gi" \
   --set vulsServer.enabled=true \
   --set vulsServer.resultsStorage.size=10Gi
+
+run_test "custom database storage size" \
+  --set vulsServer.enabled=true \
+  --set vulsServer.databaseStorage.size=30Gi
+
+assert_present "custom database storage: 30Gi in db PVC" "storage: 30Gi" \
+  --set vulsServer.enabled=true \
+  --set vulsServer.databaseStorage.size=30Gi \
+  --show-only templates/pvc-db.yaml
+
+run_test "vuls2 disabled renders without db PVC" \
+  --set vuls2.enabled=false
+
+assert_absent "vuls2 disabled: no db PVC" "db-pvc" \
+  --set vuls2.enabled=false
+
+assert_absent "vuls2 disabled: no vuls-db volume" "vuls-db" \
+  --set vuls2.enabled=false \
+  --show-only templates/deployment-vuls-server.yaml
 
 # --- Summary ---
 echo ""

--- a/argocd-helm-charts/vuls-dictionary/templates/configmap.yaml
+++ b/argocd-helm-charts/vuls-dictionary/templates/configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
   config.toml: |
     [vuls2]
-    Path = "/vuls/vuls.db"
+    Path = {{ .Values.vuls2.dbPath | quote }}
     SkipUpdate = true
 {{- end }}

--- a/argocd-helm-charts/vuls-dictionary/templates/deployment-vuls-server.yaml
+++ b/argocd-helm-charts/vuls-dictionary/templates/deployment-vuls-server.yaml
@@ -34,18 +34,65 @@ spec:
       serviceAccountName: {{ include "vuls-dictionary.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.vuls2.enabled }}
+      {{- if or .Values.vuls2.enabled .Values.vulsServer.resultRetention.enabled }}
       initContainers:
+        {{- if .Values.vulsServer.resultRetention.enabled }}
+        - name: cleanup-vuls-results
+          image: alpine:3.21
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -eu
+              RESULTS_DIR="{{ .Values.vulsServer.resultsDir }}"
+              MAX_AGE_DAYS="{{ .Values.vulsServer.resultRetention.maxAgeDays }}"
+              if [ ! -d "${RESULTS_DIR}" ]; then
+                echo "results directory ${RESULTS_DIR} does not exist, skipping cleanup"
+                exit 0
+              fi
+              for legacy_db_file in /vuls/vuls.db /vuls/vuls.db.zst /vuls/vuls.db.tmp; do
+                if [ -e "${legacy_db_file}" ]; then
+                  echo "removing legacy database file ${legacy_db_file} from results PVC"
+                  rm -f "${legacy_db_file}"
+                fi
+              done
+              echo "removing vuls result directories older than ${MAX_AGE_DAYS} days from ${RESULTS_DIR}"
+              find "${RESULTS_DIR}" -mindepth 1 -maxdepth 1 -type d -mtime +"${MAX_AGE_DAYS}" -print -exec rm -rf {} +
+          volumeMounts:
+            - name: results
+              mountPath: /vuls
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+        {{- end }}
+        {{- if .Values.vuls2.enabled }}
         - name: fetch-vuls2-db
           image: ghcr.io/oras-project/oras:v1.2.2
           command: ["sh", "-c"]
           args:
             - |
+              set -eu
+              DB_PATH="{{ .Values.vuls2.dbPath }}"
+              DB_DIR="$(dirname "${DB_PATH}")"
+              MIN_SIZE="{{ .Values.vuls2.minDbSizeBytes | int64 }}"
+              if [ -f "${DB_PATH}" ]; then
+                FILE_SIZE="$(stat -c%s "${DB_PATH}")"
+                if [ "${FILE_SIZE}" -gt "${MIN_SIZE}" ]; then
+                  echo "vuls2 db already exists ($(du -h "${DB_PATH}" | cut -f1)), skipping fetch"
+                  exit 0
+                fi
+                echo "vuls2 db exists but is too small (${FILE_SIZE} bytes), re-fetching"
+                rm -f "${DB_PATH}"
+              fi
               echo "pulling vuls2 nightly db..."
-              oras pull -o /vuls "{{ .Values.vuls2.image.repository }}:{{ .Values.vuls2.image.tag }}"
+              rm -f "${DB_PATH}.zst" "${DB_PATH}.tmp"
+              oras pull -o "${DB_DIR}" "{{ .Values.vuls2.image.repository }}:{{ .Values.vuls2.image.tag }}"
           volumeMounts:
-            - name: results
-              mountPath: /vuls
+            - name: vuls-db
+              mountPath: /vuls-db
           resources:
             requests:
               cpu: 50m
@@ -58,14 +105,31 @@ spec:
           command: ["sh", "-c"]
           args:
             - |
+              set -eu
+              DB_PATH="{{ .Values.vuls2.dbPath }}"
+              MIN_SIZE="{{ .Values.vuls2.minDbSizeBytes | int64 }}"
+              if [ -f "${DB_PATH}" ]; then
+                FILE_SIZE="$(stat -c%s "${DB_PATH}")"
+                if [ "${FILE_SIZE}" -gt "${MIN_SIZE}" ]; then
+                  echo "vuls2 db already decompressed ($(du -h "${DB_PATH}" | cut -f1))"
+                  exit 0
+                fi
+                echo "vuls2 db exists but is too small (${FILE_SIZE} bytes), re-decompressing"
+                rm -f "${DB_PATH}"
+              fi
+              if [ ! -f "${DB_PATH}.zst" ]; then
+                echo "compressed database ${DB_PATH}.zst not found"
+                exit 1
+              fi
               apk add --no-cache zstd
               echo "decompressing vuls.db.zst..."
-              unzstd -f /vuls/vuls.db.zst -o /vuls/vuls.db
-              rm -f /vuls/vuls.db.zst
-              ls -lh /vuls/vuls.db
+              unzstd -f "${DB_PATH}.zst" -o "${DB_PATH}.tmp"
+              mv "${DB_PATH}.tmp" "${DB_PATH}"
+              rm -f "${DB_PATH}.zst"
+              ls -lh "${DB_PATH}"
           volumeMounts:
-            - name: results
-              mountPath: /vuls
+            - name: vuls-db
+              mountPath: /vuls-db
           resources:
             requests:
               cpu: 100m
@@ -73,6 +137,7 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+        {{- end }}
       {{- end }}
       containers:
         - name: vuls-server
@@ -85,7 +150,7 @@ spec:
             - -listen
             - "0.0.0.0:{{ .Values.vulsServer.port }}"
             - -config=/vuls/config.toml
-            - -results-dir=/vuls/results
+            - -results-dir={{ .Values.vulsServer.resultsDir }}
             - -to-localfile
           ports:
             - name: http-vuls
@@ -104,6 +169,10 @@ spec:
           volumeMounts:
             - name: results
               mountPath: /vuls
+            {{- if .Values.vuls2.enabled }}
+            - name: vuls-db
+              mountPath: /vuls-db
+            {{- end }}
             - name: config
               mountPath: /vuls/config.toml
               subPath: config.toml
@@ -123,6 +192,11 @@ spec:
             - name: results
               mountPath: /vuls
               readOnly: true
+            {{- if .Values.vuls2.enabled }}
+            - name: vuls-db
+              mountPath: /vuls-db
+              readOnly: true
+            {{- end }}
             - name: vuls-exporter-config
               mountPath: /etc/vuls-exporter
               readOnly: true
@@ -136,6 +210,11 @@ spec:
         - name: results
           persistentVolumeClaim:
             claimName: {{ include "vuls-dictionary.fullname" . }}-results-pvc
+        {{- if .Values.vuls2.enabled }}
+        - name: vuls-db
+          persistentVolumeClaim:
+            claimName: {{ include "vuls-dictionary.fullname" . }}-db-pvc
+        {{- end }}
         - name: config
           configMap:
             name: {{ include "vuls-dictionary.fullname" . }}-vuls-config

--- a/argocd-helm-charts/vuls-dictionary/templates/pvc-db.yaml
+++ b/argocd-helm-charts/vuls-dictionary/templates/pvc-db.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.vulsServer.enabled .Values.vuls2.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "vuls-dictionary.fullname" . }}-db-pvc
+  labels:
+    {{- include "vuls-dictionary.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.vulsServer.databaseStorage.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.vulsServer.databaseStorage.size | default "25Gi" }}
+{{- if .Values.vulsServer.databaseStorage.storageClass }}
+  storageClassName: "{{ .Values.vulsServer.databaseStorage.storageClass }}"
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/vuls-dictionary/values.yaml
+++ b/argocd-helm-charts/vuls-dictionary/values.yaml
@@ -76,6 +76,8 @@ vuls2:
     repository: ghcr.io/vulsio/vuls-nightly-db
     tag: "0"
     pullPolicy: IfNotPresent
+  dbPath: /vuls-db/vuls.db
+  minDbSizeBytes: "5368709120"
 
 # the latest release ATM i.e 0.39.3 doesn't have the report from NVD and other sources
 # But, its fixed in the latest master - so, we have built the image and pushed
@@ -94,7 +96,15 @@ vulsServer:
     limits:
       cpu: 100m
       memory: 512Mi
+  resultsDir: /vuls/results
+  databaseStorage:
+    storageClass: ""
+    size: 25Gi
+    accessMode: ReadWriteOnce
   resultsStorage:
     storageClass: ""
     size: 15Gi
     accessMode: ReadWriteOnce
+  resultRetention:
+    enabled: true
+    maxAgeDays: 60


### PR DESCRIPTION
Added the long-term Vuls fix: split the vuls2 DB into its own PVC, keep scan results on the existing results PVC, restore DB cache/skip logic, prune result dirs older than 60 days, and clean up legacy `/vuls/vuls.db*` files from the results PVC