### PR TITLE
fix(buzz): wait for postgres and repair pre-0.2.0 schema on startup

### DIFF
--- a/argocd-helm-charts/buzz/README.md
+++ b/argocd-helm-charts/buzz/README.md
@@ -98,6 +98,32 @@ tracks a newer chart version.
 
 The bucket must not be folded into `buzz.s3.endpoint`; the two are passed separately.
 
+### Conformance probe (A3 gate)
+
+Before serving git traffic the relay races `BUZZ_GIT_PROBE_WRITERS` (default **32**) concurrent
+compare-and-swap writers against one key, `BUZZ_GIT_PROBE_ROUNDS` (default 3) times, to prove the
+backend gives linearizable conditional writes. Git-on-object-storage stores refs as CAS'd pointer
+objects, so a backend without that silently loses concurrent pushes — hence the gate is fatal.
+
+Backends that support `If-Match` but throttle under contention — Ceph RGW among them — fail this with
+`503 ServiceUnavailable` partway through, which looks like a capability gap but is not. The tell is
+*where* it fails: an unsupported `If-Match` fails deterministically in an early phase, whereas
+throttling fails intermittently, after earlier phases and the first round have passed.
+
+Narrow the race rather than removing the gate:
+
+```yaml
+buzz:
+  relay:
+    extraEnv:
+      - name: BUZZ_GIT_PROBE_WRITERS
+        value: "8"
+```
+
+`BUZZ_GIT_CONFORMANCE_PROBE: "false"` skips the gate entirely. That is a last resort — the relay has
+no retry or backoff for `503`, so a backend that throttles the probe will also throttle real
+concurrent pushes, and skipping only moves the failure to runtime.
+
 ## Ingress
 
 `buzz.ingress.className` and `buzz.ingress.annotations` are deliberately empty. Helm merges annotation
@@ -153,6 +179,24 @@ crane manifest ghcr.io/block/buzz:<tag> >/dev/null && echo exists
 ```
 
 `0.2.0` is the newest published release image; it shares a digest with `latest`.
+
+## Init containers
+
+`buzz.extraInitContainers` ships two, both `postgres:16-alpine`:
+
+- **`wait-for-db`** — CNPG is usually still bootstrapping when the relay first rolls out, and the
+  relay exits rather than retries. It polls with `psql` rather than `pg_isready` so it proves auth
+  and the database, not just an open socket.
+- **`reconcile-legacy-schema`** — repairs installs that passed through relay 0.1.0. That image
+  created `audit_log` at runtime but shipped no migration runner, so sqlx recorded nothing; migration
+  1 then aborts on `relation "audit_log" already exists` and rolls the whole schema back. The result
+  is a relay that starts, serves WebSockets and fails every query on a missing relation. It is
+  guarded on `_sqlx_migrations` being absent, so it is a no-op on a fresh install and after the first
+  successful migrate, and can be dropped once no install predates 0.2.0.
+
+Both assume the chart defaults — host `buzz-pgsql-rw` from `global.postgresql.instanceName`, and the
+`DATABASE_URL` key from `secrets.existingSecret`. Change either and change these to match.
+`extraInitContainers` is a list, so overriding it downstream replaces rather than merges.
 
 ## Git storage
 

--- a/argocd-helm-charts/buzz/values.yaml
+++ b/argocd-helm-charts/buzz/values.yaml
@@ -89,6 +89,68 @@ buzz:
       enabled: false
       size: 10Gi
 
+  # Both run before the relay on every start and assume the chart defaults
+  # above: host buzz-pgsql-rw from global.postgresql.instanceName, and the
+  # DATABASE_URL key from secrets.existingSecret. Change either and change
+  # these to match. See README.md.
+  extraInitContainers:
+    # CNPG is often still bootstrapping when the relay first rolls out, and the
+    # relay exits rather than retries. psql rather than pg_isready: this has to
+    # prove auth and the database itself, not just an open socket.
+    - name: wait-for-db
+      image: postgres:16-alpine
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+      env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: buzz-secrets
+              key: DATABASE_URL
+      command:
+        - sh
+        - -c
+        - |
+          until psql "$DATABASE_URL" -c 'select 1' >/dev/null 2>&1; do
+            echo "Waiting for database..."
+            sleep 2
+          done
+          echo "Database is ready!"
+    # Repairs installs that passed through relay 0.1.0. That image created
+    # audit_log at runtime but shipped no migration runner, so sqlx recorded
+    # nothing; migration 1 then aborts on "relation audit_log already exists"
+    # and rolls back the entire schema, leaving a relay that starts, serves
+    # WebSockets and fails every query. Guarded on _sqlx_migrations being
+    # absent, so it is a no-op on a fresh install and after the first migrate.
+    # Removable once no install predates 0.2.0.
+    - name: reconcile-legacy-schema
+      image: postgres:16-alpine
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+      env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: buzz-secrets
+              key: DATABASE_URL
+      command:
+        - sh
+        - -c
+        - |
+          set -e
+          applied=$(psql "$DATABASE_URL" -At -c "select to_regclass('public._sqlx_migrations')")
+          orphan=$(psql "$DATABASE_URL" -At -c "select to_regclass('public.audit_log')")
+          if [ -z "$applied" ] && [ -n "$orphan" ]; then
+            echo "Pre-0.2.0 schema found: dropping orphan audit_log so migration 1 can run"
+            psql "$DATABASE_URL" -c 'drop table if exists audit_log cascade'
+          else
+            echo "Nothing to reconcile"
+          fi
+
   # Class and annotations are left to the cluster: Helm merges annotation maps,
   # so anything set here leaks into every install and cannot be removed
   # downstream. See README.md for the NGINX WebSocket timeouts.


### PR DESCRIPTION
The 0.1.0 relay created audit_log at runtime but shipped no migration runner, so sqlx recorded nothing. Migration 1 then aborts on "relation audit_log already exists" and rolls back the entire schema, leaving a relay that starts and serves WebSockets while every query fails on a missing relation.

Add two init containers: wait-for-db polls with psql rather than pg_isready so it proves auth and the database instead of just an open socket, and reconcile-legacy-schema drops the orphan table guarded on _sqlx_migrations being absent, making it a no-op on fresh installs and after the first successful migrate.

Also document the A3 conformance probe, where a backend that supports If-Match but throttles under contention fails with 503 partway through and reads as a capability gap when it is not.