### PR TITLE
fix(prometheus-linuxaid): corrected bugs in btrfs rules alert expression to make it actually alert disk issues

### DIFF
--- a/argocd-helm-charts/prometheus-linuxaid/rules/btrfs.yaml
+++ b/argocd-helm-charts/prometheus-linuxaid/rules/btrfs.yaml
@@ -4,11 +4,15 @@ groups:
 
     - alert: monitor::system::disk::btrfs
       expr: |
-        (node_btrfs_size_bytes / node_btrfs_used_bytes) * 100  >= on(certname, block_group_type, uuid) threshold::monitor::system::disk::btrfs
+        (
+          (node_btrfs_used_bytes / node_btrfs_size_bytes) * 100
+            >= on(certname, block_group_type, uuid) threshold::monitor::system::disk::btrfs
+        )
         or
-        (node_btrfs_size_bytes / node_btrfs_used_bytes) * 100 >= 80
-        and
-        on(certname, block_group_type, uuid) obmondo_monitoring{alert_id="monitor::system::disk::btrfs"} > 0
+        (
+          (node_btrfs_used_bytes / node_btrfs_size_bytes) * 100 >= 80
+            and on(certname) obmondo_monitoring{alert_id="monitor::system::disk::usage"} > 0
+        )
       for: 10m
       labels:
         severity: warning

--- a/argocd-helm-charts/prometheus-linuxaid/tests/btrfs.yaml
+++ b/argocd-helm-charts/prometheus-linuxaid/tests/btrfs.yaml
@@ -8,20 +8,31 @@ tests:
   # btrfs use check
   - interval: 1m
     input_series:
-      - series: obmondo_monitoring{certname="cert1.abc", block_group_type="/data", uuid="4321", alert_id="monitor::system::disk::btrfs"}
+      # Enablement follows the disk::usage toggle (btrfs has no toggle of its own).
+      - series: obmondo_monitoring{certname="cert1.abc", alert_id="monitor::system::disk::usage"}
         values: 1x1000
-      - series: obmondo_monitoring{certname="remdev.abc", block_group_type="/metadata", uuid="5321", alert_id="monitor::system::disk::btrfs"}
+      - series: obmondo_monitoring{certname="remdev.abc", alert_id="monitor::system::disk::usage"}
         values: 1x1000
+      # Host with a full btrfs block group but disk monitoring disabled -> must NOT alert.
+      - series: obmondo_monitoring{certname="nomon.abc", alert_id="monitor::system::disk::usage"}
+        values: 0x1000
       - series: threshold::monitor::system::disk::btrfs{certname="cert1.abc", block_group_type="/data", uuid="4321"}
         values: 90+0x30
+      # cert1 /data: 9013 / 10000 = 90.13% used, custom threshold 90 -> fires.
       - series: node_btrfs_size_bytes{certname="cert1.abc", block_group_type="/data", uuid="4321"}
-        values: 8198x30
+        values: 10000x30
       - series: node_btrfs_used_bytes{certname="cert1.abc", block_group_type="/data", uuid="4321"}
-        values: 9096x30
+        values: 9013x30
+      # remdev /metadata: 8821 / 10000 = 88.21% used, default threshold 80 -> fires.
       - series: node_btrfs_size_bytes{certname="remdev.abc", block_group_type="/metadata", uuid="5321"}
-        values: 8024x30
+        values: 10000x30
       - series: node_btrfs_used_bytes{certname="remdev.abc", block_group_type="/metadata", uuid="5321"}
-        values: 9096x30
+        values: 8821x30
+      # nomon /data: 9500 / 10000 = 95% used, but disk::usage disabled -> no alert.
+      - series: node_btrfs_size_bytes{certname="nomon.abc", block_group_type="/data", uuid="6321"}
+        values: 10000x30
+      - series: node_btrfs_used_bytes{certname="nomon.abc", block_group_type="/data", uuid="6321"}
+        values: 9500x30
 
     alert_rule_test:
       - alertname: monitor::system::disk::btrfs


### PR DESCRIPTION
https://gitea.obmondo.com/EnableIT/abbnoa6nlk/issues/2532

this newer alert expression works -> screenshot attached.

<img width="1044" height="432" alt="Screenshot 2026-08-11 at 3 45 39 PM" src="https://github.com/user-attachments/assets/74617a02-3fb3-4142-9a88-7b22ba176bb0" />
