### PR TITLE
feat(capi-cluster): add EKS (managed control plane) support to the aws chart

### DIFF
--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSMachinePool.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSMachinePool.yaml
@@ -1,4 +1,6 @@
-{{- if (.Values.global.capa).enableMachinePools }}
+{{/* Machine pools aren't supported with the EKS variant yet — workers there
+     are MachineDeployments (CAPA's stable EKS worker path). */}}
+{{- if and (not .Values.eks) (.Values.global.capa).enableMachinePools }}
 {{- range $index, $nodeGroup := $.Values.nodeGroups }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSMachineTemplate.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSMachineTemplate.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.eks }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
@@ -21,6 +22,7 @@ spec:
       ami: {{ toYaml .Values.controlPlane.ami | nindent 8 }}
       rootVolume:
         size: {{ .Values.controlPlane.rootVolumeSize | default 35 }}
+{{- end }}
 
 {{- if (.Values.global).enableClusterAutoscaler }}
 {{- range $index, $nodeGroup := $.Values.nodeGroups }}
@@ -32,7 +34,18 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $.Values.eks }}
+      {{- /* CAPA resolves the EKS optimized AL2023 AMI for the requested K8s
+           version itself. AL2023 lacks the CAPA custom cloud-init datasource,
+           so the secrets-manager bootstrap flow must be skipped (upstream
+           requirement). EKS workers stay keyless — use SSM Session Manager. */}}
+      ami:
+        eksLookupType: AmazonLinux2023
+      cloudInit:
+        insecureSkipSecretsManager: true
+      {{- else }}
       ami: {{ toYaml $nodeGroup.ami | nindent 8 }}
+      {{- end }}
       iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
       instanceMetadataOptions:
         httpEndpoint: enabled
@@ -40,8 +53,10 @@ spec:
         httpTokens: optional
         instanceMetadataTags: disabled
       instanceType: {{ $nodeGroup.instanceType }}
+      {{- if not $.Values.eks }}
       sshKeyName: {{ $nodeGroup.sshKeyName }}
       imageLookupBaseOS: ubuntu-20.04
+      {{- end }}
       rootVolume:
         size: {{ $nodeGroup.rootVolumeSize | default 35 }}
 {{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSManagedCluster.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSManagedCluster.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.eks }}
+{{/* The Cluster infrastructureRef stand-in for EKS : all the actual
+     infrastructure config lives on AWSManagedControlPlane. */}}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSManagedCluster
+metadata:
+  name: {{ .Values.global.clusterName }}
+  labels:
+    cluster.x-k8s.io/name: {{ .Values.global.clusterName }}
+spec: {}
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSManagedControlPlane.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSManagedControlPlane.yaml
@@ -1,13 +1,14 @@
-{{- if not .Values.eks }}
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-kind: AWSCluster
+{{- if .Values.eks }}
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AWSManagedControlPlane
 metadata:
-  name: {{ .Values.global.clusterName }}
+  name: {{ .Values.global.clusterName }}-control-plane
   labels:
     cluster.x-k8s.io/name: {{ .Values.global.clusterName }}
 spec:
+  eksClusterName: {{ .Values.global.clusterName }}
   region: {{ .Values.region }}
-  sshKeyName: {{ .Values.sshKeyName }}
+  version: {{ .Values.global.kubernetes.version }}
   bastion: {{ toYaml .Values.bastion | nindent 4 }}
   network:
     vpc:
@@ -40,7 +41,12 @@ spec:
           protocol: "icmp"
           fromPort: 8
           toPort: 8
-  controlPlaneLoadBalancer:
-    loadBalancerType: {{ .Values.controlPlane.loadBalancer.type }}
-    scheme: {{ .Values.controlPlane.loadBalancer.scheme | default "internet-facing" }}
+  {{/* Cilium is the CNI (installed by kubeaid-cli, then owned by the cilium
+       ArgoCD App) and runs with kube-proxy replacement — so the EKS default
+       VPC CNI (the aws-node DaemonSet) and kube-proxy addons are disabled
+       declaratively here. */}}
+  vpcCni:
+    disable: true
+  kubeProxy:
+    disable: true
 {{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSManagedControlPlane.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/AWSManagedControlPlane.yaml
@@ -12,14 +12,14 @@ spec:
   bastion: {{ toYaml .Values.bastion | nindent 4 }}
   network:
     vpc:
-      {{- if .Values.vpc.id }}
+      {{- if (.Values.vpc).id }}
       id: {{ .Values.vpc.id }}
       {{- else }}
-      cidrBlock: {{ .Values.vpc.cidrBlock | default "10.14.0.0/22" }}
+      cidrBlock: {{ (.Values.vpc).cidrBlock | default "10.14.0.0/22" }}
       availabilityZoneSelection: Ordered
       availabilityZoneUsageLimit: 3
       {{- end }}
-    {{- if .Values.vpc.id }}
+    {{- if (.Values.vpc).id }}
     {{/* The user must specify 3 subnets- each in a different Availability Zone (AZ). This
          validation is done by KubeAid Bootstrap Script. */}}
     subnets:

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/Cluster.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/Cluster.yaml
@@ -9,6 +9,16 @@ spec:
     pods:
       cidrBlocks:
       - {{ .Values.pods.cidrBlock | default "10.244.0.0/16" }}
+  {{- if .Values.eks }}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: AWSManagedControlPlane
+    name: {{ .Values.global.clusterName }}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: AWSManagedCluster
+    name: {{ .Values.global.clusterName }}
+  {{- else }}
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: KubeadmControlPlane
@@ -17,3 +27,4 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: AWSCluster
     name: {{ .Values.global.clusterName }}
+  {{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/KubeadmConfigTemplate.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/KubeadmConfigTemplate.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global).enableClusterAutoscaler }}
+{{- if and (not .Values.eks) (.Values.global).enableClusterAutoscaler }}
 {{- range $index, $nodeGroup := $.Values.nodeGroups }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/KubeadmControlPlane.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/KubeadmControlPlane.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.eks }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlane
 metadata:
@@ -76,3 +77,4 @@ spec:
       name: {{ .Values.global.clusterName }}-control-plane
   replicas: {{ .Values.controlPlane.replicas }}
   version: {{ .Values.global.kubernetes.version }}
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/MachineDeployment.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/MachineDeployment.yaml
@@ -77,7 +77,11 @@ spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          {{- if $.Values.eks }}
+          kind: NodeadmConfigTemplate
+          {{- else }}
           kind: KubeadmConfigTemplate
+          {{- end }}
           name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/MachineHealthCheck.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/MachineHealthCheck.yaml
@@ -1,3 +1,6 @@
+{{- /* Watches control-plane Machines — EKS clusters have none (AWS owns the
+     control plane), so this renders only for the kubeadm variant. */}}
+{{- if not .Values.eks }}
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineHealthCheck
 metadata:
@@ -16,3 +19,4 @@ spec:
     - type: Ready
       status: "False"
       timeout: 5m0s
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/MachinePool.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/MachinePool.yaml
@@ -1,4 +1,6 @@
-{{- if (.Values.global.capa).enableMachinePools }}
+{{/* Machine pools aren't supported with the EKS variant yet — workers there
+     are MachineDeployments (CAPA's stable EKS worker path). */}}
+{{- if and (not .Values.eks) (.Values.global.capa).enableMachinePools }}
 {{- range $index, $nodeGroup := $.Values.nodeGroups }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta2

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/NodeadmConfigTemplate.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/NodeadmConfigTemplate.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.eks (.Values.global).enableClusterAutoscaler }}
+{{/* EKS worker bootstrap : nodeadm on AL2023 (the EKSConfig / bootstrap.sh
+     flow only supports AL2, which is EOL). One template per node-group,
+     referenced by the MachineDeployments' bootstrap.configRef. Node taints
+     come from the EKS side of the join; labels propagate via the
+     MachineDeployment template metadata like on kubeadm clusters. */}}
+{{- range $index, $nodeGroup := $.Values.nodeGroups }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: NodeadmConfigTemplate
+metadata:
+  name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
+spec:
+  template:
+    {{- if $nodeGroup.taints }}
+    spec:
+      kubelet:
+        flags:
+          - "--register-with-taints={{- $taints := list }}{{- range $taint := $nodeGroup.taints }}{{- $taints = append $taints (printf "%s=%s:%s" $taint.key $taint.value $taint.effect) }}{{- end }}{{- join "," $taints }}"
+    {{- else }}
+    spec: {}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/aws/tests/eks_test.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/tests/eks_test.yaml
@@ -1,0 +1,101 @@
+suite: aws eks (managed control plane)
+templates:
+  - "*.yaml"
+release:
+  name: demo
+chart:
+  version: 1.0.0
+  appVersion: 1.0.0
+values:
+  - ../values.example.eks.yaml
+set:
+  global.clusterName: demo
+  global.kubernetes.version: v1.34.0
+  global.enableClusterAutoscaler: true
+  global.capa.enableMachinePools: false
+  global.additionalUsers: []
+  global.kubeaid.repo: https://github.com/Obmondo/KubeAid
+  global.kubeaid.version: ""
+tests:
+  - it: points the Cluster at the managed control plane
+    template: Cluster.yaml
+    asserts:
+      - equal:
+          path: spec.controlPlaneRef.kind
+          value: AWSManagedControlPlane
+      - equal:
+          path: spec.infrastructureRef.kind
+          value: AWSManagedCluster
+
+  - it: renders the AWSManagedControlPlane with VPC CNI and kube-proxy disabled
+    template: AWSManagedControlPlane.yaml
+    asserts:
+      - equal:
+          path: spec.eksClusterName
+          value: demo
+      - equal:
+          path: spec.version
+          value: v1.34.0
+      - equal:
+          path: spec.vpcCni.disable
+          value: true
+      - equal:
+          path: spec.kubeProxy.disable
+          value: true
+
+  - it: renders the AWSManagedCluster stand-in
+    template: AWSManagedCluster.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: bootstraps workers via NodeadmConfigTemplate
+    template: MachineDeployment.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.bootstrap.configRef.kind
+          value: NodeadmConfigTemplate
+
+  - it: renders one NodeadmConfigTemplate per node-group
+    template: NodeadmConfigTemplate.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: worker machine templates use the EKS AMI lookup, keyless
+    template: AWSMachineTemplate.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.ami.eksLookupType
+          value: AmazonLinux2023
+      - equal:
+          path: spec.template.spec.cloudInit.insecureSkipSecretsManager
+          value: true
+      - notExists:
+          path: spec.template.spec.sshKeyName
+
+  - it: renders no kubeadm control-plane resources
+    template: KubeadmControlPlane.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no AWSCluster
+    template: AWSCluster.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no KubeadmConfigTemplate
+    template: KubeadmConfigTemplate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no control-plane MachineHealthCheck
+    template: MachineHealthCheck.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/argocd-helm-charts/capi-cluster/charts/aws/values.example.eks.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/values.example.eks.yaml
@@ -1,0 +1,22 @@
+# Example values for an EKS (AWS managed control plane) cluster.
+# Workers are self-managed MachineDeployments bootstrapped via
+# NodeadmConfigTemplate on EKS optimized AL2023 AMIs (K8s >= v1.33).
+eks: true
+secretName: cloud-credentials
+region: eu-west-1
+bastion:
+  enabled: true
+vpc:
+  cidrBlock: 10.14.0.0/22
+pods:
+  cidrBlock: 10.244.0.0/16
+nodeGroups:
+  - name: primary
+    minSize: 3
+    maxSize: 9
+    cpu: 2
+    memory: 8
+    instanceType: m5.large
+    rootVolumeSize: 50
+    labels: {}
+    taints: []

--- a/argocd-helm-charts/capi-cluster/charts/aws/values.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/values.yaml
@@ -1,5 +1,15 @@
 secretName: cloud-credentials
 
+# eks: true provisions an AWS managed (EKS) control plane instead of the
+# self-managed kubeadm one : AWSManagedControlPlane + AWSManagedCluster replace
+# AWSCluster + KubeadmControlPlane, and the (still self-managed)
+# MachineDeployment workers bootstrap via NodeadmConfigTemplate on EKS
+# optimized AL2023 AMIs that CAPA looks up itself. Requires Kubernetes >=
+# v1.33, and a CAPA release that ships NodeadmConfig (global.capa.version >=
+# v2.11). The AWS default VPC CNI and kube-proxy are disabled — Cilium (with
+# kube-proxy replacement) is the CNI, installed by kubeaid-cli.
+eks: false
+
 bastion:
   enabled: True
 pods:

--- a/argocd-helm-charts/capi-cluster/templates/provider-aws.yaml
+++ b/argocd-helm-charts/capi-cluster/templates/provider-aws.yaml
@@ -18,6 +18,9 @@ spec:
   version: {{ .Values.global.capa.version }}
   fetchConfig:
     url: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/{{ .Values.global.capa.version }}/infrastructure-components.yaml
+  {{- /* EKS clusters have no control-plane nodes — pinning CAPA to them
+       would leave the controller unschedulable after the pivot. */}}
+  {{- if not (.Values.aws).eks }}
   deployment:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""
@@ -25,6 +28,7 @@ spec:
       - key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
         effect: "NoSchedule"
+  {{- end }}
   manager:
     cacheNamespace: {{ $namespace }}
     metrics:
@@ -32,4 +36,9 @@ spec:
     syncPeriod: 10m0s
     featureGates:
       MachinePool: {{ .Values.global.capa.enableMachinePools }}
+      {{- /* EKS support is enabled by default in CAPA v2 (the EKS bootstrap /
+           control-plane providers are merged into the main provider); stated
+           explicitly so the managed-control-plane path never silently breaks
+           if a future CAPA release flips the default. */}}
+      EKS: true
 {{- end }}

--- a/argocd-helm-charts/capi-cluster/values.yaml
+++ b/argocd-helm-charts/capi-cluster/values.yaml
@@ -5,7 +5,10 @@ global:
     version: v1.11.3
   enableClusterAutoscaler: true
   capa:
-    version: v2.9.2
+    # v2.11+ is required for EKS clusters : NodeadmConfig (the AL2023 worker
+    # bootstrap) isn't shipped in earlier releases. v2.11.1 also matches the
+    # clusterawsadm library embedded in kubeaid-cli.
+    version: v2.11.1
     enableMachinePools: false
   caph:
     version: v1.1.7


### PR DESCRIPTION
## Summary

`aws.eks: true` renders an AWS managed (EKS) control plane instead of the self-managed kubeadm one:

- `AWSManagedControlPlane` + `AWSManagedCluster` replace `AWSCluster` + `KubeadmControlPlane` (the `Cluster` refs switch accordingly)
- Workers stay self-managed MachineDeployments — CAPA's stable EKS worker path (managed machine pools are experimental upstream) — bootstrapped via `NodeadmConfigTemplate` on EKS optimized AL2023 AMIs that CAPA resolves itself (`ami.eksLookupType: AmazonLinux2023`, `insecureSkipSecretsManager: true` per upstream, keyless / SSM)
- The EKS default VPC CNI (`aws-node`) and kube-proxy are disabled declaratively (`spec.vpcCni.disable` / `spec.kubeProxy.disable`) — Cilium with kube-proxy replacement is the CNI, installed by kubeaid-cli
- `EKS: true` feature gate set explicitly on the CAPA `InfrastructureProvider`; the control-plane nodeSelector on the CAPA deployment is dropped for EKS (no control-plane nodes exist to schedule on)
- Control-plane-scoped resources (`KubeadmConfigTemplate`, `MachineHealthCheck`) and machine pools are gated off for EKS
- CAPA bumped v2.9.2 → **v2.11.1**: NodeadmConfig isn't shipped in v2.9.2, and v2.11.1 matches the clusterawsadm library embedded in kubeaid-cli

Requires Kubernetes >= v1.33. Ships `values.example.eks.yaml`.

Companion change (CLI side): Obmondo/kubeaid-cli `feat(aws): add EKS (managed control plane) cluster support` — already on main (v0.31.7).

## Test plan

- [x] helm-unittest suite at `charts/aws/tests/eks_test.yaml` — 10 tests, passing
- [x] `helm template` verified for both variants: EKS renders exactly the managed set (no kubeadm resources); the self-managed render is unchanged
- [ ] Real EKS bootstrap via kubeaid-cli against a test AWS account