### PR TITLE
feat(mongodb): label the backup CronJob for backup-exporter

### DIFF
--- a/argocd-helm-charts/kubeaid-addons/charts/mongodb/templates/mongodb-backup-cronjob.yaml
+++ b/argocd-helm-charts/kubeaid-addons/charts/mongodb/templates/mongodb-backup-cronjob.yaml
@@ -7,6 +7,11 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ printf "%s-backup" .Values.global.mongodb.instanceName }}
+  labels:
+    # How backup-exporter finds this job. The value is fixed, unlike the
+    # per-instance "app" label on the pod template below, so one selector
+    # matches every mongodump CronJob in the cluster.
+    backup-exporter.io/backup: mongodb
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1


### PR DESCRIPTION
A fixed label on the CronJob lets backup-exporter select it server-side. The existing "app" label is on the pod template and varies per instance, so no single selector matches it.