### PR TITLE
feat(backup-exporter): add MongoDB dump monitoring

### DIFF
--- a/argocd-helm-charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/backup-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: backup-exporter
-description: A Helm chart for the Obmondo Backup Exporter — reports PostgreSQL (CNPG logical and WAL) and Velero backup health by reading object storage directly, as Prometheus metrics and a JSON API.
+description: A Helm chart for the Obmondo Backup Exporter — reports PostgreSQL (CNPG logical and WAL), Velero and MongoDB backup health by reading object storage directly, as Prometheus metrics and a JSON API.
 type: application
-version: 0.1.1
-appVersion: "v1.0.5"
+version: 0.2.0
+appVersion: "v1.1.0"

--- a/argocd-helm-charts/backup-exporter/templates/clusterrole.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/clusterrole.yaml
@@ -22,6 +22,13 @@ rules:
     resources: ["cronjobs"]
     verbs: ["get", "list"]
 
+  # MongoDBCommunity CRDs. Collection is driven by these: each names its own
+  # backup CronJob (<resource>-backup), and one with no such job reports
+  # no_backup.
+  - apiGroups: ["mongodbcommunity.mongodb.com"]
+    resources: ["mongodbcommunity"]
+    verbs: ["get", "list"]
+
   # Velero CRDs
   - apiGroups: ["velero.io"]
     resources: ["schedules"]

--- a/argocd-helm-charts/backup-exporter/templates/deployment.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/deployment.yaml
@@ -96,6 +96,35 @@ spec:
               value: {{ . | quote }}
             {{- end }}
             {{- end }}
+            {{- if (.Values.exporter.mongodb).enabled }}
+            - name: MONGODB_BACKUP_ENABLED
+              value: "true"
+            - name: MONGODB_EXPORTER_MAX_RPO
+              value: {{ .Values.exporter.mongodb.max_rpo | default "26h" | quote }}
+            - name: MONGODB_EXPORTER_INTERVAL_RATE
+              value: {{ .Values.exporter.mongodb.interval_rate | default "0.25" | quote }}
+            {{- with .Values.exporter.mongodb.s3.secretName }}
+            - name: MONGODB_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: access-key-id
+            - name: MONGODB_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: secret-access-key
+            {{- else }}
+            {{- with .Values.exporter.mongodb.s3.accessKeyId }}
+            - name: MONGODB_S3_ACCESS_KEY_ID
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.exporter.mongodb.s3.secretAccessKey }}
+            - name: MONGODB_S3_SECRET_ACCESS_KEY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- $s3 := .Values.exporter.postgres.s3 }}
             {{- with $s3.secretName }}
             - name: POSTGRES_S3_LOGICAL_ACCESS_KEY_ID

--- a/argocd-helm-charts/backup-exporter/templates/mongodb-prometheusrule.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/mongodb-prometheusrule.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.prometheusRule.enabled (hasKey .Values.prometheusRule "mongodb") ( .Values.prometheusRule.mongodb.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "backup-exporter.fullname" . }}-mongodb
+  namespace: {{ .Values.prometheusRule.mongodb.namespace | default "monitoring" }}
+  labels:
+    {{- include "backup-exporter.labels" . | nindent 4 }}
+    {{- if .Values.prometheusRule.mongodb.labels }}
+    {{- toYaml .Values.prometheusRule.mongodb.labels | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: {{ include "backup-exporter.name" . }}-mongodb
+      rules:
+        - alert: MongoDBBackupExporterJobFailed
+          expr: max by (namespace, cluster_name, backup, type) (backup_exporter_mongodb_error == 1) > 0
+          for: {{ .Values.prometheusRule.mongodb.alertForDuration | default "5m" }}
+          labels:
+            severity: {{ .Values.prometheusRule.mongodb.severity | default "critical" }}
+          annotations:
+            summary: 'MongoDB backup exporter job failed'
+            description: 'MongoDB dump check failed for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} (type: {{ `{{ $labels.type }}` }})'
+        - alert: MongoDBDumpBackupExceededRPO
+          expr: mongodb_latest_dump_backup_age > {{ include "backup-exporter.durationToSeconds" .Values.exporter.mongodb.max_rpo }}
+          for: {{ .Values.prometheusRule.mongodb.alertForDuration | default "5m" }}
+          labels:
+            severity: {{ .Values.prometheusRule.mongodb.severity | default "critical" }}
+          annotations:
+            summary: 'MongoDB dump backup exceeded RPO'
+            description: 'Dump for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} exceeded RPO (age: {{ `{{ $value }}` }})'
+        # Age 0 is the exporter's "no backup" sentinel, not a fresh backup: a
+        # dump taken this second still reports a positive age.
+        - alert: MongoDBDumpBackupMissing
+          expr: mongodb_latest_dump_backup_age == 0
+          for: {{ .Values.prometheusRule.mongodb.alertForDuration | default "5m" }}
+          labels:
+            severity: {{ .Values.prometheusRule.mongodb.severity | default "critical" }}
+          annotations:
+            summary: 'MongoDB dump backup missing'
+            description: 'No dump found for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }}'
+{{- end }}

--- a/argocd-helm-charts/backup-exporter/values.yaml
+++ b/argocd-helm-charts/backup-exporter/values.yaml
@@ -164,6 +164,31 @@ exporter:
       secretAccessKey: ""
       region: ""
       bucket: ""
+  mongodb:
+    # The MongoDB dump exporter is opt-in: the MongoDB Community operator ships
+    # no backup CRD, so a cluster without the Obmondo mongodump CronJob has
+    # nothing to report and should not be scheduled at all.
+    enabled: false
+
+    # Maximum acceptable Recovery Point Objective (RPO) for MongoDB dumps.
+    # Supported formats: "24h", "6h", "30m", "1d", "7d"
+    max_rpo: 26h
+
+    # Rate at which the exporter checks backup health, expressed as a fraction
+    # of max_rpo. Must be between 0 and 1. Defaults to 0.25.
+    interval_rate: 0.25
+
+    # Credentials for listing the dump bucket. Required when enabled: the
+    # exporter uses its own read-only keys and never reads the backup CronJob's
+    # Secret, which would need "get" on secrets in every namespace. Everything
+    # else -- bucket, prefix, endpoint -- is read off the discovered CronJob.
+    s3:
+      # Name of the Kubernetes Secret containing S3 credentials.
+      # Expected secret keys: access-key-id, secret-access-key
+      secretName: ""
+      # Direct values for testing (used when secretName is empty).
+      accessKeyId: ""
+      secretAccessKey: ""
 
 # PrometheusRule for alerting
 prometheusRule:
@@ -176,6 +201,14 @@ prometheusRule:
     namespace: monitoring
   velero:
     enabled: true
+    labels: {}
+    severity: critical
+    alertForDuration: 5m
+    namespace: monitoring
+  mongodb:
+    # Follows exporter.mongodb.enabled -- rules for an exporter that is not
+    # running would alert on series that never appear.
+    enabled: false
     labels: {}
     severity: critical
     alertForDuration: 5m


### PR DESCRIPTION
Wires the v1.1.0 exporter's MongoDB support: opt-in values, its own read-only S3 credentials, RBAC to read MongoDBCommunity resources, and the three alerts. Off by default, so existing installs are unchanged.