### PR TITLE
fix(backup-exporter): stop alerting for apps that never enabled a backup type

### DIFF
--- a/argocd-helm-charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: A Helm chart for the Obmondo Backup Exporter — reports PostgreSQL (CNPG logical and WAL), Velero, MongoDB and Sealed Secrets backup health by reading object storage directly, as Prometheus metrics and a JSON API.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "v1.2.0"

--- a/argocd-helm-charts/backup-exporter/templates/postgres-prometheusrule.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/postgres-prometheusrule.yaml
@@ -1,4 +1,11 @@
 {{- if and .Values.prometheusRule.enabled (hasKey .Values.prometheusRule "postgres") ( .Values.prometheusRule.postgres.enabled ) }}
+{{- $ignoreNS := .Values.prometheusRule.postgres.ignoreNamespaces | default list }}
+{{- $nsSuffix := "" }}
+{{- $nsBraces := "" }}
+{{- if $ignoreNS }}
+{{- $nsSuffix = printf ",exported_namespace!~\"%s\"" (join "|" $ignoreNS) }}
+{{- $nsBraces = printf "{exported_namespace!~\"%s\"}" (join "|" $ignoreNS) }}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -13,44 +20,65 @@ spec:
   groups:
     - name: {{ include "backup-exporter.name" . }}-postgres
       rules:
+        # "not enabled" error types (backup_not_enabled, cronjob_not_found,
+        # no_scheduled_backups) mean the app never turned this backup type on
+        # -- that isn't a job failure, so it's excluded here rather than
+        # firing for every app that hasn't opted in.
+        #
+        # Note: the metric's own "namespace" label collides with the one
+        # Prometheus injects from the scrape target (the exporter pod's own
+        # namespace, "monitoring") since honorLabels isn't set on the
+        # ServiceMonitor. The target's label wins, and the scraped one is
+        # renamed to "exported_namespace" -- that's the one that actually
+        # varies per app, so all namespace matching below uses it instead of
+        # "namespace".
         - alert: PostgresBackupExporterJobFailed
-          expr: max by (namespace, cluster_name, backup, type) (backup_exporter_postgres_error == 1) > 0
+          expr: max by (exported_namespace, cluster_name, backup, type) (backup_exporter_postgres_error{type!~"backup_not_enabled|cronjob_not_found|no_scheduled_backups"{{ $nsSuffix }}} == 1) > 0
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}
           annotations:
             summary: 'Postgres backup exporter error'
-            description: 'Postgres backup exporter error for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} (backup: {{ `{{ $labels.backup }}` }}, error: {{ `{{ $labels.type }}` }})'
+            description: 'Postgres backup exporter error for {{ `{{ $labels.exported_namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} (backup: {{ `{{ $labels.backup }}` }}, error: {{ `{{ $labels.type }}` }})'
         - alert: PostgresLogicalBackupExceededRPO
-          expr: postgres_latest_logical_backup_age > {{ include "backup-exporter.durationToSeconds" .Values.exporter.postgres.max_rpo }}
+          expr: postgres_latest_logical_backup_age{{ $nsBraces }} > {{ include "backup-exporter.durationToSeconds" .Values.exporter.postgres.max_rpo }}
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}
           annotations:
             summary: 'PostgreSQL logical backup exceeded RPO'
-            description: 'Logical backup for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} exceeded RPO (age: {{ `{{ $value }}` }})'
+            description: 'Logical backup for {{ `{{ $labels.exported_namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} exceeded RPO (age: {{ `{{ $value }}` }})'
         - alert: PostgresCNPGWALBackupExceededRPO
-          expr: postgres_latest_cnpg_wal_backup_age > {{ include "backup-exporter.durationToSeconds" .Values.exporter.postgres.max_rpo }}
+          expr: postgres_latest_cnpg_wal_backup_age{{ $nsBraces }} > {{ include "backup-exporter.durationToSeconds" .Values.exporter.postgres.max_rpo }}
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}
           annotations:
             summary: 'PostgreSQL CNPG WAL backup exceeded RPO'
-            description: 'WAL backup for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} exceeded RPO (age: {{ `{{ $value }}` }})'
+            description: 'WAL backup for {{ `{{ $labels.exported_namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} exceeded RPO (age: {{ `{{ $value }}` }})'
+        # The "missing" sentinel (age == 0) is published for every CNPG
+        # cluster regardless of whether logical backup was ever enabled for
+        # it, so clusters the exporter has already flagged as not-enabled
+        # (via backup_exporter_postgres_error) are excluded via the join
+        # below instead of alerting on apps that never opted in. The join
+        # matches on exported_namespace (not namespace, see note above) and
+        # cluster_name together, since cluster_name alone isn't unique
+        # across namespaces (e.g. multiple apps have a cluster named
+        # "api-postgresql").
         - alert: PostgresLogicalBackupMissing
-          expr: postgres_latest_logical_backup_age == 0
+          expr: postgres_latest_logical_backup_age{{ $nsBraces }} == 0 unless on (exported_namespace, cluster_name) (backup_exporter_postgres_error{backup="logical", type=~"backup_not_enabled|cronjob_not_found"} == 1)
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}
           annotations:
             summary: 'PostgreSQL logical backup missing'
-            description: 'No logical backup found for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }}'
+            description: 'No logical backup found for {{ `{{ $labels.exported_namespace }}` }}/{{ `{{ $labels.cluster_name }}` }}'
         - alert: PostgresWALBackupMissing
-          expr: postgres_latest_cnpg_wal_backup_age == 0
+          expr: postgres_latest_cnpg_wal_backup_age{{ $nsBraces }} == 0 unless on (exported_namespace, cluster_name) (backup_exporter_postgres_error{backup="wal", type=~"backup_not_enabled|cronjob_not_found|no_scheduled_backups"} == 1)
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}
           annotations:
             summary: 'PostgreSQL WAL backup missing'
-            description: 'No WAL backup found for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }}'
+            description: 'No WAL backup found for {{ `{{ $labels.exported_namespace }}` }}/{{ `{{ $labels.cluster_name }}` }}'
 {{- end }}

--- a/argocd-helm-charts/backup-exporter/templates/velero-prometheusrule.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/velero-prometheusrule.yaml
@@ -1,4 +1,56 @@
 {{- if and .Values.prometheusRule.enabled (hasKey .Values.prometheusRule "velero") ( .Values.prometheusRule.velero.enabled ) }}
+{{- $includeNS := .Values.prometheusRule.velero.includeNamespaces | default list }}
+{{- $nsResources := .Values.prometheusRule.velero.includeNamespaceResources | default dict }}
+{{- $ignoreNS := .Values.prometheusRule.velero.ignoreNamespaces | default list }}
+{{- $ignoreResources := .Values.prometheusRule.velero.ignoreResourceNames | default list }}
+{{/* The metric's own "namespace" label collides with the one Prometheus
+     injects from the scrape target (the exporter pod's own namespace,
+     "monitoring") since honorLabels isn't set on the ServiceMonitor. The
+     target's label wins, and the scraped one is renamed to
+     "exported_namespace" -- that's the one that actually varies per PVC, so
+     all namespace matching below uses it instead of "namespace". */}}
+{{/* $unionBraces holds one self-contained {..} label-matcher set per fully
+     open namespace group plus one per namespace restricted to specific PVC
+     names, so the alert expr becomes "metric{A} <op> or metric{B} <op> ..."
+     -- some namespaces can be fully open while others are scoped down to a
+     single named PVC, in the same rule. */}}
+{{- $unionBraces := list }}
+{{- if $includeNS }}
+{{- $unionBraces = append $unionBraces (printf "{exported_namespace=~\"%s\"}" (join "|" $includeNS)) }}
+{{- end }}
+{{- range $ns, $resources := $nsResources }}
+{{- $unionBraces = append $unionBraces (printf "{exported_namespace=\"%s\",resource_name=~\"%s\"}" $ns (join "|" $resources)) }}
+{{- end }}
+{{- $fallbackBraces := "" }}
+{{- if not $unionBraces }}
+{{/* No opt-in list set at all: fall back to the exclude-list behavior. */}}
+{{- $matchers := list }}
+{{- if $ignoreNS }}
+{{- $matchers = append $matchers (printf "exported_namespace!~\"%s\"" (join "|" $ignoreNS)) }}
+{{- end }}
+{{- if $ignoreResources }}
+{{- $matchers = append $matchers (printf "resource_name!~\"%s\"" (join "|" $ignoreResources)) }}
+{{- end }}
+{{- if $matchers }}
+{{- $fallbackBraces = printf "{%s}" (join "," $matchers) }}
+{{- end }}
+{{- end }}
+{{- $rpoThreshold := include "backup-exporter.durationToSeconds" .Values.exporter.velero.max_rpo }}
+{{- $rpoParts := list }}
+{{- $missingParts := list }}
+{{- range $b := $unionBraces }}
+{{- $rpoParts = append $rpoParts (printf "backup_exporter_velero_latest_backup_age%s > %s" $b $rpoThreshold) }}
+{{- $missingParts = append $missingParts (printf "backup_exporter_velero_latest_backup_age%s == 0" $b) }}
+{{- end }}
+{{- $rpoExpr := "" }}
+{{- $missingExpr := "" }}
+{{- if $rpoParts }}
+{{- $rpoExpr = join " or " $rpoParts }}
+{{- $missingExpr = join " or " $missingParts }}
+{{- else }}
+{{- $rpoExpr = printf "backup_exporter_velero_latest_backup_age%s > %s" $fallbackBraces $rpoThreshold }}
+{{- $missingExpr = printf "backup_exporter_velero_latest_backup_age%s == 0" $fallbackBraces }}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -22,19 +74,19 @@ spec:
             summary: 'Velero backup exporter job failed'
             description: 'Velero backup exporter error (type: {{ `{{ $labels.type }}` }})'
         - alert: VeleroBackupExceededRPO
-          expr: backup_exporter_velero_latest_backup_age > {{ include "backup-exporter.durationToSeconds" .Values.exporter.velero.max_rpo }}
+          expr: {{ $rpoExpr }}
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.velero.severity | default "critical" }}
           annotations:
             summary: 'Velero backup exceeded RPO'
-            description: 'Backup for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.resource_name }}` }} ({{ `{{ $labels.resource_type }}` }}, method: {{ `{{ $labels.backup }}` }}) exceeded RPO (age: {{ `{{ $value }}` }})'
+            description: 'Backup for {{ `{{ $labels.exported_namespace }}` }}/{{ `{{ $labels.resource_name }}` }} ({{ `{{ $labels.resource_type }}` }}, method: {{ `{{ $labels.backup }}` }}) exceeded RPO (age: {{ `{{ $value }}` }})'
         - alert: VeleroBackupMissing
-          expr: backup_exporter_velero_latest_backup_age == 0
+          expr: {{ $missingExpr }}
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.velero.severity | default "critical" }}
           annotations:
             summary: 'Velero backup missing'
-            description: 'No backup found for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.resource_name }}` }} ({{ `{{ $labels.resource_type }}` }}, method: {{ `{{ $labels.backup }}` }})'
+            description: 'No backup found for {{ `{{ $labels.exported_namespace }}` }}/{{ `{{ $labels.resource_name }}` }} ({{ `{{ $labels.resource_type }}` }}, method: {{ `{{ $labels.backup }}` }})'
 {{- end }}

--- a/argocd-helm-charts/backup-exporter/test/prometheusRuleTest.yaml
+++ b/argocd-helm-charts/backup-exporter/test/prometheusRuleTest.yaml
@@ -6,7 +6,7 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'backup_exporter_postgres_error{backup="logical",namespace="test",cluster_name="pg1",type="process"}'
+      - series: 'backup_exporter_postgres_error{backup="logical",exported_namespace="test",cluster_name="pg1",type="process"}'
         values: '1x6'
     alert_rule_test:
       - alertname: PostgresBackupExporterJobFailed
@@ -16,7 +16,7 @@ tests:
               alertname: PostgresBackupExporterJobFailed
               severity: critical
               backup: logical
-              namespace: test
+              exported_namespace: test
               cluster_name: pg1
               type: process
             exp_annotations:
@@ -25,7 +25,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'postgres_latest_logical_backup_age{namespace="test",cluster_name="pg1"}'
+      - series: 'postgres_latest_logical_backup_age{exported_namespace="test",cluster_name="pg1"}'
         values: '95000x6'
     alert_rule_test:
       - alertname: PostgresLogicalBackupExceededRPO
@@ -34,7 +34,7 @@ tests:
           - exp_labels:
               alertname: PostgresLogicalBackupExceededRPO
               cluster_name: pg1
-              namespace: test
+              exported_namespace: test
               severity: critical
             exp_annotations:
               summary: 'PostgreSQL logical backup exceeded RPO'
@@ -42,7 +42,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'postgres_latest_cnpg_wal_backup_age{namespace="test",cluster_name="pg1"}'
+      - series: 'postgres_latest_cnpg_wal_backup_age{exported_namespace="test",cluster_name="pg1"}'
         values: '95000x6'
     alert_rule_test:
       - alertname: PostgresCNPGWALBackupExceededRPO
@@ -51,7 +51,7 @@ tests:
           - exp_labels:
               alertname: PostgresCNPGWALBackupExceededRPO
               cluster_name: pg1
-              namespace: test
+              exported_namespace: test
               severity: critical
             exp_annotations:
               summary: 'PostgreSQL CNPG WAL backup exceeded RPO'
@@ -59,7 +59,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'postgres_latest_logical_backup_age{namespace="test",cluster_name="pg1"}'
+      - series: 'postgres_latest_logical_backup_age{exported_namespace="test",cluster_name="pg1"}'
         values: '0x6'
     alert_rule_test:
       - alertname: PostgresLogicalBackupMissing
@@ -68,7 +68,7 @@ tests:
           - exp_labels:
               alertname: PostgresLogicalBackupMissing
               cluster_name: pg1
-              namespace: test
+              exported_namespace: test
               severity: critical
             exp_annotations:
               summary: 'PostgreSQL logical backup missing'
@@ -76,7 +76,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'postgres_latest_cnpg_wal_backup_age{namespace="test",cluster_name="pg1"}'
+      - series: 'postgres_latest_cnpg_wal_backup_age{exported_namespace="test",cluster_name="pg1"}'
         values: '0x6'
     alert_rule_test:
       - alertname: PostgresWALBackupMissing
@@ -85,8 +85,69 @@ tests:
           - exp_labels:
               alertname: PostgresWALBackupMissing
               cluster_name: pg1
-              namespace: test
+              exported_namespace: test
               severity: critical
             exp_annotations:
               summary: 'PostgreSQL WAL backup missing'
               description: 'No WAL backup found for test/pg1'
+
+  # "not enabled" error types must not fire PostgresBackupExporterJobFailed --
+  # they mean the app never turned this backup type on, not a job failure.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_postgres_error{backup="logical",exported_namespace="disabled-ns",cluster_name="pg-disabled",type="backup_not_enabled"}'
+        values: '1x6'
+      - series: 'backup_exporter_postgres_error{backup="logical",exported_namespace="disabled-ns2",cluster_name="pg-disabled2",type="cronjob_not_found"}'
+        values: '1x6'
+      - series: 'backup_exporter_postgres_error{backup="wal",exported_namespace="disabled-ns3",cluster_name="pg-disabled3",type="no_scheduled_backups"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: PostgresBackupExporterJobFailed
+        eval_time: 6m
+        exp_alerts: []
+
+  # A genuine failure type must still fire PostgresBackupExporterJobFailed.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_postgres_error{backup="logical",exported_namespace="test",cluster_name="pg1",type="s3_connection_failed"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: PostgresBackupExporterJobFailed
+        eval_time: 6m
+        exp_alerts:
+          - exp_labels:
+              alertname: PostgresBackupExporterJobFailed
+              severity: critical
+              backup: logical
+              exported_namespace: test
+              cluster_name: pg1
+              type: s3_connection_failed
+            exp_annotations:
+              summary: 'Postgres backup exporter error'
+              description: 'Postgres backup exporter error for test/pg1 (backup: logical, error: s3_connection_failed)'
+
+  # A cluster with the zero-age "missing" sentinel AND a recorded
+  # backup_not_enabled/cronjob_not_found error must not fire
+  # PostgresLogicalBackupMissing -- the unless-join excludes it.
+  - interval: 1m
+    input_series:
+      - series: 'postgres_latest_logical_backup_age{exported_namespace="disabled-ns",cluster_name="pg-disabled"}'
+        values: '0x6'
+      - series: 'backup_exporter_postgres_error{backup="logical",exported_namespace="disabled-ns",cluster_name="pg-disabled",type="backup_not_enabled"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: PostgresLogicalBackupMissing
+        eval_time: 6m
+        exp_alerts: []
+
+  # Same, for WAL.
+  - interval: 1m
+    input_series:
+      - series: 'postgres_latest_cnpg_wal_backup_age{exported_namespace="disabled-ns3",cluster_name="pg-disabled3"}'
+        values: '0x6'
+      - series: 'backup_exporter_postgres_error{backup="wal",exported_namespace="disabled-ns3",cluster_name="pg-disabled3",type="no_scheduled_backups"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: PostgresWALBackupMissing
+        eval_time: 6m
+        exp_alerts: []

--- a/argocd-helm-charts/backup-exporter/values.yaml
+++ b/argocd-helm-charts/backup-exporter/values.yaml
@@ -230,12 +230,48 @@ prometheusRule:
     severity: critical
     alertForDuration: 5m
     namespace: monitoring
+    # Namespaces to exclude from all postgres backup-exporter alerts (regex
+    # values, matched against the "namespace" label). Use this for namespaces
+    # that should never be checked at all, on top of the automatic exclusion
+    # of clusters where logical/WAL backup was never enabled.
+    ignoreNamespaces: []
   velero:
     enabled: true
     labels: {}
     severity: critical
     alertForDuration: 5m
     namespace: monitoring
+    # Namespaces where velero backup is actually enabled (regex values,
+    # matched against the "namespace" label). When set, ONLY these
+    # namespaces are ever alerted on -- set this to the same namespaces
+    # listed in your Velero Schedule(s)' includedNamespaces, so alerts only
+    # fire where backup is enabled, not for every PVC in the cluster.
+    # Takes priority over ignoreNamespaces when both are set.
+    includeNamespaces: []
+    # Namespaces to restrict to specific PVCs only, rather than being fully
+    # open. Keyed by namespace, each value is a list of resource_name regex
+    # values -- only those PVCs are ever alerted on for that namespace, even
+    # though the namespace itself isn't (and shouldn't be) listed in
+    # includeNamespaces. Combines with includeNamespaces: some namespaces can
+    # be fully open while others here are scoped down to one named PVC.
+    # Example:
+    #   includeNamespaceResources:
+    #     monitoring:
+    #       - prometheus-k8s-db-prometheus-k8s-0
+    #     puppetserver-enableit:
+    #       - puppetserver-enableit-code-claim
+    includeNamespaceResources: {}
+    # Namespaces to exclude from all velero backup-exporter alerts (regex
+    # values, matched against the "namespace" label). Ignored if
+    # includeNamespaces is set.
+    ignoreNamespaces: []
+    # Resource names to exclude from all velero backup-exporter alerts (regex
+    # values, matched against the "resource_name" label). Intended as a
+    # stand-in for PVCs that Velero's own resourcePolicy already skips (e.g.
+    # redis, mongodb, rabbitmq, opensearch, CNPG-managed volumes) -- the
+    # exporter has no visibility into that policy today, so this list has to
+    # be kept in sync by hand.
+    ignoreResourceNames: []
   mongodb:
     # Follows exporter.mongodb.enabled -- rules for an exporter that is not
     # running would alert on series that never appear.


### PR DESCRIPTION
backup-exporter's own error-type labels (backup_not_enabled, cronjob_not_found, no_scheduled_backups) already distinguish "this app never turned this backup type on" from a real failure, but PostgresBackupExporterJobFailed fired on any error type, and the Missing alerts fire off a zero-age sentinel published for every CNPG cluster regardless of whether the backup was ever enabled. On kcm this meant 152 firing Postgres alerts for apps that don't run logical/WAL backup at all.
