### PR TITLE
fix(capi-cluster): add apiGroup to v1beta2 refs; stop declaring AzureManagedControlPlane.sshPublicKey

### DIFF
--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/Cluster.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/Cluster.yaml
@@ -11,20 +11,20 @@ spec:
       - {{ .Values.pods.cidrBlock | default "10.244.0.0/16" }}
   {{- if .Values.eks }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: AWSManagedControlPlane
     name: {{ .Values.global.clusterName }}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AWSManagedCluster
     name: {{ .Values.global.clusterName }}
   {{- else }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: {{ .Values.global.clusterName }}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AWSCluster
     name: {{ .Values.global.clusterName }}
   {{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/MachineDeployment.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/MachineDeployment.yaml
@@ -76,7 +76,7 @@ spec:
       clusterName: {{ $.Values.global.clusterName }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           {{- if $.Values.eks }}
           kind: NodeadmConfigTemplate
           {{- else }}
@@ -84,7 +84,7 @@ spec:
           {{- end }}
           name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AWSMachineTemplate
         name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
       failureDomain: {{ printf "%s%s" $.Values.region $failureDomain | quote }}

--- a/argocd-helm-charts/capi-cluster/charts/aws/templates/MachinePool.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/aws/templates/MachinePool.yaml
@@ -30,12 +30,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfig
           name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
       clusterName: {{ $.Values.global.clusterName }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AWSMachinePool
         name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
       version: {{ $.Values.global.kubernetes.version }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureManagedControlPlane.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/AzureManagedControlPlane.yaml
@@ -13,9 +13,14 @@ spec:
     kind: AzureClusterIdentity
     name: {{ .Values.global.clusterName }}-cluster-identity
   {{/* AKS nodes stay keyless — use `az aks command invoke` for node access.
-       An empty string disables SSH key provisioning; leaving the field unset
-       would make CAPZ auto-generate a key instead. */}}
-  sshPublicKey: ""
+       We deliberately do NOT set sshPublicKey here (not even to ""): CAPZ's
+       admission webhook auto-generates a key on creation regardless of
+       whether the field is sent as "" or omitted, then rejects every later
+       patch as "field is immutable" because our desired manifest keeps
+       re-declaring a different value ("" vs the generated key). Omitting
+       the field entirely means our Helm-rendered manifest never claims
+       ownership of it, so ArgoCD's three-way merge leaves the
+       webhook-generated value alone instead of fighting it forever. */}}
   {{/* Cilium is the CNI (installed by kubeaid-cli, then owned by the cilium
        ArgoCD App) and runs with kube-proxy replacement — so AKS's own CNI is
        disabled via BYO CNI ("none"), and kube-proxy via the ASO patch below.

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/MachineDeployment.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/MachineDeployment.yaml
@@ -37,11 +37,11 @@ spec:
       clusterName: {{ $.Values.global.clusterName }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
           name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AzureMachineTemplate
         name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
       version: {{ $.Values.global.kubernetes.version }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/MachinePool.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/MachinePool.yaml
@@ -25,7 +25,7 @@ spec:
       bootstrap:
         dataSecretName: ""
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AzureManagedMachinePool
         name: {{ printf "%s-%s" $.Values.global.clusterName $nodeGroup.name }}
       version: {{ $.Values.global.kubernetes.version }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/templates/cluster.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/templates/cluster.yaml
@@ -12,20 +12,20 @@ spec:
        unlike CAPA v2 (whose AWSManagedControlPlane lives under
        controlplane.cluster.x-k8s.io). */}}
   controlPlaneRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AzureManagedControlPlane
     name: {{ .Values.global.clusterName }}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AzureManagedCluster
     name: {{ .Values.global.clusterName }}
   {{- else }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: {{ .Values.global.clusterName }}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AzureCluster
     name: {{ .Values.global.clusterName }}
   {{- end }}

--- a/argocd-helm-charts/capi-cluster/charts/azure/tests/aks_test.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/azure/tests/aks_test.yaml
@@ -39,9 +39,11 @@ tests:
       - equal:
           path: spec.networkPlugin
           value: none
-      - equal:
+      # sshPublicKey is deliberately omitted from the rendered manifest
+      # (not even set to "") so CAPZ's webhook-generated key isn't fought
+      # over by ArgoCD's three-way merge — see AzureManagedControlPlane.yaml.
+      - notExists:
           path: spec.sshPublicKey
-          value: ""
       - equal:
           path: spec.oidcIssuerProfile.enabled
           value: true


### PR DESCRIPTION
## Problem

CAPI v1.11's `Cluster.spec.controlPlaneRef` / `infrastructureRef` and
`MachinePool`/`MachineDeployment` `spec.template.spec.infrastructureRef` /
`bootstrap.configRef` are now `ContractVersionedObjectReferences`, which
require `apiGroup` (group only, no version) instead of `apiVersion`. The
`azure` and `aws` `capi-cluster` subcharts still emitted the old
`apiVersion`-keyed refs, so the v1beta2 API server rejected every
Cluster/MachinePool/MachineDeployment apply with e.g.:

```
spec.controlPlaneRef.apiGroup: Required value
spec.infrastructureRef.apiGroup: Required value
```

Separately, CAPZ's admission webhook auto-generates an SSH key on
`AzureManagedControlPlane` creation regardless of whether `sshPublicKey`
is sent as `""` or omitted, then rejects every subsequent patch as
immutable because our rendered manifest kept re-declaring a value that
differs from the live, webhook-generated one:

```
spec.sshPublicKey: Invalid value: "...": field is immutable
```

This wedged every sync after the first create, including unrelated field
changes bundled in the same patch (e.g. a Kubernetes version bump), since
the whole request gets rejected atomically.

## Fix

- Swap `apiVersion` → `apiGroup` on every `controlPlaneRef`,
  `infrastructureRef`, and `bootstrap.configRef` under a v1beta2
  `Cluster`/`MachinePool`/`MachineDeployment` in both the `aws` and
  `azure` `capi-cluster` subcharts.
- Drop `sshPublicKey` from the `AzureManagedControlPlane` template
  entirely so our manifest never claims ownership of it — ArgoCD's
  three-way merge then leaves the webhook-generated value alone instead
  of fighting it forever.
- Update the `aks_test.yaml` helm-unittest to assert `spec.sshPublicKey`
  does not exist rather than equals `""`, matching the corrected
  rendered manifest.

## Testing

Verified locally with the same `helmunittest/helm-unittest:latest`
image CI uses — all 59 tests across `aws`, `azure`, and `hetzner`
charts pass.
