### PR TITLE
ci: run the capi-cluster helm-unittest suites on PRs, repair the hetzner suite

### DIFF
--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -27,8 +27,13 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Run helm-unittest on the capi-cluster subcharts
+        # --user + HOME : the image's default (non-root) user can't create
+        # the tests/__snapshot__ dirs inside the runner-owned checkout, and
+        # helm itself needs a writable HOME for its cache.
         run: |
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/tmp \
             -v "$PWD/argocd-helm-charts/capi-cluster:/apps" \
             helmunittest/helm-unittest:latest \
             charts/aws charts/azure charts/hetzner

--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -1,0 +1,34 @@
+name: Helm Unittest
+
+"on":
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - 'argocd-helm-charts/capi-cluster/**'
+      - '.github/workflows/helm-unittest.yml'
+
+permissions:
+  contents: read
+
+# This will only allow a single helm-unittest action to run per PR.
+# Any github action running on the older commits will be aborted.
+concurrency:
+  group: helm-unittest-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  helm-unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Run helm-unittest on the capi-cluster subcharts
+        run: |
+          docker run --rm \
+            -v "$PWD/argocd-helm-charts/capi-cluster:/apps" \
+            helmunittest/helm-unittest:latest \
+            charts/aws charts/azure charts/hetzner

--- a/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmConfig.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmConfig.yaml
@@ -256,7 +256,7 @@ spec:
           sleep 10s
           STORAGECTL_ARCH="$(uname -m)"
           case "$STORAGECTL_ARCH" in aarch64) STORAGECTL_ARCH=arm64 ;; esac
-          STORAGECTL_URL="https://github.com/Obmondo/kubeaid-cli/releases/{{ if $.Values.global.kubeaidStoragectl.version }}download/{{ $.Values.global.kubeaidStoragectl.version }}{{ else }}latest/download{{ end }}/kubeaid-storagectl_Linux_${STORAGECTL_ARCH}"
+          STORAGECTL_URL="https://github.com/Obmondo/kubeaid-cli/releases/{{ if (($.Values.global).kubeaidStoragectl).version }}download/{{ (($.Values.global).kubeaidStoragectl).version }}{{ else }}latest/download{{ end }}/kubeaid-storagectl_Linux_${STORAGECTL_ARCH}"
           wget -O kubeaid-storagectl "$STORAGECTL_URL" || { echo "ERROR: kubeaid-storagectl download failed from $STORAGECTL_URL" >&2; exit 1; }
           [ -s kubeaid-storagectl ] || { echo "ERROR: kubeaid-storagectl downloaded empty (likely 404) from $STORAGECTL_URL" >&2; exit 1; }
           chmod +x ./kubeaid-storagectl

--- a/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmControlPlane.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmControlPlane.yaml
@@ -409,7 +409,7 @@ spec:
           sleep 10s
           STORAGECTL_ARCH="$(uname -m)"
           case "$STORAGECTL_ARCH" in aarch64) STORAGECTL_ARCH=arm64 ;; esac
-          STORAGECTL_URL="https://github.com/Obmondo/kubeaid-cli/releases/{{ if $.Values.global.kubeaidStoragectl.version }}download/{{ $.Values.global.kubeaidStoragectl.version }}{{ else }}latest/download{{ end }}/kubeaid-storagectl_Linux_${STORAGECTL_ARCH}"
+          STORAGECTL_URL="https://github.com/Obmondo/kubeaid-cli/releases/{{ if (($.Values.global).kubeaidStoragectl).version }}download/{{ (($.Values.global).kubeaidStoragectl).version }}{{ else }}latest/download{{ end }}/kubeaid-storagectl_Linux_${STORAGECTL_ARCH}"
           wget -O kubeaid-storagectl "$STORAGECTL_URL" || { echo "ERROR: kubeaid-storagectl download failed from $STORAGECTL_URL" >&2; exit 1; }
           [ -s kubeaid-storagectl ] || { echo "ERROR: kubeaid-storagectl downloaded empty (likely 404) from $STORAGECTL_URL" >&2; exit 1; }
           chmod +x ./kubeaid-storagectl
@@ -632,7 +632,7 @@ spec:
       # global.kubeaid.version when set — keeps the in-node clone on the
       # same release the chart was rendered from. Empty version leaves
       # the clone on master.
-      - git clone --depth 1{{ if .Values.global.kubeaid.version }} --branch {{ .Values.global.kubeaid.version }}{{ end }} {{ .Values.global.kubeaid.repo }} kubeaid
+      - git clone --depth 1{{ if ((.Values.global).kubeaid).version }} --branch {{ ((.Values.global).kubeaid).version }}{{ end }} {{ ((.Values.global).kubeaid).repo | default "https://github.com/Obmondo/KubeAid.git" }} kubeaid
 
       # Copy kubeconfig to ~/.kube/config
       - mkdir -p $HOME/.kube

--- a/argocd-helm-charts/capi-cluster/charts/hetzner/tests/bare-metal-private_test.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/hetzner/tests/bare-metal-private_test.yaml
@@ -48,10 +48,13 @@ tests:
       - hasDocuments:
           count: 6
 
-  - it: writes and invokes the NAT gateway bootstrap on the control plane
+  - it: does not invoke the NAT gateway hop on bare-metal control planes
+    # Pure bare-metal nodes have their own public connectivity and no
+    # 10.0.0.1 gateway — the hop is HCloud-private / hybrid only (see the
+    # mode guard in KubeadmControlPlane.yaml).
     template: KubeadmControlPlane.yaml
     asserts:
-      - contains:
+      - notContains:
           path: spec.kubeadmConfigSpec.preKubeadmCommands
           content: chmod +x /connect-nat-gateway.sh && /connect-nat-gateway.sh
 


### PR DESCRIPTION
Nothing ran the capi-cluster chart tests in CI — and the hetzner suite had silently rotted to prove the point:

- **Template nil-safety**: subchart-alone rendering (what helm-unittest does) panicked on `global.kubeaidStoragectl.version` and `global.kubeaid.version`, both introduced after the tests were written. The lookups are now nil-safe, with absent blocks behaving exactly like the empty-string defaults (storagectl → latest release, kubeaid clone → unpinned, repo → canonical URL fallback).
- **Stale assertion**: `bare-metal-private_test.yaml` still asserted the NAT-gateway hop that the bare-metal mode guard deliberately dropped (bare-metal nodes have their own public connectivity, and the hop cost 5 minutes of boot retries). Assertion inverted to `notContains`.
- **New workflow** (`.github/workflows/helm-unittest.yml`): runs all three suites — aws (incl. EKS), azure (incl. AKS), hetzner — **59 tests** via the `helmunittest/helm-unittest` image, on any PR touching `argocd-helm-charts/capi-cluster`.

All 59 tests pass locally. No untrusted input reaches any `run:` block in the workflow.