### PR TITLE
chore(vuls-dictionary): remove default CPU limits in vuls-dictionary helm chart

### DIFF
--- a/argocd-helm-charts/vuls-dictionary/values.yaml
+++ b/argocd-helm-charts/vuls-dictionary/values.yaml
@@ -66,7 +66,6 @@ vulsExporter:
       cpu: 20m
       memory: 32Mi
     limits:
-      cpu: 50m
       memory: 64Mi
 
 # vuls2 unified database.
@@ -94,7 +93,8 @@ vulsServer:
       cpu: 50m
       memory: 256Mi
     limits:
-      cpu: 100m
+      # we don't set CPU limits because usage spike often times stays unpredictable
+      # as observed in one of our customers
       memory: 512Mi
   resultsDir: /vuls/results
   databaseStorage:


### PR DESCRIPTION
Ref - Our vuls deployments experience unexpected CPU and Memory spikes therefore we plan to remove default CPU limits