### PR TITLE
fix: eos/eol alerts text

### DIFF
--- a/build/kube-prometheus/mixins/kube-version/mixin.libsonnet
+++ b/build/kube-prometheus/mixins/kube-version/mixin.libsonnet
@@ -10,7 +10,7 @@
         rules: [
           {
             alert: 'KubernetesVersionInfoEos',
-            expr: 'count by (certname, current_version, end_of_support_date) (kubernetes_version_info_eos <= 30 and kubernetes_version_info_eos > 0)',
+            expr: 'max by (certname, current_version, end_of_support_date) (kubernetes_version_info_eos <= 30 and kubernetes_version_info_eos > 0)',
             'for': '15m',
             labels: {
               severity: 'warning',
@@ -36,7 +36,7 @@
           },
           {
             alert: 'KubernetesVersionInfoEol',
-            expr: 'count by (certname, current_version, end_of_life_date) (kubernetes_version_info_eol <= 60 and kubernetes_version_info_eol > 0)',
+            expr: 'max by (certname, current_version, end_of_life_date) (kubernetes_version_info_eol <= 60 and kubernetes_version_info_eol > 0)',
             'for': '15m',
             labels: {
               severity: 'warning',

--- a/build/kube-prometheus/mixins/kube-version/prometheus.yaml
+++ b/build/kube-prometheus/mixins/kube-version/prometheus.yaml
@@ -5,7 +5,7 @@ groups:
     annotations:
       description: The Kubernetes version on the cluster **{{ .Labels.certname }}** (that is version **{{ .Labels.current_version }}**) is **{{ .Value }}** days away from its end of support date which is **{{ .Labels.end_of_support_date }}**. You really should upgrade to ensure you will still get security updates. Please visit https://kubernetes.io/releases/patch-releases/ for more version related information.
       summary: Kubernetes version is close to end of support.
-    expr: count by (certname, current_version, end_of_support_date) (kubernetes_version_info_eos <= 30 and kubernetes_version_info_eos > 0)
+    expr: max by (certname, current_version, end_of_support_date) (kubernetes_version_info_eos <= 30 and kubernetes_version_info_eos > 0)
     for: 15m
     labels:
       alert_id: KubernetesVersionInfoEos
@@ -23,7 +23,7 @@ groups:
     annotations:
       description: The Kubernetes version on the cluster **{{ .Labels.certname }}** (that is version **{{ .Labels.current_version }}**) is **{{ .Value }}** days away from its end of life date which is **{{ .Labels.end_of_life_date }}**. You really should upgrade soon. Please visit https://kubernetes.io/releases/patch-releases/ for more version related information.
       summary: Kubernetes version is close to end of life.
-    expr: max by (certname, current_version, end_of_life_date) ( kubernetes_version_info_eol) <= 60
+    expr: max by (certname, current_version, end_of_life_date) (kubernetes_version_info_eol <= 60 and kubernetes_version_info_eol > 0)
     for: 15m
     labels:
       alert_id: KubernetesVersionInfoEol


### PR DESCRIPTION
Fix Kubernetes version EOS/EOL alert day count

Updated the Kubernetes version warning alerts to use `max by(...)` instead of `count by(...)`, so `{{ .Value }}` renders the actual days remaining until `EOS/EOL`.

Previously the alert description always showed "1 days away" because the expression counted matching series instead of preserving the metric value.