### PR TITLE
🚨 Security Hotfixes: Hardcoded Azure Password & IAM Policy Bug

### DIFF
--- a/terraform/aws/iam/external-dns.tf
+++ b/terraform/aws/iam/external-dns.tf
@@ -72,7 +72,7 @@ resource "aws_iam_policy" "external-dns" {
 
 resource "aws_iam_role_policy_attachment" "external-dns-attachment" {
   role       = aws_iam_role.external-dns.name
-  policy_arn = aws_iam_policy.kube2iam.arn
+  policy_arn = aws_iam_policy.external-dns.arn
 }
 
 resource "aws_iam_role_policy_attachment" "external-dns-attachment2" {

--- a/terraform/azure/gitlab-ci-server/vm.tf
+++ b/terraform/azure/gitlab-ci-server/vm.tf
@@ -17,9 +17,8 @@ resource "azurerm_linux_virtual_machine" "vm-gitlab" {
   ]
 
   admin_username = "ubuntu"
-  admin_password = "Testing@123"
 
-  disable_password_authentication = false
+  disable_password_authentication = true
   
   admin_ssh_key {
     username   = "ubuntu"


### PR DESCRIPTION
## Critical Fixes

1. **Azure VM Security:** Removed the hardcoded plaintext password `Testing@123` and enforced SSH-key-only login.
2. **AWS IAM:** Fixed a copy-paste bug where the ExternalDNS role was accidentally attached to the `kube2iam` policy instead of the `external-dns` policy.