### PR TITLE
feat(vuls-dictionary): periodic result cleanup via exporter sidecar

### DIFF
--- a/argocd-helm-charts/vuls-dictionary/Chart.yaml
+++ b/argocd-helm-charts/vuls-dictionary/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/argocd-helm-charts/vuls-dictionary/templates/configmap-vuls-exporter.yaml
+++ b/argocd-helm-charts/vuls-dictionary/templates/configmap-vuls-exporter.yaml
@@ -9,6 +9,12 @@ data:
   config.yaml: |
     results_dir: "/vuls/results"
     interval: {{ .Values.vulsExporter.interval | quote }}
+    {{- if .Values.vulsServer.resultRetention.enabled }}
+    cleanup:
+      enabled: true
+      max_age_days: {{ .Values.vulsServer.resultRetention.maxAgeDays }}
+      interval: {{ .Values.vulsServer.resultRetention.exporterInterval | quote }}
+    {{- end }}
     obmondo:
       url: {{ .Values.vulsExporter.obmondo.url | quote }}
       {{- if .Values.vulsExporter.tls.secretName }}

--- a/argocd-helm-charts/vuls-dictionary/templates/deployment-vuls-server.yaml
+++ b/argocd-helm-charts/vuls-dictionary/templates/deployment-vuls-server.yaml
@@ -191,7 +191,9 @@ spec:
           volumeMounts:
             - name: results
               mountPath: /vuls
-              readOnly: true
+              # Read-write only when the exporter is responsible for pruning old
+              # results; otherwise it just reads them.
+              readOnly: {{ not .Values.vulsServer.resultRetention.enabled }}
             {{- if .Values.vuls2.enabled }}
             - name: vuls-db
               mountPath: /vuls-db

--- a/argocd-helm-charts/vuls-dictionary/values.yaml
+++ b/argocd-helm-charts/vuls-dictionary/values.yaml
@@ -51,7 +51,7 @@ vulsExporter:
   enabled: false
   image:
     repository: ghcr.io/obmondo/vuls-exporter
-    tag: 1.3.3
+    tag: 1.4.0
     pullPolicy: IfNotPresent
   obmondo:
     url: ""
@@ -107,4 +107,8 @@ vulsServer:
     accessMode: ReadWriteOnce
   resultRetention:
     enabled: true
-    maxAgeDays: 60
+    maxAgeDays: 15
+    # How often the vuls-exporter sidecar re-runs the prune. The init container
+    # only cleans at pod start; the sidecar enforces this policy periodically so
+    # results do not accumulate between restarts.
+    exporterInterval: "6h"

--- a/argocd-helm-charts/vuls-dictionary/values.yaml
+++ b/argocd-helm-charts/vuls-dictionary/values.yaml
@@ -107,7 +107,7 @@ vulsServer:
     accessMode: ReadWriteOnce
   resultRetention:
     enabled: true
-    maxAgeDays: 15
+    maxAgeDays: 7
     # How often the vuls-exporter sidecar re-runs the prune. The init container
     # only cleans at pod start; the sidecar enforces this policy periodically so
     # results do not accumulate between restarts.

--- a/argocd-helm-charts/vuls-dictionary/values.yaml
+++ b/argocd-helm-charts/vuls-dictionary/values.yaml
@@ -51,7 +51,7 @@ vulsExporter:
   enabled: false
   image:
     repository: ghcr.io/obmondo/vuls-exporter
-    tag: 1.4.0
+    tag: 1.4.1
     pullPolicy: IfNotPresent
   obmondo:
     url: ""


### PR DESCRIPTION
## What

Prune old Vuls result directories on a recurring schedule instead of only at pod start.

## Why

The `cleanup-vuls-results` init container only runs once, at pod boot, so old result directories accumulated past the retention window between restarts and the results PVC grew unbounded. The vuls-exporter's own cleanup was also dead in-cluster (results mounted read-only).

## How

- Render a `cleanup:` block into the exporter config from the shared `resultRetention` policy (single source of truth with the init container).
- Mount the results volume read-write for the exporter when retention is enabled (read-only otherwise).
- Bump exporter image to `1.4.1` (periodic prune + prune-before-initial-push).
- Reduce retention to 7 days — the obmondo-api is the durable store; the PVC is only a staging buffer.

Paired with vuls-exporter PR (feat/periodic-cleanup). Verified live in the `vuls` namespace: cleanup runs first, removes >7d dirs, then pushes only recent results.
