### PR TITLE
🔧 Tech Debt: Upgrade Baseline K8s to 1.28+ & Azure Provider

### DIFF
--- a/terraform/aws/cluster/variables.tf
+++ b/terraform/aws/cluster/variables.tf
@@ -78,7 +78,7 @@ variable "kops_state_bucket_name" {
 variable "kubernetes_version" {
   type        = string
   description = "K8s cluster version"
-  default     = "1.22.8"
+  default     = "1.28.7"
 }
 
 variable "tags" {

--- a/terraform/azure/aks/providers.tf
+++ b/terraform/azure/aks/providers.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     azurerm = {
-      version = ">= 2.75.0"
+      version = "~> 3.100"
     }
 
     kubernetes = {


### PR DESCRIPTION
## Infrastructure Modernization
This PR resolves the version drift identified between our platform documentation (SBOM) and our IaC templates.

1. **AWS Kops Baseline:** Bumped default `kubernetes_version` from EOL `1.22.8` to `1.28.7`.
2. **Azure Provider:** Upgraded the `azurerm` provider constraints from the outdated `2.75.0` to `~> 3.100` to support modern AKS configurations.