### PR TITLE
chore(ntfy): lock topics down with deny-all and a user database

### DIFF
--- a/argocd-helm-charts/ntfy/values.yaml
+++ b/argocd-helm-charts/ntfy/values.yaml
@@ -22,3 +22,17 @@ ntfy:
     # Keep the message cache on the PVC (default is in-memory).
     cache:
       file: /data/cache.db
+
+    # Topics are private by default. Upstream ships defaultAccess "read-write", which lets anyone
+    # who can reach the service subscribe to any topic or publish to it -- unacceptable where a
+    # topic carries one person's on-call pages.
+    #
+    # This alone locks everybody out, including publishers. An admin user has to be created once in
+    # the pod before anything can use the instance -- see "Users & tokens" in the readme.
+    auth:
+      file: /data/user.db
+      defaultAccess: deny-all
+
+    # Humans log into the mobile app with username + password, so this has to be on. Signup stays
+    # off (the upstream default): accounts are created by an admin, not self-registered.
+    enableLogin: true


### PR DESCRIPTION
The chart inherited upstream's defaultAccess of read-write, so anything able to reach the service could subscribe to any topic or publish to it. That is untenable once a topic carries one person's on-call pages: a bystander could read them, or forge one.

Switches to deny-all with the user database on the existing PVC, beside the message cache, and turns on login so people can authenticate from the mobile app. Signup stays off, so accounts are created by an admin rather than self-registered.

Note this is not a drop-in change to a running instance: deny-all locks out publishers too, and there is no admin UI, so an admin user has to be created once inside the pod before anything works again. The readme already covers that under "Users & tokens".