### PR TITLE
(fix): pgsql logical backups name as a variable string

### DIFF
--- a/argocd-helm-charts/kubeaid-addons/templates/postgresql-logical-backup.yaml
+++ b/argocd-helm-charts/kubeaid-addons/templates/postgresql-logical-backup.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: postgres-logical-backup
+  name: {{ .Values.global.postgresql.instanceName }}-pgsql-logical-backup
 spec:
   concurrencyPolicy: Forbid
   suspend: false


### PR DESCRIPTION
closes https://github.com/Obmondo/KubeAid/issues/125