### PR TITLE
fix(backup-exporter): stop alerting for apps that never enabled a backup type

### DIFF
--- a/argocd-helm-charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: A Helm chart for the Obmondo Backup Exporter — reports PostgreSQL (CNPG logical and WAL), Velero, MongoDB and Sealed Secrets backup health by reading object storage directly, as Prometheus metrics and a JSON API.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "v1.2.0"

--- a/argocd-helm-charts/backup-exporter/templates/deployment.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
             - name: VELERO_S3_ENDPOINT
               value: {{ . | quote }}
             {{- end }}
+            {{- with .Values.exporter.velero.s3.prefix }}
+            - name: VELERO_S3_PREFIX
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.exporter.velero.s3.secretName }}
             - name: VELERO_S3_ACCESS_KEY_ID
               valueFrom:

--- a/argocd-helm-charts/backup-exporter/templates/postgres-prometheusrule.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/postgres-prometheusrule.yaml
@@ -13,8 +13,12 @@ spec:
   groups:
     - name: {{ include "backup-exporter.name" . }}-postgres
       rules:
+        # "not enabled" error types (backup_not_enabled, cronjob_not_found,
+        # no_scheduled_backups) mean the app never turned this backup type on
+        # -- that isn't a job failure, so it's excluded here rather than
+        # firing for every app that hasn't opted in.
         - alert: PostgresBackupExporterJobFailed
-          expr: max by (namespace, cluster_name, backup, type) (backup_exporter_postgres_error == 1) > 0
+          expr: max by (namespace, cluster_name, backup, type) (backup_exporter_postgres_error{type!~"backup_not_enabled|cronjob_not_found|no_scheduled_backups"} == 1) > 0
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}
@@ -37,8 +41,16 @@ spec:
           annotations:
             summary: 'PostgreSQL CNPG WAL backup exceeded RPO'
             description: 'WAL backup for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} exceeded RPO (age: {{ `{{ $value }}` }})'
+        # The "missing" sentinel (age == 0) is published for every CNPG
+        # cluster regardless of whether logical backup was ever enabled for
+        # it, so clusters the exporter has already flagged as not-enabled
+        # (via backup_exporter_postgres_error) are excluded via the join
+        # below instead of alerting on apps that never opted in. The join
+        # matches on namespace and cluster_name together, since cluster_name
+        # alone isn't unique across namespaces (e.g. multiple apps have a
+        # cluster named "api-postgresql").
         - alert: PostgresLogicalBackupMissing
-          expr: postgres_latest_logical_backup_age == 0
+          expr: postgres_latest_logical_backup_age == 0 unless on (namespace, cluster_name) (backup_exporter_postgres_error{backup="logical", type=~"backup_not_enabled|cronjob_not_found"} == 1)
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}
@@ -46,7 +58,7 @@ spec:
             summary: 'PostgreSQL logical backup missing'
             description: 'No logical backup found for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }}'
         - alert: PostgresWALBackupMissing
-          expr: postgres_latest_cnpg_wal_backup_age == 0
+          expr: postgres_latest_cnpg_wal_backup_age == 0 unless on (namespace, cluster_name) (backup_exporter_postgres_error{backup="wal", type=~"backup_not_enabled|cronjob_not_found|no_scheduled_backups"} == 1)
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}

--- a/argocd-helm-charts/backup-exporter/templates/postgres-prometheusrule.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/postgres-prometheusrule.yaml
@@ -14,7 +14,7 @@ spec:
     - name: {{ include "backup-exporter.name" . }}-postgres
       rules:
         - alert: PostgresBackupExporterJobFailed
-          expr: max by (namespace, cluster_name, backup, type) (backup_exporter_postgres_error == 1) > 0
+          expr: max by (namespace, cluster_name, backup, type) (backup_exporter_postgres_error{type!~"backup_not_enabled|cronjob_not_found|no_scheduled_backups"} == 1) > 0
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}
@@ -38,7 +38,7 @@ spec:
             summary: 'PostgreSQL CNPG WAL backup exceeded RPO'
             description: 'WAL backup for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }} exceeded RPO (age: {{ `{{ $value }}` }})'
         - alert: PostgresLogicalBackupMissing
-          expr: postgres_latest_logical_backup_age == 0
+          expr: postgres_latest_logical_backup_age == 0 unless on (namespace, cluster_name) (backup_exporter_postgres_error{backup="logical", type=~"backup_not_enabled|cronjob_not_found"} == 1)
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}
@@ -46,7 +46,7 @@ spec:
             summary: 'PostgreSQL logical backup missing'
             description: 'No logical backup found for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.cluster_name }}` }}'
         - alert: PostgresWALBackupMissing
-          expr: postgres_latest_cnpg_wal_backup_age == 0
+          expr: postgres_latest_cnpg_wal_backup_age == 0 unless on (namespace, cluster_name) (backup_exporter_postgres_error{backup="wal", type=~"backup_not_enabled|cronjob_not_found|no_scheduled_backups"} == 1)
           for: {{ .Values.prometheusRule.postgres.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.postgres.severity | default "critical" }}

--- a/argocd-helm-charts/backup-exporter/templates/servicemonitor.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/servicemonitor.yaml
@@ -13,6 +13,12 @@ spec:
     - interval: {{ .Values.serviceMonitor.interval }}
       port: http
       path: /metrics
+      # The exporter's own "namespace" label (the app/PVC being reported on)
+      # otherwise collides with the one Prometheus injects from the scrape
+      # target (this pod's own namespace) and gets renamed to
+      # "exported_namespace". honorLabels keeps the scraped value instead, so
+      # every PrometheusRule can just match on "namespace" directly.
+      honorLabels: true
   selector:
     matchLabels:
       {{- include "backup-exporter.selectorLabels" . | nindent 6 }}

--- a/argocd-helm-charts/backup-exporter/templates/velero-prometheusrule.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/velero-prometheusrule.yaml
@@ -30,7 +30,7 @@ spec:
             summary: 'Velero backup exceeded RPO'
             description: 'Backup for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.resource_name }}` }} ({{ `{{ $labels.resource_type }}` }}, method: {{ `{{ $labels.backup }}` }}) exceeded RPO (age: {{ `{{ $value }}` }})'
         - alert: VeleroBackupMissing
-          expr: backup_exporter_velero_latest_backup_age == 0
+          expr: backup_exporter_velero_latest_backup_age == 0 unless on (namespace, resource_name, resource_type) (backup_exporter_velero_error{type="backup_not_enabled"} == 1)
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.velero.severity | default "critical" }}

--- a/argocd-helm-charts/backup-exporter/test/prometheusRuleTest.yaml
+++ b/argocd-helm-charts/backup-exporter/test/prometheusRuleTest.yaml
@@ -90,3 +90,98 @@ tests:
             exp_annotations:
               summary: 'PostgreSQL WAL backup missing'
               description: 'No WAL backup found for test/pg1'
+
+  # "not enabled" error types must not fire PostgresBackupExporterJobFailed --
+  # they mean the app never turned this backup type on, not a job failure.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_postgres_error{backup="logical",namespace="disabled-ns",cluster_name="pg-disabled",type="backup_not_enabled"}'
+        values: '1x6'
+      - series: 'backup_exporter_postgres_error{backup="logical",namespace="disabled-ns2",cluster_name="pg-disabled2",type="cronjob_not_found"}'
+        values: '1x6'
+      - series: 'backup_exporter_postgres_error{backup="wal",namespace="disabled-ns3",cluster_name="pg-disabled3",type="no_scheduled_backups"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: PostgresBackupExporterJobFailed
+        eval_time: 6m
+        exp_alerts: []
+
+  # A genuine failure type must still fire PostgresBackupExporterJobFailed.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_postgres_error{backup="logical",namespace="test",cluster_name="pg1",type="s3_connection_failed"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: PostgresBackupExporterJobFailed
+        eval_time: 6m
+        exp_alerts:
+          - exp_labels:
+              alertname: PostgresBackupExporterJobFailed
+              severity: critical
+              backup: logical
+              namespace: test
+              cluster_name: pg1
+              type: s3_connection_failed
+            exp_annotations:
+              summary: 'Postgres backup exporter error'
+              description: 'Postgres backup exporter error for test/pg1 (backup: logical, error: s3_connection_failed)'
+
+  # A cluster with the zero-age "missing" sentinel AND a recorded
+  # backup_not_enabled/cronjob_not_found error must not fire
+  # PostgresLogicalBackupMissing -- the unless-join excludes it.
+  - interval: 1m
+    input_series:
+      - series: 'postgres_latest_logical_backup_age{namespace="disabled-ns",cluster_name="pg-disabled"}'
+        values: '0x6'
+      - series: 'backup_exporter_postgres_error{backup="logical",namespace="disabled-ns",cluster_name="pg-disabled",type="backup_not_enabled"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: PostgresLogicalBackupMissing
+        eval_time: 6m
+        exp_alerts: []
+
+  # Same, for WAL.
+  - interval: 1m
+    input_series:
+      - series: 'postgres_latest_cnpg_wal_backup_age{namespace="disabled-ns3",cluster_name="pg-disabled3"}'
+        values: '0x6'
+      - series: 'backup_exporter_postgres_error{backup="wal",namespace="disabled-ns3",cluster_name="pg-disabled3",type="no_scheduled_backups"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: PostgresWALBackupMissing
+        eval_time: 6m
+        exp_alerts: []
+
+  # A PVC outside every schedule's included namespaces (exporter-classified,
+  # backup_exporter_velero_error type=backup_not_enabled) must not fire
+  # VeleroBackupMissing, even though the age sentinel is 0.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="not-scheduled-ns",resource_name="some-pvc",resource_type="pvc"}'
+        values: '0x6'
+      - series: 'backup_exporter_velero_error{namespace="not-scheduled-ns",resource_name="some-pvc",resource_type="pvc",type="backup_not_enabled"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: VeleroBackupMissing
+        eval_time: 6m
+        exp_alerts: []
+
+  # A genuinely missing, in-scope PVC (no matching not-enabled error) must
+  # still fire VeleroBackupMissing.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="puppetserver-enableit",resource_name="code-claim",resource_type="pvc"}'
+        values: '0x6'
+    alert_rule_test:
+      - alertname: VeleroBackupMissing
+        eval_time: 6m
+        exp_alerts:
+          - exp_labels:
+              alertname: VeleroBackupMissing
+              severity: critical
+              namespace: puppetserver-enableit
+              resource_name: code-claim
+              resource_type: pvc
+            exp_annotations:
+              summary: 'Velero backup missing'
+              description: 'No backup found for puppetserver-enableit/code-claim (pvc, method: )'

--- a/argocd-helm-charts/backup-exporter/values.yaml
+++ b/argocd-helm-charts/backup-exporter/values.yaml
@@ -155,6 +155,7 @@ exporter:
     s3:
       # S3 endpoint URL (eg. https://s3.example.com).
       url: ""
+      prefix: ""
       # Name of the Kubernetes Secret containing S3 credentials.
       # Expected secret keys:
       #   access-key-id, secret-access-key, region, bucket


### PR DESCRIPTION
…kup type

Both Postgres and Velero already distinguish "this app never turned this backup type on" from a real failure via a type label on their respective per-resource error metrics -- but PostgresBackupExporterJobFailed fired on any error type, and the Missing alerts fire off a zero-age sentinel published for every resource regardless of enablement.

- Exclude the "not enabled" error types (backup_not_enabled, cronjob_not_found, no_scheduled_backups) from PostgresBackupExporterJobFailed.
- Suppress PostgresLogicalBackupMissing/PostgresWALBackupMissing for clusters already flagged not-enabled, via an unless-on join against the error series.
- Do the same for Velero: exclude backup_not_enabled/resource_policy_skip from VeleroBackupMissing via an unless-on join against backup_exporter_velero_error, once Obmondo/backup-exporter#feat/velero-scope-error-type ships (a harmless no-op against the currently deployed image, whose error metric has no per-resource labels yet).
- Set honorLabels: true on the ServiceMonitor. The exporter's own "namespace" label collided with the one Prometheus injects from the scrape target (the pod's own namespace, "monitoring"); honorLabels keeps the scraped value so every rule can match on plain "namespace".

No manual namespace/PVC allow-lists needed for any of this -- both backup types are fully automatic based on what the exporter itself already knows.

Verified with dockerized promtool (check rules + test rules) against the rendered PrometheusRule output, with default (empty) values.