### PR TITLE
feat(etcd-backup-recover): creating the Helm chart

### DIFF
--- a/argocd-helm-charts/etcd-backup-restore/Chart.yaml
+++ b/argocd-helm-charts/etcd-backup-restore/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Helm chart for etcd with backup-restore support.
+name: etcd-backup-restore
+version: 0.1.0

--- a/argocd-helm-charts/etcd-backup-restore/templates/_snapstore.tpl
+++ b/argocd-helm-charts/etcd-backup-restore/templates/_snapstore.tpl
@@ -1,0 +1,80 @@
+{{/* Provider credential env vars. */}}
+{{- define "etcd-backup-restore.snapstoreEnv" -}}
+- name: STORAGE_CONTAINER
+  value: {{ .Values.backup.storageContainer }}
+{{- if eq .Values.backup.storageProvider "S3" }}
+- name: "AWS_APPLICATION_CREDENTIALS"
+  value: "/var/etcd-backup"
+{{- if .Values.backup.s3.endpoint }}
+- name: "AWS_ENDPOINT_URL_S3"
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-etcd-backup
+      key: "endpoint"
+      optional: true
+{{- end }}
+{{- else if eq .Values.backup.storageProvider "ABS" }}
+- name: "AZURE_APPLICATION_CREDENTIALS"
+  value: "/var/etcd-backup"
+{{- else if eq .Values.backup.storageProvider "GCS" }}
+- name: "GOOGLE_APPLICATION_CREDENTIALS"
+{{- if .Values.backup.tokenAuth.enabled }}
+  value: "/var/.gcp/credentialsConfig"
+{{- else }}
+  value: "/var/.gcp/serviceaccount.json"
+{{- end }}
+{{- else if eq .Values.backup.storageProvider "Swift" }}
+- name: "OPENSTACK_APPLICATION_CREDENTIALS"
+  value: "/var/etcd-backup"
+{{- else if eq .Values.backup.storageProvider "OSS" }}
+- name: "ALICLOUD_APPLICATION_CREDENTIALS"
+  value: "/var/etcd-backup"
+{{- else if eq .Values.backup.storageProvider "OCS" }}
+- name: "OPENSHIFT_APPLICATION_CREDENTIALS"
+  value: "/var/etcd-backup"
+{{- else if eq .Values.backup.storageProvider "ECS" }}
+- name: "ECS_ENDPOINT"
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-etcd-backup
+      key: "endpoint"
+- name: "ECS_ACCESS_KEY_ID"
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-etcd-backup
+      key: "accessKeyID"
+- name: "ECS_SECRET_ACCESS_KEY"
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-etcd-backup
+      key: "secretAccessKey"
+{{- end }}
+{{- end -}}
+
+{{/* Mount point for the provider credential secret. */}}
+{{- define "etcd-backup-restore.snapstoreVolumeMount" -}}
+{{- if eq .Values.backup.storageProvider "GCS" }}
+- name: etcd-backup
+  mountPath: "/var/.gcp/"
+{{- else }}
+- name: etcd-backup
+  mountPath: "/var/etcd-backup/"
+{{- end }}
+{{- end -}}
+
+{{/* The provider credential secret itself. */}}
+{{- define "etcd-backup-restore.snapstoreVolume" -}}
+- name: etcd-backup
+  projected:
+    defaultMode: 0440
+    sources:
+    - secret:
+        name: {{ .Release.Name }}-etcd-backup
+        optional: false
+{{- if .Values.backup.tokenAuth.enabled }}
+    - serviceAccountToken:
+        path: token
+        expirationSeconds: {{ .Values.backup.tokenAuth.expirationSeconds }}
+        audience: {{ .Values.backup.tokenAuth.audience }}
+{{- end }}
+{{- end -}}

--- a/argocd-helm-charts/etcd-backup-restore/templates/deployment.yaml
+++ b/argocd-helm-charts/etcd-backup-restore/templates/deployment.yaml
@@ -1,0 +1,168 @@
+{{- $tls := .Values.etcd.tls }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd-backup-restore
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  # Not configurable. Two replicas writing one store-prefix would interleave
+  # full/delta sequences and confuse garbage collection.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: etcd-backup-restore
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app.kubernetes.io/name: etcd-backup-restore
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+{{- if .Values.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+{{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if $tls.enabled }}
+      initContainers:
+      # The node's etcd certs are root-owned and mode 0600, so something
+      # privileged has to read them once. Doing it here keeps the long-running
+      # backup-restore container non-root. The hostPath is mounted read-only.
+      - name: copy-etcd-certs
+        image: {{ .Values.images.certCopy.repository }}:{{ .Values.images.certCopy.tag }}
+        imagePullPolicy: {{ .Values.images.certCopy.pullPolicy }}
+        command:
+        - sh
+        - -c
+        - |
+          set -eu
+          cp /host-etcd-pki/{{ $tls.caFile }}   /etcd-certs/ca.crt
+          cp /host-etcd-pki/{{ $tls.certFile }} /etcd-certs/tls.crt
+          cp /host-etcd-pki/{{ $tls.keyFile }}  /etcd-certs/tls.key
+          chown 65532:65532 /etcd-certs/ca.crt /etcd-certs/tls.crt /etcd-certs/tls.key
+          chmod 0400        /etcd-certs/ca.crt /etcd-certs/tls.crt /etcd-certs/tls.key
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
+        volumeMounts:
+        - name: host-etcd-pki
+          mountPath: /host-etcd-pki
+          readOnly: true
+        - name: etcd-certs
+          mountPath: /etcd-certs
+{{- end }}
+      containers:
+      - name: backup-restore
+        image: {{ .Values.images.etcdBackupRestore.repository }}:{{ .Values.images.etcdBackupRestore.tag }}
+        imagePullPolicy: {{ .Values.images.etcdBackupRestore.pullPolicy }}
+        args:
+        # "snapshot", not "server": server also initializes an etcd whose data
+        # directory it owns, which is meaningless for an etcd managed by
+        # kubeadm. snapshot has no --data-dir and uses the client API only.
+        - snapshot
+        - --endpoints={{ join "," .Values.etcd.endpoints }}
+{{- if $tls.enabled }}
+        - --cacert=/var/etcd/ssl/client/ca.crt
+        - --cert=/var/etcd/ssl/client/tls.crt
+        - --key=/var/etcd/ssl/client/tls.key
+        - --insecure-transport=false
+        - --insecure-skip-tls-verify=false
+{{- else }}
+        - --insecure-transport=true
+        - --insecure-skip-tls-verify=true
+{{- end }}
+        - --storage-provider={{ .Values.backup.storageProvider }}
+        - --store-prefix={{ .Values.backup.storePrefix }}
+{{- if .Values.backup.endpointOverride }}
+        - --store-endpoint-override={{ .Values.backup.endpointOverride }}
+{{- end }}
+        - --schedule={{ .Values.backup.schedule }}
+        - --delta-snapshot-period={{ .Values.backup.deltaSnapshotPeriod }}
+        - --delta-snapshot-memory-limit={{ int $.Values.backup.deltaSnapshotMemoryLimit }}
+        - --garbage-collection-policy={{ .Values.backup.garbageCollectionPolicy }}
+{{- if eq .Values.backup.garbageCollectionPolicy "LimitBased" }}
+        - --max-backups={{ .Values.backup.maxBackups }}
+{{- end }}
+        - --garbage-collection-period={{ .Values.backup.garbageCollectionPeriod }}
+        - --compress-snapshots={{ .Values.backup.compression.enabled }}
+        - --compression-policy={{ .Values.backup.compression.policy }}
+        - --etcd-connection-timeout={{ .Values.backup.etcdConnectionTimeout }}
+        - --etcd-snapshot-timeout={{ .Values.backup.etcdSnapshotTimeout }}
+        # Always passed: etcdbrctl rejects an empty spec, and omitting the flag
+        # makes it default to "0 0 */3 * *". See values.yaml.
+        - {{ printf "--defragmentation-schedule=%s" .Values.backup.defragmentationSchedule | quote }}
+        - --etcd-defrag-timeout={{ .Values.backup.etcdDefragTimeout }}
+        - --snapstore-temp-directory=/var/etcd/tmp
+{{- if and .Values.etcdAuth.username .Values.etcdAuth.password }}
+        - --etcd-username={{ .Values.etcdAuth.username }}
+        - --etcd-password={{ .Values.etcdAuth.password }}
+{{- end }}
+        env:
+{{ include "etcd-backup-restore.snapstoreEnv" . | indent 8 }}
+        resources:
+{{ toYaml .Values.resources.backup | indent 10 }}
+        securityContext:
+          runAsUser: 65532
+          runAsGroup: 65532
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: temp
+          mountPath: /var/etcd/tmp
+        # readOnlyRootFilesystem is on, and the cloud SDKs and compression path
+        # both fall back to /tmp regardless of --snapstore-temp-directory.
+        - name: tmp
+          mountPath: /tmp
+{{- if $tls.enabled }}
+        - name: etcd-certs
+          mountPath: /var/etcd/ssl/client
+          readOnly: true
+{{- end }}
+{{ include "etcd-backup-restore.snapstoreVolumeMount" . | indent 8 }}
+      securityContext:
+        fsGroup: 65532
+      volumes:
+      - name: temp
+        emptyDir:
+          sizeLimit: {{ .Values.tempDirSizeLimit }}
+      - name: tmp
+        emptyDir:
+          sizeLimit: {{ .Values.tempDirSizeLimit }}
+{{- if $tls.enabled }}
+      - name: host-etcd-pki
+        hostPath:
+          path: {{ $tls.hostPath }}
+          type: Directory
+      - name: etcd-certs
+        emptyDir: {}
+{{- end }}
+{{ include "etcd-backup-restore.snapstoreVolume" . | indent 6 }}

--- a/argocd-helm-charts/etcd-backup-restore/values.yaml
+++ b/argocd-helm-charts/etcd-backup-restore/values.yaml
@@ -1,0 +1,174 @@
+images:
+  # Image used to copy the node's etcd client certs into an emptyDir readable
+  # by the non-root backup-restore container.
+  certCopy:
+    repository: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
+    tag: 3.20.3
+    pullPolicy: IfNotPresent
+  # etcd-backup-restore image to use
+  etcdBackupRestore:
+    repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
+    tag: v0.43.0
+    pullPolicy: IfNotPresent
+
+resources:
+  # Taking a full snapshot is CPU-bound: the SHA256 integrity check and the
+  # compression both run over the entire database. Starved of CPU it does not
+  # fail, it never finishes -- the pod sits pegged at its limit logging
+  # "checking the full snapshot integrity with the help of SHA256" while
+  # nothing reaches the snapstore. The upstream 100m default is sized for
+  # Gardener's small per-shoot etcd, not a real control-plane one.
+  backup:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+
+# etcd being backed up. With hostNetwork and the control-plane nodeSelector
+# below, this is the local kubeadm etcd member. etcd is raft-replicated, so any
+# one member serves a complete snapshot.
+etcd:
+  endpoints:
+    - https://127.0.0.1:2379
+  tls:
+    enabled: true
+    # Read off the node rather than copied into a Secret: kubeadm rotates these
+    # on renewal and a copy would go stale silently.
+    hostPath: /etc/kubernetes/pki/etcd
+    caFile: ca.crt
+    # server.crt is etcd's serving cert, not a client cert.
+    certFile: healthcheck-client.crt
+    keyFile: healthcheck-client.key
+
+# Needed so 127.0.0.1 is the node's etcd rather than the pod's loopback.
+hostNetwork: true
+
+nodeSelector:
+  node-role.kubernetes.io/control-plane: ""
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+affinity: {}
+priorityClassName: system-cluster-critical
+
+# Scratch space for staging a snapshot before upload. Must exceed the etcd
+# on-disk DB SIZE, not the live "IN USE" figure -- on an etcd that has never
+# been defragmented the two differ by a lot.
+# Check with: etcdctl endpoint status -w table
+tempDirSizeLimit: 4Gi
+
+backup:
+  # schedule is cron standard schedule to take full snapshots.
+  schedule: "0 */1 * * *"
+
+  storePrefix: etcd
+
+  # deltaSnapshotPeriod is Period after which delta snapshot will be persisted. If this value is set to be lesser than 1 second, delta snapshotting will be disabled.
+  deltaSnapshotPeriod: "60s"
+  # deltaSnapshotMemoryLimit is memory limit in bytes after which delta snapshots will be taken out of schedule.
+  deltaSnapshotMemoryLimit: 104857600 #100MB
+
+  # defragmentationSchedule is schedule on which the etcd data will defragmented. Value should follow standard cron format.
+  # Defragmentation runs against the live control-plane etcd and blocks writes
+  # on the member it is connected to, so it ships disabled. It cannot be
+  # disabled with "" -- etcdbrctl parses this unconditionally and exits with
+  # "failed to parse defragmentation schedule: empty spec string" -- so "off"
+  # is a valid cron that never fires: 31 February.
+  defragmentationSchedule: "0 0 31 2 *"
+
+  # garbageCollectionPolicy mentions the policy for garbage collecting old backups. Allowed values are Exponential(default), LimitBased.
+  garbageCollectionPolicy: Exponential
+  # maxBackups is the maximum number of backups to keep (may change in future). This is honoured only in the case when garbageCollectionPolicy is set to LimitBased.
+  maxBackups: 7
+  # garbageCollectionPeriod is the time period after which old snapshots are periodically garbage-collected
+  garbageCollectionPeriod: "1m"
+
+  etcdConnectionTimeout: "5m"
+  etcdSnapshotTimeout: "8m"
+  etcdDefragTimeout: "8m"
+
+  # storageContainer is name of the container or bucket name used for storage.
+  # Directory name in case of local storage provider.
+  storageContainer: "etcd-bucket"
+
+  # storageProvider indicate the type of backup storage provider.
+  # Supported values are ABS,GCS,S3,Swift,OSS,OCS,ECS,Local, empty means no backup.
+  storageProvider: ""
+
+  # endpoint that will be used to override the default endpoint of the storage provider
+  # endpointOverride: ""
+
+  # compression defines the specification to compress the snapshots(full as well as delta).
+  # it only supports 3 compression Policy: gzip(default), zlib, lzw.
+  compression:
+    enabled: true
+    policy: "gzip"
+
+  # Please uncomment the following section based on the storage provider.
+  # local:
+  #   path: "/etc/local-backupbuckets"
+  # s3:
+  #   region: region-where-bucket-exists
+  #   secretAccessKey: secret-access-key-with-object-storage-privileges
+  #   accessKeyID: access-key-id-with-route53-privileges
+  #   endpoint: endpoint-override-for-s3 # optional
+  #   s3ForcePathStyle: "true" # optional
+  #   sseCustomerKey: aes-256-sse-customer-key # optional
+  #   sseCustomerAlgorithm: aes-256-sse-customer-algorithm # optional
+  #   roleARN: arn:aws:iam::123456789012:role/role-name
+  # gcs:
+  #   serviceAccountJson: service-account-json-with-object-storage-privileges
+  #   credentialsConfig:
+  #     universe_domain: "googleapis.com"
+  #     type: "external_account"
+  #     audience: "//iam.googleapis.com/projects/<project_number>/locations/global/workloadIdentityPools/<pool_name>/providers/<provider_name>"
+  #     subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
+  #     token_url: "https://sts.googleapis.com/v1/token"
+  #     service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<service_account_email>:generateAccessToken" # optional
+  #   projectID: project
+  #   storageAPIEndpoint: endpoint-override-for-storage-api # optional
+  #   emulatorEnabled: boolean-flag-to-configure-etcdbr-to-use-gcs-emulator # optional
+  # abs:
+  #   storageAccount: storage-account-with-object-storage-privileges
+  #   storageKey: storage-key-with-object-storage-privileges
+  #   domain: non-default-domain-for-object-storage-service # optional
+  #   emulatorEnabled: boolean-float-to-enable-e2e-tests-to-use-azure-emulator # optional
+  # swift:
+  #   authURL: identity-server-url
+  #   domainName: domain-name
+  #   username: username-with-object-storage-privileges
+  #   password: password
+  #   tenantName: tenant-name
+  #   regionName: region-name
+  # oss:
+  #   endpoint: oss-endpoint-url
+  #   accessKeySecret: secret-access-key-with-object-storage-privileges
+  #   accessKeyID: access-key-id-with-object-storage-privileges
+  # ecs:
+  #   endpoint: ecs-endpoint-url
+  #   secretAccessKey: secret-access-key-with-object-storage-privileges
+  #   accessKeyID: access-key-id-with-object-storage-privileges
+  #   disableSsl: "false"         # optional
+  #   insecureSkipVerify: "false" # optional
+  # ocs:
+  #   accessKeyID: access-key-id-with-object-storage-privileges
+  #   secretAccessKey: secret-access-key-with-object-storage-privileges
+  #   endpoint: ocs-endpoint-url
+  #   region: region-name
+  tokenAuth:
+    enabled: false
+    audience: aud
+    expirationSeconds: 3600
+
+# etcdAuth field contains the pre-created username-password pair
+# for etcd. Comment this whole section if you dont want to use
+# password-based authentication for the etcd.
+etcdAuth: {}
+  # username: username
+  # password: password
+
+# podAnnotations that will be passed to the resulting etcd pod
+podAnnotations: {}


### PR DESCRIPTION
The `ETCD Backup Restore` project [provides a Chart](https://github.com/gardener/etcd-backup-restore/tree/master/chart/etcd-backup-restore), but doesn't publish it.

It's also bloated, seeing from our perspective : since we'll have `ETCD` deployed using `Kubeadm`. So, we just need `etcdbrctl` being managed via a `Deployment`.