### PR TITLE
docs: document the EKS / AKS managed control planes, fix the Azure key guidance

### DIFF
--- a/argocd-helm-charts/capi-cluster/README.md
+++ b/argocd-helm-charts/capi-cluster/README.md
@@ -8,6 +8,28 @@ Install the [cluster-api chart](../cluster-api/)
 
 [hetzner robot control plane](./examples/hetzner-robot-control-plane.yaml)
 
+## Managed control planes
+
+The AWS and Azure subcharts can provision cloud-managed control planes instead
+of self-managed kubeadm ones:
+
+* `aws.eks: true` — EKS via CAPA's `AWSManagedControlPlane`; workers stay
+  self-managed MachineDeployments (NodeadmConfig on EKS optimized AL2023
+  AMIs). See [values.example.eks.yaml](./charts/aws/values.example.eks.yaml).
+* `azure.aks: true` — AKS via CAPZ's `AzureManagedControlPlane`; workers are
+  AKS agent pools (`AzureManagedMachinePool`), scaled by AKS's built-in
+  autoscaler, with kube-proxy disabled (Cilium replaces it — the
+  `KubeProxyConfigurationPreview` feature must be registered on the
+  subscription). See
+  [values.example.aks.yaml](./charts/azure/values.example.aks.yaml).
+
+Both suites are covered by helm-unittest tests (`charts/aws/tests/`,
+`charts/azure/tests/`) — run them with:
+
+```bash
+docker run --rm -v $(pwd):/apps helmunittest/helm-unittest charts/aws charts/azure
+```
+
 ## TODO
 
 * Add support for private repo to get added in bootstrap setup

--- a/docs/getting-started/pre-configuration.md
+++ b/docs/getting-started/pre-configuration.md
@@ -105,6 +105,35 @@ cloud:
         maxSize: 10
 ```
 
+#### AWS EKS (managed control plane)
+
+Set `eks: true` to get an AWS managed (EKS) control plane instead of the
+self-managed EC2 one. AWS runs the control plane multi-AZ, CAPA resolves the
+EKS optimized AL2023 worker AMIs itself, and workers stay keyless — so
+`controlPlane`, `sshKeyName` and per-node-group AMIs must be left unset.
+Requires Kubernetes >= v1.33.
+
+```yaml
+cloud:
+  aws:
+    region: eu-central-1
+    eks: true
+    bastionEnabled: true
+    nodeGroups:
+      - name: default
+        minSize: 3
+        maxSize: 6
+        cpu: 4
+        memory: 8
+        instanceType: c6i.xlarge
+        rootVolumeSize: 35
+```
+
+> **Note:** `cluster upgrade` doesn't apply to EKS clusters — bump
+> `global.kubernetes.version` in `argocd-apps/values-capi-cluster.yaml` in your
+> kubeaid-config repo and let ArgoCD sync; CAPA then upgrades the control plane
+> and rolls the node-groups.
+
 #### Azure
 
 ```yaml
@@ -122,6 +151,41 @@ cloud:
         minSize: 1
         maxSize: 10
 ```
+
+#### Azure AKS (managed control plane)
+
+Set `aks: true` to get an Azure managed (AKS) control plane instead of the
+self-managed VM one. Azure owns the control plane, the node images and the
+agent-pool autoscaling, and CAPZ authenticates with your AAD service principal
+directly — so `controlPlane`, `sshPublicKey`, `canonicalUbuntuImage`,
+`storageAccount`, `workloadIdentity` and `aadApplication` must all be left
+unset. Node-groups become AKS agent pools: the first one is the required
+`System` pool, and names must be 1-12 lowercase alphanumeric characters
+starting with a letter.
+
+```yaml
+cloud:
+  azure:
+    tenantID: <tenant-id>
+    subscriptionID: <subscription-id>
+    location: westeurope
+    aks: true
+    nodeGroups:
+      - name: default
+        minSize: 3
+        maxSize: 6
+        cpu: 4
+        memory: 8
+        vmSize: Standard_F4s_v2
+        diskSizeGB: 128
+```
+
+> **Note:** Register the `KubeProxyConfigurationPreview` feature on your
+> subscription before bootstrapping (see [Prerequisites](./prerequisites.md)) —
+> KubeAid disables AKS's kube-proxy and runs Cilium with kube-proxy
+> replacement. Like EKS, `cluster upgrade` doesn't apply: bump
+> `global.kubernetes.version` in `argocd-apps/values-capi-cluster.yaml` and let
+> ArgoCD sync.
 
 #### Hetzner HCloud
 

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -160,24 +160,36 @@ or create a separate user called `obmondo-<service>-user` and provide its Person
   
 - **Service Principal**: [Register an application (Service Principal) in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
   
-- **SSH Keypairs**:
-  - An OpenSSH type SSH keypair (private key for SSH access to VMs). You can generate this using:
+- **SSH Keypairs** (self-managed clusters only — AKS clusters need neither):
+  - An **RSA** SSH keypair (public key provisioned onto the VMs for SSH
+    access). Azure's ARM API rejects non-RSA keys at VM creation, so ed25519
+    keys cannot be used here. Generate with:
 
     ```bash
-    ssh-keygen -t ed25519 -f azure-ssh-key -C "azure-cluster-key"
+    ssh-keygen -t rsa -b 4096 -f azure-ssh-key -C "azure-cluster-key"
     ```
 
-  - A key pair in PEM format (required for [Azure Workload Identity setup](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster)).
-    You can generate this using:
+  - An **RSA** keypair for the workload-identity OIDC provider (it signs the
+    cluster's ServiceAccount tokens; Microsoft Entra ID verifies them with
+    RS256, so ed25519 cannot be used here either). Generate with:
 
     ```bash
-    openssl genpkey -algorithm ed25519 -out jwt-signing-key.pem
-    openssl pkey -in jwt-signing-key.pem -pubout -out jwt-signing-pub.pem
+    ssh-keygen -t rsa -b 4096 -f ~/.ssh/azure-oidc-issuer -N ""
     ```
 
-  > **Note:** ed25519 keys are shorter and more secure than RSA keys, though not quantum-safe.
-  > If RSA is preferred by you or your organization, use `ssh-keygen -t rsa -b 4096`
-  > and `openssl genrsa -out jwt-signing-key.pem 4096` instead.
+  > **Tip:** if your kubeaid-config deploy key happens to be RSA, kubeaid-cli
+  > reuses its public half as the VM SSH key automatically and skips the
+  > question.
+
+- **AKS clusters** (`cloud.azure.aks: true`): register the kube-proxy
+  configuration preview feature on the subscription before bootstrapping —
+  KubeAid disables AKS's kube-proxy and runs Cilium with kube-proxy
+  replacement:
+
+  ```bash
+  az feature register --namespace Microsoft.ContainerService --name KubeProxyConfigurationPreview
+  az provider register --namespace Microsoft.ContainerService
+  ```
   
 ### Bare Metal  
   


### PR DESCRIPTION
Documentation catch-up for the managed control planes (#170, #171 and kubeaid-cli #60, #61):

- **pre-configuration.md**: new `eks: true` and `aks: true` sections with the real config schema — nodeGroups shape, which fields must stay unset, AKS System-pool naming rules, and the GitOps upgrade pointers (`cluster upgrade` doesn't apply to managed control planes).
- **prerequisites.md**: the Azure SSH and workload-identity OIDC keys must be **RSA** — the previous guidance recommended ed25519, but Azure's ARM API rejects non-RSA SSH keys at VM creation and Entra ID verifies ServiceAccount tokens with RS256, so following it produced keys the bootstrap can't use. Also notes the deploy-key reuse (kubeaid-cli #61), that AKS clusters need neither key, and the `KubeProxyConfigurationPreview` registration AKS needs.
- **capi-cluster README**: managed control-plane flags, links to `values.example.eks.yaml` / `values.example.aks.yaml`, and the docker helm-unittest invocation for the two test suites.

markdownlint-cli2 clean on the edited files.