### PR TITLE
feat(backup-exporter): allow reading velero volume policies

### DIFF
--- a/argocd-helm-charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: A Helm chart for the Obmondo Backup Exporter — reports PostgreSQL (CNPG logical and WAL), Velero, MongoDB and Sealed Secrets backup health by reading object storage directly, as Prometheus metrics and a JSON API.
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "v1.2.1"

--- a/argocd-helm-charts/backup-exporter/templates/clusterrole.yaml
+++ b/argocd-helm-charts/backup-exporter/templates/clusterrole.yaml
@@ -47,6 +47,16 @@ rules:
     resources: ["deployments"]
     verbs: ["get", "list"]
 
+  # Velero volume policies. A Schedule can name a ConfigMap that tells Velero to
+  # skip a volume outright -- the velero chart renders exactly that from
+  # skipVolumePolicies, for databases backed up logically instead. The exporter
+  # reads it so those volumes are not reported as missing backups. Removing this
+  # rule fails safe but silently: the policy cannot be read, so every skipped
+  # volume alerts as unbacked, once per volume, forever.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+
   # Namespaces for cross-namespace discovery
   - apiGroups: [""]
     resources: ["namespaces"]


### PR DESCRIPTION
The velero chart renders a resource policy ConfigMap from skipVolumePolicies, telling Velero to skip volumes backed up logically instead. backup-exporter reads it so those volumes are not reported as missing backups; without the rule it fails safe but silently, alerting on every skipped volume forever.