### PR TITLE
fix(velero): match resourcePolicy skip labels to real PVC labels

### DIFF
--- a/argocd-helm-charts/velero/Chart.yaml
+++ b/argocd-helm-charts/velero/Chart.yaml
@@ -1,7 +1,7 @@
 # See new chart versions here: https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero
 apiVersion: v2
 name: velero
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - name: velero
     version: 12.1.0

--- a/argocd-helm-charts/velero/values.yaml
+++ b/argocd-helm-charts/velero/values.yaml
@@ -8,10 +8,20 @@ schedule:
   excludedResources:
     - workloadconfigurationscansummaries.spdx.softwarecomposition.kubescape.io
 skipVolumePolicies:
+  # rabbitmq: covers both the plain "app" label some deployments use and the
+  # app.kubernetes.io/name label the Bitnami/helm chart sets.
   - app: rabbitmq
+  - app.kubernetes.io/name: rabbitmq
+  # redis: redis_setup_type covers the enableit redis chart; the Bitnami
+  # chart (e.g. kube-prometheus-stack's Redis) never sets that label at all,
+  # only app.kubernetes.io/name.
   - redis_setup_type: cluster
   - redis_setup_type: standalone
+  - app.kubernetes.io/name: redis
+  # mongodb: replica-set and community operator deployments label
+  # differently ("...-replica-set-svc" vs "...-community-svc").
   - app: mongodb-replica-set-svc
+  - app: mongodb-community-svc
   - app.kubernetes.io/name: opensearch
   - app.kubernetes.io/managed-by: cloudnative-pg
 velero:


### PR DESCRIPTION
skipVolumePolicies (cnpg-skip-volumes ConfigMap) is meant to make Velero's own volume backup skip redis/rabbitmq/mongodb/opensearch/CNPG PVCs, but on kcm the rules never matched: PVC labels checked directly against the cluster showed no PVC anywhere with a plain "app: rabbitmq" or "redis_setup_type" label -- those workloads use
app.kubernetes.io/name: rabbitmq / redis instead (Bitnami-style chart labels). Same gap for the MongoDB community operator, which labels its PVCs "app: mongodb-community-svc" rather than the already-covered "...-replica-set-svc".

Because the labels never matched, Velero attempted (and Ceph/CSI data movement then failed or was slow for) volumes that were supposed to be skipped entirely, and backup-exporter reported them as genuinely missing rather than skipped -- indistinguishable from a real gap.

Adds the missing label variants alongside the existing ones (kept, since other workloads in this shared chart do use those exact labels) rather than replacing them.