### PR TITLE
docs: rewrite README developer-first and adopt CNCF project standard

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,23 @@
+# Adopters
+
+This is the list of organizations and users that have publicly shared how they are using KubeAid.
+
+💡 **Add your organization by creating a PR, or by [opening an issue](https://github.com/Obmondo/KubeAid/issues/new)**
+
+Note: There are several other organizations and users that are unable to publicly share their stories but are active
+in the KubeAid community. We appreciate all our users and their contributions to making KubeAid a successful project.
+
+The list of organizations that have publicly shared their usage of KubeAid:
+
+| Organization | Success Story |
+|:---|:---|
+| [Obmondo](https://obmondo.com) | Obmondo's own managed customer clusters, provisioned and operated with KubeAid. |
+| [Kilroy International](https://www.kilroy.net/) | Multi-cloud production clusters (Azure and Hetzner) across several environments, provisioned and managed with KubeAid. |
+| [BlackWoodSeven (BW7)](https://www.blackwoodseven.com/) | Multiple AWS production and staging environments, kept up to date and operated with KubeAid. |
+| [GN Store Nord](https://www.gn.com/) | High-performance computing and build environments for R&D in hearing and audio, run on open source automation including KubeAid. |
+| [HBK](https://www.hbkworld.com/) | Server infrastructure security updates and maintenance, streamlined with Obmondo's tooling including KubeAid. |
+| [ebillet a/s](https://ebillet.dk/) | Cinema ticketing platform infrastructure — load balancers and automated certificate handling, run with KubeAid. |
+| [Officient](https://officient.io/) (now [Exact Officient](https://www.exact.com/benl/software/exact-officient)) | Infrastructure vulnerability assessment and security hardening for their HR platform, supported by Obmondo. |
+| [EnableIT](https://enableit.dk/) | Internal production Kubernetes clusters, provisioned and managed with KubeAid. |
+
+<!-- append new rows above this line, in the same table format -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# KubeAid Community Code of Conduct
+
+KubeAid follows the [CNCF Community Code of Conduct v1.0](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ on as an open-source patch.
 3. **Create a branch** locally with a succinct name (e.g., `feat/add-azure-support`).
 4. **Commit changes** to your own branch.
 5. **Push** your work back up to your fork.
-6. Submit a **Pull Request** to the `main` branch.
+6. Submit a **Pull Request** to the `master` branch.
 
 ### 3. Style Guide & Standards
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,104 @@
+# KubeAid Governance
+
+This document defines governance policies for the KubeAid project.
+
+## Our Mission
+
+> **Kubernetes, the same way, everywhere — with the ecosystem churn handled for you.**
+
+Operating production Kubernetes means constantly tracking a moving ecosystem:
+deprecated charts, breaking API changes, shifting best practices, and security
+updates. Our goal is to carry that mental overhead for our users: one curated,
+tested platform definition that installs and operates the same way on every
+cloud and on bare metal, delivered as regular, reviewable updates through Git.
+
+KubeAid aims to make GitOps the default operating model for the whole platform,
+not an advanced add-on: every change lands as a Git commit, reconciled by
+ArgoCD, so a cluster's entire history is auditable and reproducible.
+
+## Core Values
+
+We believe a healthy open-source project is built on trust, merit, and
+accountability. KubeAid embraces the following values:
+
+* **Technical Excellence:** We aim to provide the safest, most predictable
+  Kubernetes platform available on any supported provider.
+* **Security and Quality by Design:** Charts are vendored and reviewed,
+  defaults are tested, and updates are shipped on a regular cycle — security
+  is part of the development lifecycle, not an afterthought.
+* **Community First:** The health of the project and its users comes before
+  the release schedule or goals of any single sponsoring organization. Every
+  contributor participates as an individual peer.
+* **Fairness and Meritocracy:** Contributions are evaluated on their technical
+  merit and value to the project, regardless of the contributor's employer.
+* **Radical Transparency:** Development happens in the open — issues, pull
+  requests, and design discussions are the default venue for decisions.
+
+## Maintainers
+
+Maintainers are the stewards of KubeAid. Being a maintainer is a privilege
+that comes with responsibility — it is reserved for individuals who have
+demonstrated sustained commitment to the project's health and growth.
+
+A maintainer is more than a contributor with write access. They are expected
+to:
+
+* Collaborate effectively with the wider community.
+* Facilitate reviews by connecting contributors with the right expertise.
+* Uphold high standards for code quality and test coverage.
+* Take ownership of issues through to resolution.
+
+All current maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+### Changes in Leadership
+
+The maintainer group is self-governing. New maintainers must be nominated by
+an existing maintainer. Both appointments and removals are decided by a
+**two-thirds (⅔) majority vote** of current maintainers.
+
+A maintainer who steps down, or is removed by vote, is acknowledged for their
+past contributions in the project's history and release notes.
+
+### GitHub Permissions
+
+* **Maintainers:** Have write access to the repository — managing issues,
+  reviewing pull requests, and merging code.
+* **Chart updates:** The automated weekly chart update cycle is overseen by
+  maintainers, since its output is delivered directly to users' mirrors.
+
+## Communication
+
+Discussion and design decisions happen in GitHub issues and pull requests by
+default. Anything sensitive — an unpatched security vulnerability, or a Code
+of Conduct report — is instead handled privately among maintainers, as
+described below.
+
+## Code of Conduct Enforcement
+
+KubeAid follows the [CNCF Community Code of Conduct](CODE_OF_CONDUCT.md).
+Reports concerning general community members are reviewed and resolved by the
+maintainers.
+
+**Reports against a maintainer:** the maintainer in question is recused from
+the discussion entirely. The remaining maintainers designate someone to
+oversee the resolution, involving an independent third party if needed to
+keep the process fair.
+
+## Decision Making
+
+### Lazy Consensus
+
+Most day-to-day changes operate on lazy consensus: a proposal or change is
+assumed accepted unless an objection is raised within a reasonable timeframe.
+This keeps the project moving without unnecessary process.
+
+### Voting
+
+Any maintainer may call for a formal vote on a specific decision, held in a
+GitHub Discussion, a maintainers-only channel (for security or conduct
+matters), or during a live discussion.
+
+* **Standard decisions** require a **simple majority (>50%)** of active
+  maintainers.
+* **Changes to this governance document** require a **two-thirds (⅔)
+  supermajority** of active maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# Maintainers
+
+This is the list of maintainers for KubeAid.
+
+The current maintainers of the KubeAid project are (in alphabetical order):
+
+| Maintainer | GitHub ID | Company/Organization |
+| ---------- | --------- | --------------------- |
+| Archisman Mridha | [@Archisman-Mridha](https://github.com/Archisman-Mridha) | Obmondo |
+| Ashish Jaiswal | [@ashish1099](https://github.com/ashish1099) | Obmondo |
+| Klavs Klavsen | [@KlavsKlavsen](https://github.com/KlavsKlavsen) | Obmondo |
+| Rishi Mondal | [@MAVRICK-1](https://github.com/MAVRICK-1) | Obmondo |
+| Shubham Singh | [@1Shubham7](https://github.com/1Shubham7) | Obmondo |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KubeAid: Kubernetes, the Same Way, Everywhere
+# KubeAid
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Obmondo/KubeAid)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
@@ -85,15 +85,15 @@ updates are delivered to you, so keeping it clean means updating your cluster is
 Install the [KubeAid CLI](https://github.com/Obmondo/kubeaid-cli/releases), then:
 
 ```sh
-# Generate configuration for your platform:
-#   local | aws | azure | hetzner hcloud | hetzner bare-metal | hetzner hybrid | bare-metal
-kubeaid-cli config generate local
+# Interactive prompt walks you through cluster name, platform
+# (local K3D, AWS, Azure, Hetzner, bare metal) and everything else
+kubeaid-cli config generate --configs-directory ./outputs/configs/<cluster>/
 
-# Review and edit the generated config, then bring the cluster up
-kubeaid-cli cluster bootstrap
+# Review the generated config, then bring the cluster up
+kubeaid-cli cluster bootstrap --configs-directory ./outputs/configs/<cluster>/
 ```
 
-`local` gives you a K3D playground on your own machine — the workflow is identical to a production cloud cluster. The
+Choosing local K3D gives you a playground on your own machine — the workflow is identical to a production cloud cluster. The
 **[Getting Started Guide](./docs/getting-started/README.md)** walks through prerequisites, configuration, installation,
 and day-2 operations for every supported platform.
 

--- a/README.md
+++ b/README.md
@@ -1,207 +1,165 @@
-# Welcome to **KubeAid**: Kubernetes, the Same Way, Everywhere
+# KubeAid: Kubernetes, the Same Way, Everywhere
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Obmondo/KubeAid)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 
-Everyone thinks installing Kubernetes on any cloud is easy. It's not.
-AWS has IAM. Azure has Workload Identity. Hetzner has its own model.
-Best practices differ *dramatically*, and that's just installation.
+**KubeAid is an open-source Kubernetes platform: one tested, maintained way to install and operate Kubernetes
+clusters on every platform** — AWS (self-managed or EKS), Azure (self-managed or AKS), Hetzner (HCloud and Bare
+Metal), on-premise bare metal, or locally on K3D.
 
-**KubeAid gives you one way to install and operate Kubernetes on any cloud (or your own servers)**, with GitOps,
-security, monitoring, and compliance built in from day one.
+Running Kubernetes means constantly tracking a moving ecosystem: which chart just got deprecated, which API version is
+about to break, which default is a security risk, what current best practice looks like. **KubeAid's job is to carry
+that mental overhead for you.** We curate the stack, test the defaults, track deprecations and breaking changes, and
+ship the result as regular updates — you review and pull them when it suits you. It also gives you a trustworthy
+source of Helm charts: every chart is vendored into this repository and updated through periodic, reviewed releases —
+not pulled live from upstream registries at deploy time — which protects you against supply-chain attacks.
+
+This repository holds the platform itself — curated Helm charts, monitoring, and secure defaults. It is consumed by
+the **[KubeAid CLI](https://github.com/Obmondo/kubeaid-cli)**, which is the tool you actually run to create and manage
+clusters.
 
 → [**Why KubeAid?**](./docs/kubeaid/why-kubeaid.md)
 · [**Getting Started**](./docs/getting-started/README.md)
 · [**Full Documentation**](./docs/README.md)
 
------------------
+## Table of Contents
 
-## What KubeAid Does
+- [What Exactly Is KubeAid?](#what-exactly-is-kubeaid)
+- [How It Works](#how-it-works)
+- [Quick Start](#quick-start)
+- [Features](#features)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Community and Governance](#community-and-governance)
+- [Roadmap](ROADMAP.md)
+- [Support](#support)
+- [License](#license)
 
-KubeAid is a comprehensive Kubernetes platform management system that provides production-ready cluster deployment and
-operations using GitOps principles. It delivers a complete stack (infrastructure provisioning, monitoring, security,
-networking, and data persistence), with everything managed as code through ArgoCD.
+## What Exactly Is KubeAid?
 
-* **Multi-cloud installation**: Deploy on AWS, Azure, Hetzner (HCloud and Bare Metal), and on-premise bare metal using
-  [Cluster API](https://cluster-api.sigs.k8s.io/). One install method, any target.
-* **100+ pre-configured Helm charts** in [`argocd-helm-charts`](./argocd-helm-charts/) with automated weekly updates.
-  We test and provide default values following best practices, handling the configuration complexity so you can focus on
-  your business logic.
-* **Comprehensive monitoring** using [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) with
-  [Jsonnet](https://jsonnet.org/)-based generation.
-* **Unified access management** through Teleport for Kubernetes, applications, and databases.
-* **Compliance by default**: Security and operational defaults mapped to ISO 27001:2022, covering GDPR and NIS2 goals.
-  [Learn more](https://obmondo.com/en/compliance).
+Installing Kubernetes looks easy until you do it on a second platform. AWS wants IAM roles, Azure wants Workload
+Identity, Hetzner and bare metal have their own models — and that's before monitoring, ingress, storage, and upgrades.
+KubeAid removes the per-platform relearning: one workflow, one repository layout, one set of defaults, everywhere.
 
-The entire platform is managed through a single Git repository where configuration changes can trigger deployments via
-ArgoCD. By default, auto-sync is not enabled, giving you full control over when changes are applied. You can enable
-auto-sync for your application workloads if you prefer automated deployments.
+It is three pieces that work together:
 
-## KubeAid Architecture Overview
+1. **This repository (KubeAid)** — the platform definition: 100+ maintained Helm chart wrappers in
+   [`argocd-helm-charts/`](./argocd-helm-charts/), with tested default values and automated weekly updates, plus
+   [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) monitoring generated with
+   [Jsonnet](https://jsonnet.org/). You don't run anything from here directly — it is consumed by the KubeAid CLI, and
+   later by ArgoCD from your own mirror of it. Mirroring it into your own Git platform means you keep full control
+   even if access to the upstream repository is ever lost.
+2. **[KubeAid CLI](https://github.com/Obmondo/kubeaid-cli)** — the entry point. A command-line tool you run once per
+   cluster: it consumes this repository, generates your configuration, and bootstraps the cluster using
+   [Cluster API](https://cluster-api.sigs.k8s.io/) (or [KubeOne](https://github.com/kubermatic/kubeone) for SSH-only
+   bare metal).
+3. **Your `kubeaid-config` repository** — generated for you during bootstrap; holds all your cluster-specific
+   settings, layered on top of your KubeAid mirror. ArgoCD inside the cluster watches it and applies changes, so Git
+   is the single source of truth for everything running in the cluster.
 
-KubeAid follows a GitOps-driven, automated approach to provision and manage production-ready Kubernetes clusters. The
-diagram below explains the high-level flow:
+Every KubeAid cluster ships with [Cilium](https://cilium.io/) (kube-proxyless),
+[ArgoCD](https://argo-cd.readthedocs.io/), [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets/), and
+kube-prometheus. By default, auto-sync is not enabled, so you decide when changes are applied; you can turn it on per
+application if you prefer automated deployments.
 
-```mermaid
----
-title: KubeAid Architecture
----
-flowchart TB
-    subgraph GitRepo["Git Repository"]
-        direction TB
-        modules["KubeAid Modules"]
-        yaml["YAML Configs"]
-        helm["Helm Charts"]
-    end
+## How It Works
 
-    subgraph ArgoCD["ArgoCD"]
-        direction TB
-        watch["Watches Git for changes"]
-        apply["Applies configs to cluster"]
-    end
-
-    subgraph Automation["KubeAid Automation Layer"]
-        direction TB
-        bootstrap["Cluster bootstrap & lifecycle management"]
-        addons["Add-ons installation<br/>(Ingress, Certs, Monitoring, etc.)"]
-        defaults["Secure defaults & best practices"]
-        upgrades["Automated upgrades and recovery"]
-    end
-
-    subgraph K8sCluster["KubeAid Kubernetes Cluster"]
-        direction TB
-        networking["Networking (CNI, Ingress)"]
-        storage["Storage (CSI, PVCs)"]
-        certs["Certificates (StepCA/Cert-Manager)"]
-        monitoring["Monitoring (Prometheus, Grafana)"]
-        logging["Logging & Alerting"]
-        workloads["Application Workloads"]
-    end
-
-    GitRepo -->|"GitOps Sync"| ArgoCD
-    ArgoCD -->|"Deploys / Updates"| Automation
-    Automation -->|"Provisions / Manages"| K8sCluster
-
-    style GitRepo fill:#4a90a4,stroke:#2d5a6b,color:#fff
-    style ArgoCD fill:#e8833a,stroke:#b35c1e,color:#fff
-    style Automation fill:#6b8e23,stroke:#4a6319,color:#fff
-    style K8sCluster fill:#7b68ee,stroke:#5a4bb8,color:#fff
-```
-
-## Setup of Kubernetes Clusters
-
-We use **KubeAid CLI** to set up and manage Kubernetes clusters. The CLI handles all the complexity of cluster
-provisioning, configuration, and lifecycle management.
-
-We recommend mirroring the KubeAid repository into your own Git platform. This ensures you own the product you are
-using. If access to the upstream KubeAid repository is ever lost, you still have full control over your infrastructure.
-
-You must NEVER make any changes on the master/main branch of your mirror of the KubeAid repository, as we use this to
-deliver updates to you. This means that your cluster can be updated simply by running `git pull` on your copy of this
-repository.
-
-After installation, you will work with a `kubeaid-config` repository that contains all your cluster-specific
-customisations. The [Getting Started Guide](./docs/getting-started/README.md) explains this workflow in detail.
-
-## Installation
-
-> 🎬 **[Watch the Installation Video](https://drive.google.com/file/d/1d9EdghntjDoJRkCHj-DeRiEMfQ4xjBbw/view?usp=sharing)**-
-a step-by-step walkthrough of setting up KubeAid via KubeAid-cli.
-
-For complete installation instructions, see the **[Getting Started Guide](./docs/getting-started/README.md)** which
-includes:
-
-* Prerequisites and pre-configuration
-* Installation (supports AWS, Azure, Hetzner HCloud, Hetzner Bare Metal, and Local K3D)
-* Post-configuration and basic operations
-
-For hosting-specific reference and operations guides, see the [documentation](./docs/README.md).
-
-## Support
-
-Besides community support, [Obmondo](https://obmondo.com) (the primary developers of this project) offers professional
-support services. We can observe your clusters, react to your alerts, and help you develop new features or other tasks
-on clusters set up using this project.
-
-There is ZERO vendor lock-in. Any subscription you sign can be cancelled at any time. You only pay for one month at a
-time.
-
-With a subscription, we will ensure smooth operations for you. We will speed up your development efforts on KubeAid if
-needed.
-
-## Secrets
-
-We use [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets/) which means secrets are encrypted locally (by
-the developer who knows them) and committed to your KubeAid config repository.
-
-You can read the sealed-secrets details in the [sealed-secrets README](./argocd-helm-charts/sealed-secrets/README.md).
-
-## License
-
-**KubeAid** is licensed under the Affero GPLv3 license, as we believe this is the best way to protect against the patent
-attacks we see hurting the industry; where companies submit code that uses technology they have patented, and then turn
-and litigate companies that use the software.
-
-The Affero GNU Public License has always been focused on ensuring everyone gets the same privileges, protecting against
-methods
-like [TiVoization](https://en.wikipedia.org/wiki/Tivoization), which means it's very much aligned with the goals of this
-project, namely to allow everyone to work on a level playing ground.
-
-## Feature Goals
+The KubeAid CLI runs once to bootstrap: it generates your `kubeaid-config` repository and provisions the cluster. From
+then on, ArgoCD inside the cluster continuously syncs from `kubeaid-config`, reconciling both the platform stack and
+your applications:
 
 <!-- markdownlint-disable MD033 -->
-<details>
-<summary>Click to expand the full feature list</summary>
-
-* Set up Kubernetes clusters on:
-  * **Physical servers**: On-premise and [Hetzner](https://www.hetzner.com/) Bare Metal
-  * **Cloud VMs**: [Hetzner HCloud](https://www.hetzner.com/cloud), [AWS](https://aws.amazon.com/), and
-    [Azure](https://azure.microsoft.com/)
-  * **Hybrid clusters**: Combining Hetzner Bare Metal with HCloud VMs
-* Auto-scaling for all cloud Kubernetes clusters and easy scaling for physical servers
-* Manage an ever-growing list of Open Source Kubernetes applications (see [`argocd-helm-charts`](./argocd-helm-charts/)
-  folder for a list)
-* Build advanced, customised Prometheus monitoring using just a per-cluster config file, with automated handling of
-  trivial alerts, like disk filling.
-* GitOps setup - ALL changes in a cluster are done via Git AND we detect if anyone adds anything in cluster or modifies
-  existing resources without doing it through Git.
-* Frequent updates for KubeAid-managed applications with security and bug fixes, ready to be issued to your cluster(s)
-  at will - so you can focus on your business applications.
-* [Air-gapped operation](https://kubernetes.io/blog/2023/10/12/bootstrap-an-air-gapped-cluster-with-kubeadm/) of your
-  clusters, to ensure operational stability
-* Cluster security - we provide proper NetworkPolicies to secure intra-cluster and ingress traffic, ensuring least
-  privilege between applications
-* Backup, recovery and live migration of applications or entire clusters
-* Major cluster upgrades via a shadow Kubernetes setup (a parallel failover cluster that allows you to test upgrades and
-  seamlessly switch over), utilising the recovery and live migration features
-* Supply chain attack protection and discovery, with frequent security scans of all software used in the clusters (as
-  new vulnerabilities are constantly being discovered)
-
-</details>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./docs/images/kubeaid-architecture-dark.svg">
+  <img alt="KubeAid architecture diagram: the KubeAid CLI bootstraps once, then ArgoCD continuously syncs the cluster
+    from your kubeaid-config repository, which is layered on your KubeAid mirror"
+    src="./docs/images/kubeaid-architecture.svg">
+</picture>
 <!-- markdownlint-enable MD033 -->
 
-## Technical Details on the Features
+One rule to know up front: never commit directly to the master/main branch of your KubeAid mirror — that branch is how
+updates are delivered to you, so keeping it clean means updating your cluster is as simple as a `git pull`.
 
-Read about the current status of all features of KubeAid from these links:
+## Quick Start
 
-* [GitOps setup and change detection](./docs/kubeaid/features-technical-details.md#gitops-setup-and-change-detection)
-* [Auto-scaling for all cloud Kubernetes clusters and easy scaling for physical
-  servers](./docs/kubeaid/features-technical-details.md#auto-scaling-for-all-cloud-kubernetes-clusters-and-easy-scaling-for-physical-servers)
-* [Manage an ever-growing list of Open Source Kubernetes
-  applications](./docs/kubeaid/features-technical-details.md#manage-an-ever-growing-list-of-open-source-kubernetes-applications-see-argocd-helm-charts-folder-for-a-list)
-* [Build advanced, customised Prometheus monitoring using just a per-cluster config
-  file](./docs/kubeaid/features-technical-details.md#build-advanced-customised-prometheus-monitoring-using-just-a-per-cluster-config-file)
-* [Regular application updates with security and bug fixes, ready to be issued to your cluster(s) at
-  will](./docs/kubeaid/features-technical-details.md#regular-application-updates-with-security-and-bug-fixes-ready-to-be-issued-to-your-clusters-at-will)
-* [Air-gapped operation of your clusters, to ensure operational
-  stability](./docs/kubeaid/features-technical-details.md#air-gapped-operation-of-your-clusters-to-ensure-operational-stability)
-* [Cluster security](./docs/kubeaid/features-technical-details.md#cluster-security)
-* [Backup, recovery and live-migration of applications or entire
-  clusters](./docs/kubeaid/features-technical-details.md#backup-recovery-and-live-migration-of-applications-or-entire-clusters)
-* [Major cluster upgrades, via a shadow Kubernetes setup utilising the recovery and live-migration
-  features](./docs/kubeaid/features-technical-details.md#major-cluster-upgrades-via-a-shadow-kubernetes-setup-utilising-the-recovery-and-live-migration-features)
-* [Supply chain attack protection and discovery - and security scans of all software used in
-  cluster](./docs/kubeaid/features-technical-details.md#supply-chain-attack-protection-and-discovery---and-security-scans-of-all-software-used-in-cluster)
+Install the [KubeAid CLI](https://github.com/Obmondo/kubeaid-cli/releases), then:
+
+```sh
+# Generate configuration for your platform:
+#   local | aws | azure | hetzner hcloud | hetzner bare-metal | hetzner hybrid | bare-metal
+kubeaid-cli config generate local
+
+# Review and edit the generated config, then bring the cluster up
+kubeaid-cli cluster bootstrap
+```
+
+`local` gives you a K3D playground on your own machine — the workflow is identical to a production cloud cluster. The
+**[Getting Started Guide](./docs/getting-started/README.md)** walks through prerequisites, configuration, installation,
+and day-2 operations for every supported platform.
+
+## Features
+
+* **No-mental-overhead updates**: we track what's broken, deprecated, or superseded across the whole stack, and ship
+  tested chart and security updates weekly — ready to be applied to your clusters at will, so you can focus on your
+  own applications.
+* **Multi-cloud installation**: self-managed clusters on AWS, Azure, Hetzner, and bare metal; managed control planes
+  on [EKS](https://aws.amazon.com/eks/) and
+  [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service); hybrid Hetzner Bare Metal + HCloud clusters.
+  One install method, any target.
+* **GitOps everything**: all cluster changes go through Git, and drift is detected if anyone changes resources
+  directly in the cluster.
+* **Curated application catalogue**: an ever-growing list of open-source Kubernetes applications in
+  [`argocd-helm-charts/`](./argocd-helm-charts/), each wrapped with default values that follow current best practices.
+  Upstream charts are vendored into this repository, so what you deploy is exactly what was reviewed — a defence
+  against supply-chain attacks, backed by frequent security scans of all software used in the clusters.
+* **Monitoring built in**: advanced, customised Prometheus monitoring from a per-cluster config file, with automated
+  handling of trivial alerts like disks filling up.
+* **Secrets in Git, safely**: [sealed-secrets](./argocd-helm-charts/sealed-secrets/README.md) encrypts secrets locally
+  before they are committed to your config repository.
+* **Unified access management** through Teleport for Kubernetes, applications, and databases.
+* **Cluster security**: NetworkPolicies enforce least privilege between applications and secure intra-cluster and
+  ingress traffic.
+* **Lifecycle operations**: auto-scaling, backup and recovery, live migration of applications or whole clusters, major
+  upgrades via a parallel shadow cluster, and [air-gapped
+  operation](https://kubernetes.io/blog/2023/10/12/bootstrap-an-air-gapped-cluster-with-kubeadm/).
+* **Compliance by default**: security and operational defaults mapped to ISO 27001:2022, covering GDPR and NIS2 goals.
+
+The implementation status of each feature is documented in
+[Technical Details on the Features](./docs/kubeaid/features-technical-details.md); planned work lives in the
+[Roadmap](ROADMAP.md).
 
 ## Documentation
 
 You can find the documentation, guides and tutorials in the [`/docs`](./docs/) directory.
+
+## Contributing
+
+Contributions are welcome — bug reports, chart updates, new providers, and documentation alike. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for the workflow; note that commits need a DCO sign-off (`git commit -s`).
+
+## Community and Governance
+
+- [Code of Conduct](CODE_OF_CONDUCT.md) — we follow the CNCF Community Code of Conduct.
+- [Governance](GOVERNANCE.md) — how decisions are made and how maintainers are added.
+- [Maintainers](MAINTAINERS.md) — current maintainers of the project.
+- [Adopters](ADOPTERS.md) — organizations running KubeAid; add yours with a PR.
+- [Security policy](SECURITY.md) — how to report vulnerabilities privately.
+
+## Support
+
+Community support happens through the issue tracker. Besides that, [Obmondo](https://obmondo.com) (the primary
+developers of this project) offers professional support: we can observe your clusters, react to your alerts, and help
+you develop new features on clusters set up using this project.
+
+There is zero vendor lock-in — KubeAid works the same with or without a support agreement, and any agreement can be
+cancelled at any time.
+
+## License
+
+**KubeAid** is licensed under the [Affero GPLv3 license](LICENSE), as we believe this is the best way to protect
+against the patent attacks we see hurting the industry; where companies submit code that uses technology they have
+patented, and then turn and litigate companies that use the software.
+
+The Affero GNU Public License has always been focused on ensuring everyone gets the same privileges, protecting against
+methods like [TiVoization](https://en.wikipedia.org/wiki/Tivoization), which means it's very much aligned with the goals
+of this project, namely to allow everyone to work on a level playing ground.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,48 @@
+# Roadmap
+
+High-level feature goals for KubeAid. The current implementation status of
+each item — what's done, what's in progress, and how it works — is documented
+in [Technical Details on the
+Features](./docs/kubeaid/features-technical-details.md).
+
+This roadmap reflects current priorities and will shift as the project and
+its users grow; it isn't a committed release schedule.
+
+## Feature goals
+
+* Set up Kubernetes clusters on:
+  * **Physical servers**: On-premise and [Hetzner](https://www.hetzner.com/) Bare Metal
+  * **Cloud VMs**: [Hetzner HCloud](https://www.hetzner.com/cloud), [AWS](https://aws.amazon.com/), and
+    [Azure](https://azure.microsoft.com/)
+  * **Managed control planes**: [AWS EKS](https://aws.amazon.com/eks/) and
+    [Azure AKS](https://azure.microsoft.com/en-us/products/kubernetes-service)
+  * **Hybrid clusters**: Combining Hetzner Bare Metal with HCloud VMs
+* Auto-scaling for all cloud Kubernetes clusters and easy scaling for physical
+  servers
+* Manage an ever-growing list of open-source Kubernetes applications (see the
+  [`argocd-helm-charts/`](./argocd-helm-charts/) folder for the current list)
+* Build advanced, customised Prometheus monitoring using just a per-cluster
+  config file, with automated handling of trivial alerts, like disk filling
+* GitOps setup — ALL changes in a cluster are done via Git, AND we detect if
+  anyone adds anything in the cluster or modifies existing resources without
+  doing it through Git
+* Frequent updates for KubeAid-managed applications with security and bug
+  fixes, ready to be issued to your cluster(s) at will — so you can focus on
+  your business applications
+* [Air-gapped operation](https://kubernetes.io/blog/2023/10/12/bootstrap-an-air-gapped-cluster-with-kubeadm/)
+  of your clusters, to ensure operational stability
+* Cluster security — proper NetworkPolicies to secure intra-cluster and
+  ingress traffic, ensuring least privilege between applications
+* Backup, recovery and live migration of applications or entire clusters
+* Major cluster upgrades via a shadow Kubernetes setup (a parallel failover
+  cluster that allows you to test upgrades and seamlessly switch over),
+  utilising the recovery and live migration features
+* Supply-chain attack protection and discovery, with frequent security scans
+  of all software used in the clusters (as new vulnerabilities are constantly
+  being discovered)
+
+## Contributing to the roadmap
+
+Have a use case this doesn't cover, or want to work on one of the items
+above? Open an [issue](https://github.com/Obmondo/KubeAid/issues) — see
+[CONTRIBUTING.md](./CONTRIBUTING.md) for how to get started.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report it privately via
+[GitHub Security Advisories](https://github.com/Obmondo/KubeAid/security/advisories/new)
+for this repository. A maintainer (see [MAINTAINERS.md](MAINTAINERS.md)) will
+acknowledge the report, work with you to understand and validate the impact,
+and coordinate a fix and disclosure timeline before any public advisory goes
+out.
+
+If you'd rather not use GitHub, you can also report security issues directly
+to [info@obmondo.com](mailto:info@obmondo.com).
+
+## Supported Versions
+
+KubeAid delivers updates on the `master` branch — clusters are kept current by
+pulling the latest state into your mirror; there are no long-term-support
+branches. Security fixes for the charts and defaults land on `master` as part
+of the regular update cycle — please update your mirror before reporting an
+issue that may already be fixed.
+
+## Scope
+
+This policy covers the contents of this repository: the Helm chart wrappers in
+`argocd-helm-charts/`, their default values, and the Jsonnet-based monitoring
+configuration. Vulnerabilities in the upstream applications packaged by these
+charts should be reported to those projects directly — though we track their
+releases and ship updated chart versions as part of the regular update cycle.

--- a/docs/images/kubeaid-architecture-dark.svg
+++ b/docs/images/kubeaid-architecture-dark.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1160 505" font-family="-apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" role="img" aria-label="KubeAid architecture: KubeAid CLI bootstraps once - writing your initial kubeaid-config and provisioning the cluster. From then on ArgoCD inside the cluster continuously syncs from kubeaid-config, which is layered on your KubeAid mirror, reconciling the platform stack and your applications. Cluster API is pivoted into the cluster so it manages its own nodes.">
+  <!--
+    KubeAid architecture diagram (dark theme).
+    The dark variant (kubeaid-architecture-dark.svg) is generated from kubeaid-architecture.svg
+    by palette swap - edit the light file first, then mirror the change here.
+  -->
+  <style>
+    .card    { fill: #15222F; stroke: #2C3E50; stroke-width: 1; }
+    .panel   { fill: #111C28; }
+    .chip    { fill: #223447; }
+    .chiptx  { font-size: 12px; font-weight: 500; fill: #AFC6DA; }
+    .title   { font-size: 16px; font-weight: 700; fill: #E5ECF2; }
+    .ctitle  { font-size: 15px; font-weight: 600; fill: #E5ECF2; }
+    .stitle  { font-size: 13px; font-weight: 600; fill: #E5ECF2; }
+    .sub     { font-size: 12px; fill: #9FB2C2; }
+    .glabel  { font-size: 11px; font-weight: 600; letter-spacing: 1.4px; fill: #7E93A8; }
+    .edge    { fill: none; stroke: #7E9CB8; stroke-width: 1.6; stroke-dasharray: 5 5; }
+    .edgeac  { fill: none; stroke: #F0435E; stroke-width: 2.2; }
+    .badge   { fill: #15222F; stroke: #7E9CB8; stroke-width: 1.4; }
+    .badgeac { fill: #15222F; stroke: #F0435E; stroke-width: 1.4; }
+    .badgetx { font-size: 11px; font-weight: 600; fill: #7E9CB8; }
+    .badgeactx { font-size: 11px; font-weight: 600; fill: #F0435E; }
+    .legend  { font-size: 12px; fill: #9FB2C2; }
+    .pill    { fill: #3A2028; }
+    .pilltx  { font-size: 11px; font-weight: 600; fill: #F0435E; }
+    .glyph   { font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; font-size: 13px; font-weight: 700; fill: #F0435E; }
+  </style>
+  <defs>
+    <marker id="arw" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#7E9CB8"/>
+    </marker>
+    <marker id="arwA" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#F0435E"/>
+    </marker>
+  </defs>
+
+  <!-- KubeAid CLI -->
+  <rect class="card" x="40" y="150" width="240" height="130" rx="14"/>
+  <rect class="pill" x="64" y="172" width="28" height="28" rx="8"/>
+  <text class="glyph" x="78" y="191" text-anchor="middle">&gt;_</text>
+  <rect class="pill" x="176" y="175" width="80" height="22" rx="11"/>
+  <text class="pilltx" x="216" y="190" text-anchor="middle">runs once</text>
+  <text class="title" x="64" y="230">KubeAid CLI</text>
+  <text class="sub" x="64" y="252">provisions clusters · generates config</text>
+
+  <!-- Your Git platform -->
+  <rect class="panel" x="340" y="80" width="290" height="320" rx="16"/>
+  <text class="glabel" x="364" y="112">YOUR GIT PLATFORM</text>
+
+  <!-- mirror card sits behind config card: config is layered on the mirror -->
+  <rect class="card" x="376" y="232" width="218" height="96" rx="12"/>
+  <text class="ctitle" x="485" y="276" text-anchor="middle">KubeAid mirror</text>
+  <text class="sub" x="485" y="298" text-anchor="middle">platform defaults · 100+ charts</text>
+
+  <rect class="card" x="364" y="138" width="242" height="110" rx="12"/>
+  <text class="ctitle" x="485" y="182" text-anchor="middle">kubeaid-config</text>
+  <text class="sub" x="485" y="204" text-anchor="middle">your cluster-specific overrides</text>
+
+  <text class="sub" x="485" y="376" text-anchor="middle" font-size="11">config is layered on the mirror — you own both repos</text>
+
+  <!-- Your cluster -->
+  <rect class="panel" x="690" y="40" width="430" height="400" rx="16"/>
+  <text class="glabel" x="714" y="72">YOUR CLUSTER — ANY CLOUD OR BARE METAL</text>
+
+  <rect class="card" x="795" y="92" width="190" height="68" rx="12"/>
+  <text class="ctitle" x="890" y="122" text-anchor="middle">ArgoCD</text>
+  <text class="sub" x="890" y="142" text-anchor="middle">GitOps controller</text>
+
+  <path d="M 882,172 l 8,8 l 8,-8" fill="none" stroke="#7E93A8" stroke-width="2"/>
+
+  <text class="stitle" x="714" y="212">Platform stack</text>
+  <rect class="chip" x="714" y="224" width="68" height="28" rx="14"/>
+  <text class="chiptx" x="748" y="242" text-anchor="middle">Cilium</text>
+  <rect class="chip" x="792" y="224" width="106" height="28" rx="14"/>
+  <text class="chiptx" x="845" y="242" text-anchor="middle">cert-manager</text>
+  <rect class="chip" x="908" y="224" width="126" height="28" rx="14"/>
+  <text class="chiptx" x="971" y="242" text-anchor="middle">kube-prometheus</text>
+  <rect class="chip" x="714" y="260" width="110" height="28" rx="14"/>
+  <text class="chiptx" x="769" y="278" text-anchor="middle">Sealed Secrets</text>
+  <rect class="chip" x="834" y="260" width="66" height="28" rx="14"/>
+  <text class="chiptx" x="867" y="278" text-anchor="middle">Velero</text>
+  <rect class="chip" x="910" y="260" width="92" height="28" rx="14"/>
+  <text class="chiptx" x="956" y="278" text-anchor="middle">Rook-Ceph</text>
+
+  <rect class="card" x="714" y="330" width="186" height="60" rx="12"/>
+  <text class="stitle" x="807" y="365" text-anchor="middle">Your applications</text>
+
+  <rect class="card" x="920" y="330" width="176" height="60" rx="12"/>
+  <text class="stitle" x="1008" y="354" text-anchor="middle">Cluster API</text>
+  <text class="sub" x="1008" y="372" text-anchor="middle" font-size="11">self-managed node lifecycle</text>
+
+  <!-- 1: bootstrap writes the initial config -->
+  <path class="edge" d="M 280,200 H 336" marker-end="url(#arw)"/>
+  <circle class="badge" cx="308" cy="200" r="10"/>
+  <text class="badgetx" x="308" y="204" text-anchor="middle">1</text>
+
+  <!-- 2: bootstrap provisions the cluster -->
+  <path class="edge" d="M 160,280 V 420 H 686" marker-end="url(#arw)"/>
+  <circle class="badge" cx="420" cy="420" r="10"/>
+  <text class="badgetx" x="420" y="424" text-anchor="middle">2</text>
+
+  <!-- 3: continuous GitOps sync (accent) -->
+  <path class="edgeac" d="M 606,193 H 660 V 126 H 791" marker-end="url(#arwA)"/>
+  <circle class="badgeac" cx="660" cy="160" r="10"/>
+  <text class="badgeactx" x="660" y="164" text-anchor="middle">3</text>
+
+  <!-- legend -->
+  <circle class="badge" cx="54" cy="478" r="10"/>
+  <text class="badgetx" x="54" y="482" text-anchor="middle">1</text>
+  <text class="legend" x="72" y="482">bootstrap — writes your initial config (runs once)</text>
+  <circle class="badge" cx="470" cy="478" r="10"/>
+  <text class="badgetx" x="470" y="482" text-anchor="middle">2</text>
+  <text class="legend" x="488" y="482">bootstrap — provisions the cluster, pivots Cluster API into it</text>
+  <circle class="badgeac" cx="880" cy="478" r="10"/>
+  <text class="badgeactx" x="880" y="482" text-anchor="middle">3</text>
+  <text class="legend" x="898" y="482">operations — continuous GitOps sync</text>
+</svg>

--- a/docs/images/kubeaid-architecture.svg
+++ b/docs/images/kubeaid-architecture.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1160 505" font-family="-apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" role="img" aria-label="KubeAid architecture: KubeAid CLI bootstraps once - writing your initial kubeaid-config and provisioning the cluster. From then on ArgoCD inside the cluster continuously syncs from kubeaid-config, which is layered on your KubeAid mirror, reconciling the platform stack and your applications. Cluster API is pivoted into the cluster so it manages its own nodes.">
+  <!--
+    KubeAid architecture diagram (light theme).
+    The dark variant (kubeaid-architecture-dark.svg) is generated from this file
+    by swapping the palette - edit this file first, then mirror the change there.
+  -->
+  <style>
+    .card    { fill: #FFFFFF; stroke: #D8E1E8; stroke-width: 1; }
+    .panel   { fill: #EEF3F7; }
+    .chip    { fill: #E3ECF3; }
+    .chiptx  { font-size: 12px; font-weight: 500; fill: #33506B; }
+    .title   { font-size: 16px; font-weight: 700; fill: #16283A; }
+    .ctitle  { font-size: 15px; font-weight: 600; fill: #16283A; }
+    .stitle  { font-size: 13px; font-weight: 600; fill: #16283A; }
+    .sub     { font-size: 12px; fill: #5B7186; }
+    .glabel  { font-size: 11px; font-weight: 600; letter-spacing: 1.4px; fill: #7A8FA3; }
+    .edge    { fill: none; stroke: #4A6B8A; stroke-width: 1.6; stroke-dasharray: 5 5; }
+    .edgeac  { fill: none; stroke: #C8102E; stroke-width: 2.2; }
+    .badge   { fill: #FFFFFF; stroke: #4A6B8A; stroke-width: 1.4; }
+    .badgeac { fill: #FFFFFF; stroke: #C8102E; stroke-width: 1.4; }
+    .badgetx { font-size: 11px; font-weight: 600; fill: #4A6B8A; }
+    .badgeactx { font-size: 11px; font-weight: 600; fill: #A50D26; }
+    .legend  { font-size: 12px; fill: #5B7186; }
+    .pill    { fill: #F8E3E7; }
+    .pilltx  { font-size: 11px; font-weight: 600; fill: #A50D26; }
+    .glyph   { font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; font-size: 13px; font-weight: 700; fill: #A50D26; }
+  </style>
+  <defs>
+    <marker id="arw" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#4A6B8A"/>
+    </marker>
+    <marker id="arwA" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#C8102E"/>
+    </marker>
+  </defs>
+
+  <!-- KubeAid CLI -->
+  <rect class="card" x="40" y="150" width="240" height="130" rx="14"/>
+  <rect class="pill" x="64" y="172" width="28" height="28" rx="8"/>
+  <text class="glyph" x="78" y="191" text-anchor="middle">&gt;_</text>
+  <rect class="pill" x="176" y="175" width="80" height="22" rx="11"/>
+  <text class="pilltx" x="216" y="190" text-anchor="middle">runs once</text>
+  <text class="title" x="64" y="230">KubeAid CLI</text>
+  <text class="sub" x="64" y="252">provisions clusters · generates config</text>
+
+  <!-- Your Git platform -->
+  <rect class="panel" x="340" y="80" width="290" height="320" rx="16"/>
+  <text class="glabel" x="364" y="112">YOUR GIT PLATFORM</text>
+
+  <!-- mirror card sits behind config card: config is layered on the mirror -->
+  <rect class="card" x="376" y="232" width="218" height="96" rx="12"/>
+  <text class="ctitle" x="485" y="276" text-anchor="middle">KubeAid mirror</text>
+  <text class="sub" x="485" y="298" text-anchor="middle">platform defaults · 100+ charts</text>
+
+  <rect class="card" x="364" y="138" width="242" height="110" rx="12"/>
+  <text class="ctitle" x="485" y="182" text-anchor="middle">kubeaid-config</text>
+  <text class="sub" x="485" y="204" text-anchor="middle">your cluster-specific overrides</text>
+
+  <text class="sub" x="485" y="376" text-anchor="middle" font-size="11">config is layered on the mirror — you own both repos</text>
+
+  <!-- Your cluster -->
+  <rect class="panel" x="690" y="40" width="430" height="400" rx="16"/>
+  <text class="glabel" x="714" y="72">YOUR CLUSTER — ANY CLOUD OR BARE METAL</text>
+
+  <rect class="card" x="795" y="92" width="190" height="68" rx="12"/>
+  <text class="ctitle" x="890" y="122" text-anchor="middle">ArgoCD</text>
+  <text class="sub" x="890" y="142" text-anchor="middle">GitOps controller</text>
+
+  <path d="M 882,172 l 8,8 l 8,-8" fill="none" stroke="#7A8FA3" stroke-width="2"/>
+
+  <text class="stitle" x="714" y="212">Platform stack</text>
+  <rect class="chip" x="714" y="224" width="68" height="28" rx="14"/>
+  <text class="chiptx" x="748" y="242" text-anchor="middle">Cilium</text>
+  <rect class="chip" x="792" y="224" width="106" height="28" rx="14"/>
+  <text class="chiptx" x="845" y="242" text-anchor="middle">cert-manager</text>
+  <rect class="chip" x="908" y="224" width="126" height="28" rx="14"/>
+  <text class="chiptx" x="971" y="242" text-anchor="middle">kube-prometheus</text>
+  <rect class="chip" x="714" y="260" width="110" height="28" rx="14"/>
+  <text class="chiptx" x="769" y="278" text-anchor="middle">Sealed Secrets</text>
+  <rect class="chip" x="834" y="260" width="66" height="28" rx="14"/>
+  <text class="chiptx" x="867" y="278" text-anchor="middle">Velero</text>
+  <rect class="chip" x="910" y="260" width="92" height="28" rx="14"/>
+  <text class="chiptx" x="956" y="278" text-anchor="middle">Rook-Ceph</text>
+
+  <rect class="card" x="714" y="330" width="186" height="60" rx="12"/>
+  <text class="stitle" x="807" y="365" text-anchor="middle">Your applications</text>
+
+  <rect class="card" x="920" y="330" width="176" height="60" rx="12"/>
+  <text class="stitle" x="1008" y="354" text-anchor="middle">Cluster API</text>
+  <text class="sub" x="1008" y="372" text-anchor="middle" font-size="11">self-managed node lifecycle</text>
+
+  <!-- 1: bootstrap writes the initial config -->
+  <path class="edge" d="M 280,200 H 336" marker-end="url(#arw)"/>
+  <circle class="badge" cx="308" cy="200" r="10"/>
+  <text class="badgetx" x="308" y="204" text-anchor="middle">1</text>
+
+  <!-- 2: bootstrap provisions the cluster -->
+  <path class="edge" d="M 160,280 V 420 H 686" marker-end="url(#arw)"/>
+  <circle class="badge" cx="420" cy="420" r="10"/>
+  <text class="badgetx" x="420" y="424" text-anchor="middle">2</text>
+
+  <!-- 3: continuous GitOps sync (accent) -->
+  <path class="edgeac" d="M 606,193 H 660 V 126 H 791" marker-end="url(#arwA)"/>
+  <circle class="badgeac" cx="660" cy="160" r="10"/>
+  <text class="badgeactx" x="660" y="164" text-anchor="middle">3</text>
+
+  <!-- legend -->
+  <circle class="badge" cx="54" cy="478" r="10"/>
+  <text class="badgetx" x="54" y="482" text-anchor="middle">1</text>
+  <text class="legend" x="72" y="482">bootstrap — writes your initial config (runs once)</text>
+  <circle class="badge" cx="470" cy="478" r="10"/>
+  <text class="badgetx" x="470" y="482" text-anchor="middle">2</text>
+  <text class="legend" x="488" y="482">bootstrap — provisions the cluster, pivots Cluster API into it</text>
+  <circle class="badgeac" cx="880" cy="478" r="10"/>
+  <text class="badgeactx" x="880" y="482" text-anchor="middle">3</text>
+  <text class="legend" x="898" y="482">operations — continuous GitOps sync</text>
+</svg>


### PR DESCRIPTION
## What

Rewrites the README from the perspective of a developer evaluating the project, and brings the repository up to the same CNCF project standard kubeaid-cli already follows.

### README
- Explains exactly what KubeAid is: the platform definition (vendored charts + monitoring + defaults) **consumed by kubeaid-cli**, which is the tool you actually run — plus your generated `kubeaid-config` repo synced by ArgoCD.
- Leads with the core value proposition: no mental overhead about what's broken/deprecated/current best practice — KubeAid carries that churn and ships it as regular, reviewed updates; vendored charts with periodic releases as supply-chain protection.
- Adds EKS/AKS managed control planes (merged this week) to the supported platforms.
- Adds a concrete quick start (`config generate` → `cluster bootstrap`).
- Removes the Google Drive installation-video link.
- Replaces the mermaid architecture diagram with a light/dark SVG pair (placeholder — diagram to be revisited separately).
- Moves the support section to the bottom and trims the subscription wording.

### CNCF standard files (mirrored from kubeaid-cli)
- `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `SECURITY.md`, `ADOPTERS.md`
- `ROADMAP.md` — the Feature Goals list moved here from the README, linking to the technical-details doc for status
- `CONTRIBUTING.md` now points PRs at `master` (was `main`)

## Review notes
- MAINTAINERS/ADOPTERS were adapted from kubeaid-cli — please check the lists apply to this repo as-is.
- The architecture diagram swap is a stopgap; happy to redo it once we've talked about what it should show.