### PR TITLE
chore(backup-exporter): track v1.2.0

### DIFF
--- a/argocd-helm-charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/backup-exporter/Chart.yaml
@@ -2,7 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: A Helm chart for the Obmondo Backup Exporter — reports PostgreSQL (CNPG logical and WAL), Velero, MongoDB and Sealed Secrets backup health by reading object storage directly, as Prometheus metrics and a JSON API.
 type: application
-version: 0.3.0
-# Sealed-secrets support is not in v1.1.0 -- bump this when the release
-# carrying it is cut.
-appVersion: "v1.1.0"
+version: 0.3.1
+appVersion: "v1.2.0"


### PR DESCRIPTION
v1.2.0 carries the sealed-secrets key backup monitoring, so the note pinning appVersion behind it no longer applies.