### PR TITLE
feat(tetragon): ship a curated TracingPolicy set

### DIFF
--- a/argocd-helm-charts/tetragon/README.md
+++ b/argocd-helm-charts/tetragon/README.md
@@ -18,8 +18,10 @@ Upstream chart: [https://helm.cilium.io/](https://github.com/cilium/tetragon) (s
 
 ## Usage
 
-- Installed as-is, Tetragon is **observability-only**: it emits process,
-  network and file events (JSON export + gRPC). Nothing is blocked.
+- Tetragon here is **observability-only**: it emits process, network and file
+  events (JSON export + gRPC), plus the curated detections from the
+  [TracingPolicies KubeAid ships](#tracingpolicies-shipped-by-kubeaid).
+  Nothing is blocked.
 - Inspect events from a node with the `tetra` CLI:
 
   ```sh
@@ -37,6 +39,62 @@ Upstream chart: [https://helm.cilium.io/](https://github.com/cilium/tetragon) (s
 
   Tetragon integrates naturally with Cilium (same vendor), which KubeAid
   already uses as the CNI.
+
+## TracingPolicies shipped by KubeAid
+
+Tetragon ships **no** TracingPolicy of its own. Without one it is a firehose of
+raw events with no curated detections, so KubeAid ships a small set under
+`kubeaid.tracingPolicies`.
+
+Every policy is vendored verbatim from Tetragon's **curated** policy library
+([`examples/policylibrary`](https://github.com/cilium/tetragon/tree/main/examples/policylibrary)),
+not the community examples in `examples/tracingpolicy` — upstream states those
+are "not curated in terms of suitability for specific use cases or best
+practices".
+
+All are **observability-only**. None carries a `Sigkill` or `Override` action,
+so nothing is ever blocked. Enforcement stays a separate, deliberate decision.
+
+| Value | Policy | Default | Detects |
+| ----- | ------ | ------- | ------- |
+| `policies.kernelModules` | `monitor-kernel-modules` | **on** | Kernel module loads (`security_kernel_module_request`, `security_kernel_read_file`) |
+| `policies.privilegesRaise` | `privileges-raise` | **on** | `capset`, unprivileged user-namespace creation, uid/gid changes to root |
+| `policies.bpf` | `bpf-library-policy` | off | eBPF program and map loads, BPFFS access |
+
+Disable the whole set with `kubeaid.tracingPolicies.enabled: false`.
+
+### Why these defaults
+
+**`kernelModules`** — module loads are near-zero in normal cluster operation
+and are a common rootkit step, giving the best signal-to-noise of anything in
+the library.
+
+**`privilegesRaise`** — upstream rate-limits every selector to one message per
+minute, which is what makes it safe to run fleet-wide. It deliberately
+supersedes the library's `privileges-setuid-root` policy, which is a strict
+subset: both watch uid/gid changes to root, but `privileges-raise` also covers
+`capset` and user-namespace creation. Shipping both would double-report every
+setuid event.
+
+**`bpf` is off** for two reasons specific to this stack:
+
+1. Cilium reloads eBPF programs continuously during endpoint regeneration, and
+   Tetragon loads its own. On a Cilium cluster the policy therefore reports
+   mostly the platform's own activity.
+2. It hooks `security_file_permission` and `security_mmap_file`, two of the
+   hottest paths in the kernel. Selectors filter in-kernel so filtered events
+   never reach userspace, but the kprobe still fires on every call.
+
+Enable it where an unexpected eBPF load is a meaningful signal, after
+confirming the event volume on a single cluster.
+
+### Adding more
+
+The library also contains `egress`, `library` (shared-object loads) and `sshd`
+policies. They are not vendored here. `library` in particular sets
+`loader: true` and fires on every shared-library load, which would flood the
+event pipeline across a large fleet — read and volume-test any of them on one
+cluster before adding.
 
 ## Configuration
 

--- a/argocd-helm-charts/tetragon/templates/_helpers.tpl
+++ b/argocd-helm-charts/tetragon/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Common name helpers for the tetragon wrapper chart.
+*/}}
+{{- define "tetragon-wrapper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tetragon-wrapper.labels" -}}
+app.kubernetes.io/name: {{ include "tetragon-wrapper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/argocd-helm-charts/tetragon/templates/tracingpolicies/bpf.yaml
+++ b/argocd-helm-charts/tetragon/templates/tracingpolicies/bpf.yaml
@@ -1,0 +1,119 @@
+{{- if and .Values.kubeaid.tracingPolicies.enabled .Values.kubeaid.tracingPolicies.policies.bpf }}
+# Vendored verbatim from Tetragon's curated policy library:
+# https://github.com/cilium/tetragon/blob/main/examples/policylibrary/bpf.yaml
+#
+# OFF BY DEFAULT on KubeAid clusters. Two reasons, both specific to this stack:
+#
+#   1. Cilium loads and reloads eBPF programs continuously during endpoint
+#      regeneration, and Tetragon loads its own. On a Cilium cluster this
+#      policy therefore reports mostly its own platform's activity.
+#
+#   2. It hooks security_file_permission and security_mmap_file, two of the
+#      hottest paths in the kernel. Selectors filter in-kernel so the events do
+#      not reach userspace, but the kprobe still fires on every call.
+#
+# Enable it on clusters where an unexpected eBPF load is a meaningful signal,
+# after confirming the volume on one cluster first.
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "bpf-library-policy"
+  labels:
+    {{- include "tetragon-wrapper.labels" . | nindent 4 }}
+spec:
+  kprobes:
+  - call: "bpf_check"
+    syscall: false
+    args:
+    - index: 1
+      type: "bpf_attr"
+  - call: "security_perf_event_alloc"
+    syscall: false
+    args:
+    - index: 0
+      type: "perf_event"
+  - call: "security_bpf_map_alloc" # bpf map create, < Linux 6.9
+    syscall: false
+    args:
+    - index: 0
+      type: "bpf_map"
+    ignore:
+      callNotFound: true
+  - call: "security_bpf_map_create" # bpf map create, Linux 6.9+
+    syscall: false
+    args:
+    - index: 0
+      type: "bpf_map"
+    ignore:
+      callNotFound: true
+  - call: "security_file_permission"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "file"
+    - index: 1
+      type: "int" # 0x04 MAY_READ, 0x02 MAY_WRITE
+    returnArg:
+      index: 0
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Prefix"
+        values:
+        - "/sys/fs/bpf"
+      - index: 1
+        operator: "Equal"
+        values:
+        - "4" # MAY_READ
+    - matchArgs:
+      - index: 0
+        operator: "Prefix"
+        values:
+        - "/sys/fs/bpf"
+      - index: 1
+        operator: "Equal"
+        values:
+        - "2" # MAY_WRITE
+  - call: "security_mmap_file"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "file"
+    - index: 1
+      type: "uint32" # prot flags
+    - index: 2
+      type: "uint32" # mmap flags
+    returnArg:
+      index: 0
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Prefix"
+        values:
+        - "/sys/fs/bpf"
+      - index: 1
+        operator: "Equal"
+        values:
+        - "1" # MAY_READ
+      - index: 2
+        operator: "Mask"
+        values:
+        - "1" # MAP_SHARED
+    - matchArgs:
+      - index: 0
+        operator: "Prefix"
+        values:
+        - "/sys/fs/bpf"
+      - index: 1
+        operator: "Mask"
+        values:
+        - "2" # PROT_WRITE
+      - index: 2
+        operator: "Mask"
+        values:
+        - "1" # MAP_SHARED
+{{- end }}

--- a/argocd-helm-charts/tetragon/templates/tracingpolicies/monitor-kernel-modules.yaml
+++ b/argocd-helm-charts/tetragon/templates/tracingpolicies/monitor-kernel-modules.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.kubeaid.tracingPolicies.enabled .Values.kubeaid.tracingPolicies.policies.kernelModules }}
+# Vendored verbatim from Tetragon's curated policy library:
+# https://github.com/cilium/tetragon/blob/main/examples/policylibrary/modules.yaml
+#
+# Kernel module loads are near-zero in normal cluster operation, which makes
+# this one of the highest signal-to-noise detections available. Loading a
+# module is a common rootkit step.
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "monitor-kernel-modules"
+  annotations:
+    description: "Monitor kernel modules operations"
+  labels:
+    {{- include "tetragon-wrapper.labels" . | nindent 4 }}
+spec:
+  kprobes:
+  - call: "security_kernel_module_request"
+    message: "Kernel module requested and is being loaded automatically"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "string"
+    returnArg:
+      index: 0
+      type: "int"
+  - call: "security_kernel_read_file"
+    message: "Kernel module is being loaded"
+    # Explicit module loading using file descriptor finit_module() to print module full path
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "file"
+    - index: 1
+      type: "int"
+    returnArg:
+      index: 0
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "2"  # READING_MODULE
+{{- end }}

--- a/argocd-helm-charts/tetragon/templates/tracingpolicies/privileges-raise.yaml
+++ b/argocd-helm-charts/tetragon/templates/tracingpolicies/privileges-raise.yaml
@@ -1,0 +1,236 @@
+{{- if and .Values.kubeaid.tracingPolicies.enabled .Values.kubeaid.tracingPolicies.policies.privilegesRaise }}
+# Vendored verbatim from Tetragon's curated policy library:
+# https://github.com/cilium/tetragon/blob/main/examples/policylibrary/privileges/privileges-raise.yaml
+#
+# Detects three privilege-raising paths: capset, unprivileged user-namespace
+# creation, and uid/gid changes to root. Upstream rate-limits every selector to
+# one message per minute, which is why this is safe to run fleet-wide.
+#
+# This is a superset of the library's privileges-setuid-root policy — running
+# both would double-report every setuid event, so only this one is shipped.
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "privileges-raise"
+  annotations:
+    description: "Detects privileges raising operations"
+  labels:
+    {{- include "tetragon-wrapper.labels" . | nindent 4 }}
+spec:
+  kprobes:
+  - call: "security_capset"
+    syscall: false
+    message: "Process changed its capabilities using capset system call"
+    args:
+    - index: 0
+      type: "nop"
+    - index: 1
+      type: "cred"
+    - index: 2
+      type: "cap_effective"
+    - index: 3
+      type: "cap_inheritable"
+    - index: 4
+      type: "cap_permitted"
+    selectors:
+    - matchArgs:
+      - index: 2
+        operator: "NotEqual"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+    - matchArgs:
+      - index: 3
+        operator: "NotEqual"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+    - matchArgs:
+      - index: 4
+        operator: "NotEqual"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+  - call: "create_user_ns"
+    syscall: false
+    message: "Unprivileged process created a user namespace where it will be privileged"
+    args:
+    - index: 0
+      type: "nop"
+    selectors:
+    - matchCapabilities:
+      - type: Effective
+        operator: NotIn
+        values:
+        - "CAP_SYS_ADMIN"
+  - call: "__sys_setuid"
+    message: "Privileged operation setuid to root"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+  - call: "__sys_setgid"
+    message: "Privileged operation setgid to root"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+  - call: "__sys_setreuid"
+    message: "Privileged operation setuid to root"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+  - call: "__sys_setregid"
+    message: "Privileged operation setgid to root"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+  - call: "__sys_setresuid"
+    message: "Privileged operation setuid to root"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "int"
+    - index: 2
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 1 # effective user id, to reduce noise
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+    - matchArgs:
+      - index: 2
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+  - call: "__sys_setresgid"
+    message: "Privileged operation setgid to root"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "int"
+    - index: 2
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 1 # effective group id, to reduce noise
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+    - matchArgs:
+      - index: 2
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+  - call: "__sys_setfsuid"
+    message: "Privileged operation setuid to root"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+  - call: "__sys_setfsgid"
+    message: "Privileged operation setgid to root"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "0"
+      matchActions:
+      - action: Post
+        rateLimit: "1m"
+{{- end }}

--- a/argocd-helm-charts/tetragon/values.yaml
+++ b/argocd-helm-charts/tetragon/values.yaml
@@ -21,3 +21,36 @@ tetragon:
   #   exporter + pipeline in the openobserve-collector values (filter on the Tetragon
   #   namespace) — Tetragon itself is unchanged.
   {}
+
+# KubeAid-owned TracingPolicy set.
+#
+# Tetragon ships no TracingPolicy of its own, so without these it is a firehose
+# of process/network/file events with no curated detections. Every policy here
+# is vendored verbatim from Tetragon's CURATED policy library
+# (examples/policylibrary), not the uncurated community examples
+# (examples/tracingpolicy).
+#
+# All are observability-only: none carry a Sigkill or Override action, so
+# nothing is ever blocked. Enforcement stays a deliberate, separate decision.
+kubeaid:
+  tracingPolicies:
+    enabled: true
+
+    policies:
+      # Kernel module loads. Near-zero in normal operation and a common rootkit
+      # step, so the highest signal-to-noise detection available.
+      kernelModules: true
+
+      # capset, unprivileged user-namespace creation, and uid/gid changes to
+      # root. Upstream rate-limits every selector to one message per minute.
+      #
+      # Deliberately supersedes the library's privileges-setuid-root policy,
+      # which is a strict subset — shipping both would double-report every
+      # setuid event.
+      privilegesRaise: true
+
+      # eBPF program and map loads. OFF by default on KubeAid clusters: Cilium
+      # and Tetragon both load eBPF continuously, so this mostly reports the
+      # platform's own activity, and it hooks two very hot kernel paths.
+      # Confirm volume on one cluster before enabling fleet-wide.
+      bpf: false


### PR DESCRIPTION
Tetragon ships no TracingPolicy of its own, so as packaged it is a firehose of process, network and file events with no curated detections. Nothing in the cluster turns that stream into a signal anyone would act on.

Every policy here is vendored verbatim from Tetragon's curated policy library rather than the uncurated community examples, and all are observability-only: none carries a Sigkill or Override action, so nothing is ever blocked. Enforcement stays a separate, deliberate decision.

Kernel-module loads and privilege raises are on by default, being near-zero in normal operation and high-signal when they happen. The eBPF load policy is off: Cilium and Tetragon both load eBPF continuously, so it mostly reports the platform's own activity while hooking two very hot kernel paths. Confirm volume on one cluster before enabling it fleet-wide.

privileges-raise deliberately supersedes the library's privileges-setuid-root policy, which is a strict subset -- shipping both would double-report every setuid event.