### PR TITLE
chore(capi): bump CAPH to v1.1.8

### DIFF
--- a/argocd-helm-charts/capi-cluster/values.yaml
+++ b/argocd-helm-charts/capi-cluster/values.yaml
@@ -8,7 +8,7 @@ global:
     version: v2.9.2
     enableMachinePools: false
   caph:
-    version: v1.1.7
+    version: v1.1.8
   capz:
     version: v1.21.1
   kubeaid:

--- a/docs/hosting/cloud-providers.md
+++ b/docs/hosting/cloud-providers.md
@@ -152,7 +152,7 @@ All modes include:
 
 - [Cilium](https://cilium.io) CNI in [kube-proxyless mode](https://cilium.io/use-cases/kube-proxy/) with **VXLAN tunnel
   routing** (pod traffic is encapsulated over the node network - no routes programmed in HCloud)
-- [CAPH](https://github.com/syself/cluster-api-provider-hetzner) **v1.1.7** with default OS image **Ubuntu 26.04**
+- [CAPH](https://github.com/syself/cluster-api-provider-hetzner) **v1.1.8** with default OS image **Ubuntu 26.04**
 - GitOps with [ArgoCD](https://argoproj.github.io/cd/), [Sealed
   Secrets](https://github.com/bitnami-labs/sealed-secrets), [ClusterAPI](https://cluster-api.sigs.k8s.io)
 - Monitoring with [KubePrometheus](https://prometheus-operator.dev)


### PR DESCRIPTION
Bumps cluster-api-provider-hetzner v1.1.7 -> v1.1.8 ([upstream release](https://github.com/syself/cluster-api-provider-hetzner/releases/tag/v1.1.8), 2026-08-03).

Highlights: proxy protocol + configurable health checks for control plane load balancers, bare metal remediation options, fix for hanging server creation, dependency CVE bumps.

CRDs still serve `infrastructure.cluster.x-k8s.io/v1beta1`, so the hetzner subchart templates are unchanged. `helm template` renders clean.