### PR TITLE
feat(capi-cluster): AKS (managed control plane) support in the azure chart

### DIFF
--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureCluster.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureCluster.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.aks }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureCluster
 metadata:
@@ -44,3 +45,4 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
     name: {{ .Values.global.clusterName }}-cluster-identity
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureClusterIdentity.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureClusterIdentity.yaml
@@ -7,15 +7,28 @@ metadata:
     clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: {{ .Values.global.clusterName }}-cluster-identity
 spec:
-  {{/* Azure AD Workload identity is similar to IRSA in AWS. You can read more about it here :
-       https://azure.github.io/azure-workload-identity/docs/introduction.html. */}}
-  type: WorkloadIdentity
-
   {{/* A tenant is a Microsoft Entra ID entity that typically encompasses an organization.
        Tenants can have one or more subscriptions, which are agreements with Microsoft to use cloud
        services, including Azure. Every Azure resource is associated with a subscription.
        REFERENCE : https://learn.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id. */}}
   tenantID: {{ .Values.tenantID }}
+
+  {{- if .Values.aks }}
+  {{/* AKS clusters authenticate CAPZ with the AAD service principal (app
+       registration) directly — the client secret comes from the
+       cloud-credentials Secret kubeaid-cli seals into this namespace. The
+       whole workload-identity machinery (storage-account OIDC provider,
+       UAMIs) that the self-managed branch below depends on is skipped for
+       AKS; AKS's own OIDC issuer will back workload identity later. */}}
+  type: ServicePrincipal
+  clientID: {{ .Values.clientID }}
+  clientSecret:
+    name: {{ .Values.secretName }}
+    namespace: {{ .Release.Namespace }}
+  {{- else }}
+  {{/* Azure AD Workload identity is similar to IRSA in AWS. You can read more about it here :
+       https://azure.github.io/azure-workload-identity/docs/introduction.html. */}}
+  type: WorkloadIdentity
 
   {{/* While developers can securely store the secrets in Azure Key Vault, services need a way to
        access Azure Key Vault. Managed identities provide an automatically managed identity in
@@ -23,15 +36,16 @@ spec:
        Microsoft Entra authentication. Applications can use managed identities to obtain Microsoft
        Entra tokens without having to manage any credentials.
        There are two types of managed identities :
-       
+
        (1) System Assigned
-       
+
        (2) User Assigned - You can create a user-assigned managed identity and assign it to one or
                            more Azure Resources.
-                           
+
         REFERENCE : https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview#managed-identity-types. */}}
   clientID: {{ .Values.userAssignedIdentity.clientID }}
+  {{- end }}
 
-  allowedNamespaces: 
+  allowedNamespaces:
     list:
       - {{ .Release.Namespace }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureMachineTemplate.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureMachineTemplate.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.aks }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate
 metadata:
@@ -46,4 +47,5 @@ spec:
         diskSizeGB: {{ $nodeGroup.diskSizeGB }}
         osType: Linux
       sshPublicKey: {{ $.Values.sshPublicKey | b64enc }}
+{{- end }}
 {{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureManagedCluster.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureManagedCluster.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.aks }}
+{{/* The Cluster infrastructureRef stand-in for AKS : all the actual
+     infrastructure config lives on AzureManagedControlPlane. */}}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedCluster
+metadata:
+  name: {{ .Values.global.clusterName }}
+spec: {}
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureManagedControlPlane.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureManagedControlPlane.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.aks }}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedControlPlane
+metadata:
+  name: {{ .Values.global.clusterName }}-control-plane
+spec:
+  version: {{ .Values.global.kubernetes.version }}
+  location: {{ .Values.location }}
+  resourceGroupName: {{ .Values.resourceGroup }}
+  subscriptionID: {{ .Values.subscriptionID }}
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: {{ .Values.global.clusterName }}-cluster-identity
+  {{/* AKS nodes stay keyless — use `az aks command invoke` for node access.
+       An empty string disables SSH key provisioning; leaving the field unset
+       would make CAPZ auto-generate a key instead. */}}
+  sshPublicKey: ""
+  {{/* Cilium is the CNI (installed by kubeaid-cli, then owned by the cilium
+       ArgoCD App) and runs with kube-proxy replacement — so AKS's own CNI is
+       disabled via BYO CNI ("none"), and kube-proxy via the ASO patch below.
+       The classic CAPZ API carries no first-class kube-proxy field, so the
+       patch reaches through to the underlying ASO ManagedCluster.
+       NOTE : AKS's kube-proxy configuration rides the
+       KubeProxyConfigurationPreview feature — register it on the
+       subscription first :
+         az feature register --namespace Microsoft.ContainerService \
+           --name KubeProxyConfigurationPreview
+       enablePreviewFeatures makes CAPZ drive the preview ASO API version the
+       patch needs. */}}
+  networkPlugin: none
+  asoManagedClusterPatches:
+    - '{"spec": {"networkProfile": {"kubeProxyConfig": {"enabled": false}}}}'
+  enablePreviewFeatures: true
+  {{/* AKS's own OIDC issuer — the foundation for workload identity on AKS
+       (replacing the storage-account OIDC provider self-managed clusters
+       host). Enabled from day one so enabling workload identity later needs
+       no control-plane update. */}}
+  oidcIssuerProfile:
+    enabled: true
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureManagedMachinePool.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureManagedMachinePool.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.aks }}
+{{- range $index, $nodeGroup := $.Values.nodeGroups }}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedMachinePool
+metadata:
+  name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
+spec:
+  {{/* Every AKS cluster needs at least one System mode pool (it hosts the
+       critical kube-system workloads) — the first node-group takes that
+       role; the rest are User pools. kubeaid-cli validation guarantees at
+       least one node-group exists. */}}
+  mode: {{ eq $index 0 | ternary "System" "User" }}
+  name: {{ $nodeGroup.name }}
+  sku: {{ $nodeGroup.vmSize }}
+  osDiskSizeGB: {{ $nodeGroup.diskSizeGB }}
+  {{/* AKS's built-in cluster autoscaler scales the pool within these
+       bounds — no in-cluster cluster-autoscaler deployment involved. */}}
+  scaling:
+    minSize: {{ $nodeGroup.minSize }}
+    maxSize: {{ $nodeGroup.maxSize }}
+  {{- if $nodeGroup.labels }}
+  nodeLabels: {{- toYaml $nodeGroup.labels | nindent 4 }}
+  {{- end }}
+  {{- if $nodeGroup.taints }}
+  taints:
+    {{- range $taint := $nodeGroup.taints }}
+    - key: {{ $taint.key }}
+      value: {{ $taint.value }}
+      effect: {{ $taint.effect }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/MachineDeployment.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/MachineDeployment.yaml
@@ -1,3 +1,6 @@
+{{/* AKS workers are AzureManagedMachinePools (see MachinePool.yaml) — the
+     MachineDeployment path is kubeadm-only. */}}
+{{- if not $.Values.aks }}
 {{- range $nodeGroupIndex, $nodeGroup := $.Values.nodeGroups }}
 {{/* Since subnets in Azure are region wide, we don't need to worry about failure domains. */}}
 ---
@@ -42,4 +45,5 @@ spec:
         kind: AzureMachineTemplate
         name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
       version: {{ $.Values.global.kubernetes.version }}
+{{- end }}
 {{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/MachinePool.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/MachinePool.yaml
@@ -1,0 +1,33 @@
+{{/* AKS workers are agent pools : one CAPI MachinePool per node-group, backed
+     by an AzureManagedMachinePool. CAPZ managed clusters support no other
+     worker shape (MachineDeployments cannot attach to an AKS control
+     plane). */}}
+{{- if .Values.aks }}
+{{- range $index, $nodeGroup := $.Values.nodeGroups }}
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachinePool
+metadata:
+  name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
+  annotations:
+    {{/* Scaling is owned by AKS's built-in cluster autoscaler (the scaling
+         block on AzureManagedMachinePool) — CAPZ requires this annotation so
+         CAPI leaves spec.replicas alone. */}}
+    cluster.x-k8s.io/replicas-managed-by: external-autoscaler
+spec:
+  clusterName: {{ $.Values.global.clusterName }}
+  replicas: {{ $nodeGroup.minSize }}
+  template:
+    spec:
+      clusterName: {{ $.Values.global.clusterName }}
+      {{/* AKS bootstraps its own nodes — an empty dataSecretName tells CAPI
+           no bootstrap provider is involved. */}}
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureManagedMachinePool
+        name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
+      version: {{ $.Values.global.kubernetes.version }}
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/cluster.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/cluster.yaml
@@ -7,6 +7,19 @@ spec:
     pods:
       cidrBlocks:
         - {{ (.Values.global.pods).cidrBlock | default "192.168.0.0/16" }}
+  {{- if .Values.aks }}
+  {{/* CAPZ keeps its managed control plane in the infrastructure API group,
+       unlike CAPA v2 (whose AWSManagedControlPlane lives under
+       controlplane.cluster.x-k8s.io). */}}
+  controlPlaneRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureManagedControlPlane
+    name: {{ .Values.global.clusterName }}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureManagedCluster
+    name: {{ .Values.global.clusterName }}
+  {{- else }}
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: KubeadmControlPlane
@@ -15,3 +28,4 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureCluster
     name: {{ .Values.global.clusterName }}
+  {{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/kubeadmConfigTemplate.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/kubeadmConfigTemplate.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global).enableClusterAutoscaler }}
+{{- if and (not .Values.aks) (.Values.global).enableClusterAutoscaler }}
 {{- range $index, $nodeGroup := $.Values.nodeGroups }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/kubeadmControlPlane.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/kubeadmControlPlane.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.aks }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlane
 metadata:
@@ -255,3 +256,4 @@ spec:
       name: {{ .Values.global.clusterName }}-control-plane
   replicas: {{ .Values.controlPlane.replicas }}
   version: {{ .Values.global.kubernetes.version }}
+{{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/tests/aks_test.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/tests/aks_test.yaml
@@ -1,0 +1,145 @@
+suite: azure aks (managed control plane)
+templates:
+  - "*.yaml"
+release:
+  name: demo
+  namespace: capi-cluster
+chart:
+  version: 1.0.0
+  appVersion: 1.0.0
+values:
+  - ../values.example.aks.yaml
+set:
+  global.clusterName: demo
+  global.kubernetes.version: v1.34.0
+  global.enableClusterAutoscaler: true
+  global.additionalUsers: []
+  global.kubeaid.repo: https://github.com/Obmondo/KubeAid
+  global.kubeaid.version: ""
+tests:
+  - it: points the Cluster at the managed control plane
+    template: cluster.yaml
+    asserts:
+      - equal:
+          path: spec.controlPlaneRef.kind
+          value: AzureManagedControlPlane
+      - equal:
+          path: spec.infrastructureRef.kind
+          value: AzureManagedCluster
+
+  - it: renders the AzureManagedControlPlane keyless, BYO CNI, kube-proxy disabled
+    template: AzureManagedControlPlane.yaml
+    asserts:
+      - equal:
+          path: spec.version
+          value: v1.34.0
+      - equal:
+          path: spec.resourceGroupName
+          value: demo
+      - equal:
+          path: spec.networkPlugin
+          value: none
+      - equal:
+          path: spec.sshPublicKey
+          value: ""
+      - equal:
+          path: spec.oidcIssuerProfile.enabled
+          value: true
+      - equal:
+          path: spec.enablePreviewFeatures
+          value: true
+      - matchRegex:
+          path: spec.asoManagedClusterPatches[0]
+          pattern: kubeProxyConfig.*false
+
+  - it: renders the AzureManagedCluster stand-in
+    template: AzureManagedCluster.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: authenticates CAPZ with the service principal
+    template: AzureClusterIdentity.yaml
+    asserts:
+      - equal:
+          path: spec.type
+          value: ServicePrincipal
+      - equal:
+          path: spec.clientID
+          value: 33333333-3333-3333-3333-333333333333
+      - equal:
+          path: spec.clientSecret.name
+          value: cloud-credentials
+      - equal:
+          path: spec.clientSecret.namespace
+          value: capi-cluster
+
+  - it: renders one MachinePool per node-group, externally autoscaled, no bootstrap provider
+    template: MachinePool.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.template.spec.bootstrap.dataSecretName
+          value: ""
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.infrastructureRef.kind
+          value: AzureManagedMachinePool
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["cluster.x-k8s.io/replicas-managed-by"]
+          value: external-autoscaler
+        documentIndex: 0
+
+  - it: first agent pool is System mode, the rest User
+    template: AzureManagedMachinePool.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.mode
+          value: System
+        documentIndex: 0
+      - equal:
+          path: spec.mode
+          value: User
+        documentIndex: 1
+      - equal:
+          path: spec.sku
+          value: Standard_D2s_v3
+        documentIndex: 0
+      - equal:
+          path: spec.scaling.minSize
+          value: 3
+        documentIndex: 0
+      - equal:
+          path: spec.scaling.maxSize
+          value: 9
+        documentIndex: 0
+
+  - it: renders no kubeadm control-plane resources
+    template: kubeadmControlPlane.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no AzureCluster
+    template: AzureCluster.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no KubeadmConfigTemplate
+    template: kubeadmConfigTemplate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no MachineDeployments or AzureMachineTemplates
+    templates:
+      - MachineDeployment.yaml
+      - AzureMachineTemplate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/argocd-helm-charts/capi-cluster/charts/azure/values.example.aks.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/values.example.aks.yaml
@@ -1,0 +1,29 @@
+# Example values for an AKS (Azure managed control plane) cluster.
+# Workers are AKS agent pools (AzureManagedMachinePool), scaled by AKS's
+# built-in cluster autoscaler; the first node-group is the System pool.
+aks: true
+secretName: cloud-credentials
+tenantID: 11111111-1111-1111-1111-111111111111
+subscriptionID: 22222222-2222-2222-2222-222222222222
+clientID: 33333333-3333-3333-3333-333333333333
+location: westeurope
+resourceGroup: demo
+nodeGroups:
+  - name: system0
+    minSize: 3
+    maxSize: 9
+    cpu: 2
+    memory: 8
+    vmSize: Standard_D2s_v3
+    diskSizeGB: 128
+    labels: {}
+    taints: []
+  - name: worker0
+    minSize: 1
+    maxSize: 6
+    cpu: 4
+    memory: 16
+    vmSize: Standard_D4s_v3
+    diskSizeGB: 256
+    labels: {}
+    taints: []

--- a/argocd-helm-charts/capi-cluster/charts/azure/values.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/values.yaml
@@ -1,3 +1,14 @@
+# -- Azure managed (AKS) control plane. When true, the chart renders
+# AzureManagedControlPlane + AzureManagedCluster + one AzureManagedMachinePool
+# per node-group instead of AzureCluster + KubeadmControlPlane +
+# MachineDeployments, and the AzureClusterIdentity switches to a
+# ServicePrincipal reading its client secret from `secretName`.
+aks: false
+
+# -- Secret (in the release namespace) holding the AAD service principal's
+# clientSecret key. Sealed by kubeaid-cli. AKS only.
+secretName: cloud-credentials
+
 location: northcentralus
 
 virtualNetwork:

--- a/argocd-helm-charts/capi-cluster/templates/provider-azure.yaml
+++ b/argocd-helm-charts/capi-cluster/templates/provider-azure.yaml
@@ -15,6 +15,9 @@ spec:
   version: {{ .Values.global.capz.version }}
   fetchConfig:
     url: https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/{{ .Values.global.capz.version }}/infrastructure-components.yaml
+  {{- /* AKS clusters have no control-plane nodes — pinning CAPZ to them
+       would leave the controller unschedulable after the pivot. */}}
+  {{- if not (.Values.azure).aks }}
   deployment:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""
@@ -22,6 +25,7 @@ spec:
       - key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
         effect: "NoSchedule"
+  {{- end }}
   manager:
     cacheNamespace: {{ $namespace }}
     # BUG : CAPZ infrastructure provider errors out, complaining :
@@ -29,4 +33,10 @@ spec:
     # metrics:
     #   bindAddress: ":8443"
     syncPeriod: 10m0s
+    featureGates:
+      {{- /* AKS agent pools are AzureManagedMachinePools, which build on the
+           CAPI MachinePool experiment. Enabled by default in CAPZ; stated
+           explicitly so the managed-control-plane path never silently breaks
+           if a future release flips the default. */}}
+      MachinePool: true
 {{- end }}

--- a/argocd-helm-charts/capi-cluster/values.yaml
+++ b/argocd-helm-charts/capi-cluster/values.yaml
@@ -13,7 +13,11 @@ global:
   caph:
     version: v1.1.8
   capz:
-    version: v1.21.1
+    # v1.26.0 (latest, Jun 2026) for AKS clusters : the classic managed API
+    # (AzureManagedControlPlane), networkPlugin "none" (BYO CNI) and
+    # asoManagedClusterPatches (the kube-proxy disable) are all verified
+    # present at this release.
+    version: v1.26.0
   kubeaid:
     repo: https://github.com/Obmondo/KubeAid.git
     # KubeAid git ref the postKubeadmCommands `git clone` checks out


### PR DESCRIPTION
Chart-side pair of kubeaid-cli's AKS support (Obmondo/kubeaid-cli#60), mirroring how EKS shipped (#170). Behind a new `azure.aks` values flag:

- **`AzureManagedControlPlane`** — keyless (`sshPublicKey: ""`), BYO CNI (`networkPlugin: none`) for the KubeAid Cilium chart, kube-proxy disabled via `asoManagedClusterPatches` (`networkProfile.kubeProxyConfig.enabled: false`) + `enablePreviewFeatures` (the classic CAPZ API has no first-class kube-proxy field), `oidcIssuerProfile.enabled: true` for future workload identity — plus the `AzureManagedCluster` stand-in. The `Cluster`'s refs switch to them when `aks` is set.
- **One `MachinePool` + `AzureManagedMachinePool` per node-group** — first pool `System` mode, rest `User`; scaled by AKS's built-in autoscaler (`scaling` block + `replicas-managed-by: external-autoscaler` annotation); `bootstrap.dataSecretName: ""` since AKS bootstraps its own nodes.
- **`AzureClusterIdentity`** gains a ServicePrincipal branch reading the client secret from the `cloud-credentials` Secret kubeaid-cli seals; the WorkloadIdentity/UAMI shape stays kubeadm-only.
- Kubeadm-path resources (`AzureCluster`, `KubeadmControlPlane`, `KubeadmConfigTemplate`, `AzureMachineTemplate`, `MachineDeployment`) render only when `aks` is unset. CAPZ deployment drops the control-plane nodeSelector for AKS (no CP nodes exist post-pivot) and states the `MachinePool` feature gate explicitly.
- **CAPZ bumped v1.21.1 → v1.26.0** (classic managed API, `networkPlugin: none`, and `asoManagedClusterPatches` verified present).

## Operational prerequisite

AKS's kube-proxy configuration rides the `KubeProxyConfigurationPreview` feature — register it on the subscription before bootstrapping:
`az feature register --namespace Microsoft.ContainerService --name KubeProxyConfigurationPreview`

## Verification

- helm-unittest: new `charts/azure/tests/aks_test.yaml` (10 tests) + existing aws EKS suite — 20/20 passing.
- Self-managed azure path smoke-rendered: identical resource set as before (AzureCluster, KubeadmControlPlane, AzureMachineTemplate, WorkloadIdentity identity), no managed kinds.
- Real-Azure e2e is an open item, same as EKS.