### PR TITLE
feat(backup-exporter): add sealed-secrets key backup monitoring

### DIFF
--- a/argocd-helm-charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/backup-exporter/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: backup-exporter
-description: A Helm chart for the Obmondo Backup Exporter — reports PostgreSQL (CNPG logical and WAL), Velero and MongoDB backup health by reading object storage directly, as Prometheus metrics and a JSON API.
+description: A Helm chart for the Obmondo Backup Exporter — reports PostgreSQL (CNPG logical and WAL), Velero, MongoDB and Sealed Secrets backup health by reading object storage directly, as Prometheus metrics and a JSON API.
 type: application
-version: 0.2.0
+version: 0.3.0
+# Sealed-secrets support is not in v1.1.0 -- bump this when the release
+# carrying it is cut.
 appVersion: "v1.1.0"

--- a/argocd-helm-charts/backup-exporter/templates/deployment.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/deployment.yaml
@@ -125,6 +125,43 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- if (.Values.exporter.sealedSecrets).enabled }}
+            - name: SEALED_SECRETS_BACKUP_ENABLED
+              value: "true"
+            - name: SEALED_SECRETS_EXPORTER_MAX_RPO
+              value: {{ .Values.exporter.sealedSecrets.max_rpo | default "26h" | quote }}
+            - name: SEALED_SECRETS_EXPORTER_INTERVAL_RATE
+              value: {{ .Values.exporter.sealedSecrets.interval_rate | default "0.25" | quote }}
+            {{- with .Values.exporter.sealedSecrets.s3.bucket }}
+            - name: SEALED_SECRETS_S3_BUCKET
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.exporter.sealedSecrets.s3.endpoint }}
+            - name: SEALED_SECRETS_S3_ENDPOINT
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.exporter.sealedSecrets.s3.secretName }}
+            - name: SEALED_SECRETS_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: access-key-id
+            - name: SEALED_SECRETS_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: secret-access-key
+            {{- else }}
+            {{- with .Values.exporter.sealedSecrets.s3.accessKeyId }}
+            - name: SEALED_SECRETS_S3_ACCESS_KEY_ID
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.exporter.sealedSecrets.s3.secretAccessKey }}
+            - name: SEALED_SECRETS_S3_SECRET_ACCESS_KEY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- $s3 := .Values.exporter.postgres.s3 }}
             {{- with $s3.secretName }}
             - name: POSTGRES_S3_LOGICAL_ACCESS_KEY_ID

--- a/argocd-helm-charts/backup-exporter/templates/sealed-secrets-prometheusrule.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/sealed-secrets-prometheusrule.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.prometheusRule.enabled (hasKey .Values.prometheusRule "sealedSecrets") ( .Values.prometheusRule.sealedSecrets.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "backup-exporter.fullname" . }}-sealed-secrets
+  namespace: {{ .Values.prometheusRule.sealedSecrets.namespace | default "monitoring" }}
+  labels:
+    {{- include "backup-exporter.labels" . | nindent 4 }}
+    {{- if .Values.prometheusRule.sealedSecrets.labels }}
+    {{- toYaml .Values.prometheusRule.sealedSecrets.labels | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: {{ include "backup-exporter.name" . }}-sealed-secrets
+      rules:
+        - alert: SealedSecretsBackupExporterJobFailed
+          expr: max by (namespace, type) (backup_exporter_sealedsecrets_error == 1) > 0
+          for: {{ .Values.prometheusRule.sealedSecrets.alertForDuration | default "5m" }}
+          labels:
+            severity: {{ .Values.prometheusRule.sealedSecrets.severity | default "critical" }}
+          annotations:
+            summary: 'Sealed-secrets key backup check failed'
+            description: 'Key backup check failed in {{ `{{ $labels.namespace }}` }} (type: {{ `{{ $labels.type }}` }})'
+        - alert: SealedSecretsKeyBackupExceededRPO
+          expr: sealed_secrets_latest_key_backup_age > {{ include "backup-exporter.durationToSeconds" .Values.exporter.sealedSecrets.max_rpo }}
+          for: {{ .Values.prometheusRule.sealedSecrets.alertForDuration | default "5m" }}
+          labels:
+            severity: {{ .Values.prometheusRule.sealedSecrets.severity | default "critical" }}
+          annotations:
+            summary: 'Sealed-secrets key backup exceeded RPO'
+            description: 'Newest key archive in {{ `{{ $labels.namespace }}` }} is {{ `{{ $value }}` }}s old. These keys decrypt every SealedSecret in git and this backup is their only copy outside the cluster.'
+        # Age 0 is the exporter's "no backup" sentinel, not a fresh backup: an
+        # archive written this second still reports a positive age. Reaching
+        # here means the backup job is running but its bucket is empty.
+        - alert: SealedSecretsKeyBackupMissing
+          expr: sealed_secrets_latest_key_backup_age == 0
+          for: {{ .Values.prometheusRule.sealedSecrets.alertForDuration | default "5m" }}
+          labels:
+            severity: {{ .Values.prometheusRule.sealedSecrets.severity | default "critical" }}
+          annotations:
+            summary: 'Sealed-secrets key backup missing'
+            description: 'The key backup job in {{ `{{ $labels.namespace }}` }} is configured but no archive exists in its bucket. Losing this cluster would make every SealedSecret in git unrecoverable.'
+{{- end }}

--- a/argocd-helm-charts/backup-exporter/values.yaml
+++ b/argocd-helm-charts/backup-exporter/values.yaml
@@ -189,6 +189,37 @@ exporter:
       # Direct values for testing (used when secretName is empty).
       accessKeyId: ""
       secretAccessKey: ""
+  sealedSecrets:
+    # The sealed-secrets master key backup. Opt-in: a cluster whose
+    # sealed-secrets chart has backup.enabled=false has nothing to report.
+    #
+    # These keys decrypt every SealedSecret in git, and the backup CronJob is
+    # their only copy outside the cluster, so this is the backup with the least
+    # margin for error.
+    enabled: false
+
+    # Maximum acceptable Recovery Point Objective (RPO) for key backups.
+    # Supported formats: "24h", "6h", "30m", "1d", "7d"
+    max_rpo: 26h
+
+    # Rate at which the exporter checks backup health, expressed as a fraction
+    # of max_rpo. Must be between 0 and 1. Defaults to 0.25.
+    interval_rate: 0.25
+
+    s3:
+      # Bucket and endpoint the key archives are written to. Unlike the other
+      # exporters these cannot be discovered: the sealed-secrets chart templates
+      # them into the backup script, so the CronJob's env never carries them.
+      # They MUST match backup.s3Bucket and backup.s3Endpoint in that chart --
+      # a mismatch reports as a missing backup.
+      bucket: ""
+      endpoint: ""
+      # Read-only credentials for that bucket.
+      # Expected secret keys: access-key-id, secret-access-key
+      secretName: ""
+      # Direct values for testing (used when secretName is empty).
+      accessKeyId: ""
+      secretAccessKey: ""
 
 # PrometheusRule for alerting
 prometheusRule:
@@ -208,6 +239,13 @@ prometheusRule:
   mongodb:
     # Follows exporter.mongodb.enabled -- rules for an exporter that is not
     # running would alert on series that never appear.
+    enabled: false
+    labels: {}
+    severity: critical
+    alertForDuration: 5m
+    namespace: monitoring
+  sealedSecrets:
+    # Follows exporter.sealedSecrets.enabled.
     enabled: false
     labels: {}
     severity: critical


### PR DESCRIPTION
Bucket and endpoint are values, not discovered: the sealed-secrets chart templates them into the backup script, so the CronJob env never has them. Off by default.