### PR TITLE
docs: fix commands, paths and examples to match kubeaid-cli reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This repository holds the platform itself — curated Helm charts, monitoring, a
 the **[KubeAid CLI](https://github.com/Obmondo/kubeaid-cli)**, which is the tool you actually run to create and manage
 clusters.
 
-→ [**Why KubeAid?**](./docs/kubeaid/why-kubeaid.md)
-· [**Getting Started**](./docs/getting-started/README.md)
-· [**Full Documentation**](./docs/README.md)
+→ [**Why KubeAid?**](https://kubeaid.io/docs/kubeaid/why-kubeaid)
+· [**Getting Started**](https://kubeaid.io/docs/getting-started/)
+· [**Full Documentation**](https://kubeaid.io/docs/)
 
 ## Table of Contents
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -205,14 +205,14 @@ fi
 
 git tag -a "$NEW_TAG" -m "Kubeaid Release $NEW_TAG"
 
-echo "Pushing changelog changes to Gitea"
+echo "Pushing changelog changes to GitHub (origin)"
 git push origin master
 
-echo "Pushing tag to Gitea"
+echo "Pushing tag to GitHub (origin)"
 git push origin "$NEW_TAG"
 
-echo "Pushing changelog changes to Internal Gitea"
+echo "Pushing changelog changes to internal Gitea"
 git push gitea master
 
-echo "Pushing tag to Internal Gitea"
+echo "Pushing tag to internal Gitea"
 git push gitea "$NEW_TAG"

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,8 @@ Hosting-specific details and considerations:
 | [Bare Metal](./hosting/bare-metal.md) | On-premise dedicated servers |
 | [Single Host K8s](./hosting/single-host-k8s.md) | Single-node deployments |
 | [Hybrid Setup](./hosting/hybrid-setup.md) | Mixed cloud and bare metal |
+| [Hetzner Server Buying Guide](./guides/hetzner-server-buy-guides.md) | Bare metal and HCloud server purchasing recommendations |
+| [Harbor Registry](./guides/harbor-registry.md) | Host your own central container registry |
 
 ### Operations
 
@@ -52,6 +54,7 @@ Guides for ongoing cluster management:
 | [Node Reboot](./operations/node-reboot.md) | Safe node maintenance |
 | [Node Disk Repair](./operations/fixing-a-k8s-node-disk.md) | Procedure to replace and fix corrupted node disks |
 | [AWS Private Link Setup](./operations/aws-private-link-setup.md) | Cross-account connectivity |
+| [Updating Your Kubernetes Cluster](./updating-your-kubernetes-cluster.md) | Service windows and stakeholder communication for upgrades |
 | [Operations Tips](./operations/operations-tips.md) | Legacy operational procedures and debugging |
 
 #### Monitoring
@@ -87,13 +90,13 @@ Guides for ongoing cluster management:
 | [Features Technical Details](./kubeaid/features-technical-details.md) | In-depth feature documentation |
 | [Helm Umbrella Pattern](./kubeaid/helm-umbrella-pattern.md) | How KubeAid manages applications |
 | [Prometheus Configuration](./kubeaid/prometheus-configuration.md) | Configuring monitoring with kube-prometheus |
-| [Monitoring](./monitoring.md) | Metrics and log monitoring overview |
 | [GitOps Drift Detection](./kubeaid/gitops-drift-detection.md) | ArgoCD sync status and alerting |
 
 ### Architecture & Decisions
 
 | Guide | Description |
 | ------- | ------------- |
+| [Cluster Design](./cluster-design.md) | Control plane, storage, and database HA design principles |
 | [Architecture Decisions](../decisions.md) | Technical choices and architectural evolution |
 | [GitOps Decision Record](../decisions/gitops.md) | Real-world GitOps patterns and incident lessons |
 

--- a/docs/cluster-design.md
+++ b/docs/cluster-design.md
@@ -669,8 +669,6 @@ kubectl taint nodes <cp-node> node-role.kubernetes.io/control-plane:NoSchedule
 2. Add more worker nodes
 3. Migrate to Ceph storage
 
-See: [Hetzner CSI Volume Limit Debugging](../guides/storage/hetzner/hetzner-csi-volume-limit-debugging.md)
-
 ### "Database not recovering after node failure"
 
 **Cause:** Using local PV with single replica
@@ -681,29 +679,6 @@ See: [Hetzner CSI Volume Limit Debugging](../guides/storage/hetzner/hetzner-csi-
 postgres:
   instance: 2
 ```
-
----
-
-## Related Documentation
-
-**Hetzner Storage Guides:**
-
-- [Hetzner CSI Volume Limit Debugging](https://gitea.obmondo.com/EnableIT/wiki/src/branch/master/guides/storage/hetzner/hetzner-csi-volume-limit-debugging.md)
-  16 volumes/node limit
-- [Hetzner Block Storage Debugging](https://gitea.obmondo.com/EnableIT/wiki/src/branch/master/guides/storage/hetzner/hetzner-block-storage-debugging.md)
-  Volume mount issues
-
-**Alert Handling:**
-
-- [KubeContainerWaiting](https://gitea.obmondo.com/EnableIT/wiki/src/branch/master/procedures/alerts/KubeContainerWaiting.md)
-  Pods stuck in ContainerCreating
-- [KubePodNotReady](https://gitea.obmondo.com/EnableIT/wiki/src/branch/master/procedures/alerts/KubePodNotReady.md)
-  Pod scheduling issues
-
-**Application Guides:**
-
-- [CSS/JS Asset Loading Failures](https://gitea.obmondo.com/EnableIT/wiki/src/branch/master/guides/debugging/css-js-asset-loading-failures.md)
-  Volume path mismatches
 
 ---
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -65,7 +65,9 @@ KubeAid supports the following hosting environments:
 | Provider | Type | Autoscaling | Notes |
 | ---------- | ------ | ------------- | ------- |
 | **AWS** | Cloud (API-managed) | ✅ Scale to/from 0 | Uses ClusterAPI |
+| **AWS EKS** | Cloud (managed control plane) | ✅ Scale to/from 0 | CAPA; upgrade via GitOps bump, recover not yet |
 | **Azure** | Cloud (API-managed) | ✅ Scale to/from 0 | Uses ClusterAPI |
+| **Azure AKS** | Cloud (managed control plane) | ✅ AKS agent pools | CAPZ; upgrade via GitOps bump, recover not yet |
 | **Hetzner HCloud** | Cloud (API-managed) | ✅ Scale to/from 0 | Uses ClusterAPI |
 | **Hetzner Bare Metal** | Dedicated servers | ❌ Manual | Uses ClusterAPI |
 | **Hetzner Hybrid** | Cloud + Bare Metal | ✅ HCloud only | Uses ClusterAPI |
@@ -77,29 +79,21 @@ KubeAid supports the following hosting environments:
 
 ## Quick Start
 
-For experienced users, here's the minimal workflow:
+For experienced users, here's the minimal workflow. The
+[KubeAid CLI quick start](https://github.com/Obmondo/kubeaid-cli#quick-start) is the authoritative, always-current
+version of this sequence.
 
 ```bash
 # 1. Install the CLI
-KUBEAID_CLI_VERSION=$(curl -s "https://api.github.com/repos/Obmondo/kubeaid-cli/releases/latest" | jq -r .tag_name)
-OS=$([ "$(uname -s)" = "Linux" ] && echo "Linux" || echo "Darwin")
-CPU_ARCHITECTURE=$([ "$(uname -m)" = "x86_64" ] && echo "amd64" || echo "arm64")
-wget "https://github.com/Obmondo/kubeaid-cli/releases/download/${KUBEAID_CLI_VERSION}/kubeaid-cli_${OS}_${CPU_ARCHITECTURE}.tar.gz"
-tar -xzf kubeaid-cli_${OS}_${CPU_ARCHITECTURE}.tar.gz
-sudo mv kubeaid-cli /usr/local/bin/kubeaid-cli
-sudo chmod +x /usr/local/bin/kubeaid-cli
-rm kubeaid-cli_${OS}_${CPU_ARCHITECTURE}.tar.gz
+curl -fsSL https://raw.githubusercontent.com/Obmondo/kubeaid-cli/main/scripts/install.sh | sh
 
-# 2. Generate config (replace <provider> with: aws, azure, hetzner hcloud, hetzner bare-metal, hetzner hybrid, bare-metal, local)
-kubeaid-cli config generate <provider>
+# 2. Generate general.yaml and secrets.yaml via the interactive prompt
+kubeaid-cli config generate --configs-directory ./outputs/configs/<cluster>/
 
-# 3. Edit configuration files
-# Edit outputs/configs/general.yaml and outputs/configs/secrets.yaml
+# 3. Review the generated files, then bootstrap
+kubeaid-cli cluster bootstrap --configs-directory ./outputs/configs/<cluster>/
 
-# 4. Bootstrap
-kubeaid-cli cluster bootstrap
-
-# 5. Access cluster
-export KUBECONFIG=./outputs/kubeconfigs/main.yaml
+# 4. Access cluster
+export KUBECONFIG=./outputs/kubeconfigs/clusters/main.yaml
 kubectl cluster-info
 ```

--- a/docs/getting-started/basic-operations.md
+++ b/docs/getting-started/basic-operations.md
@@ -13,13 +13,21 @@ Here's a quick reference of the most common `kubeaid-cli` commands:
 
 | Command | Description |
 | --------- | ------------- |
-| `kubeaid-cli config generate <provider>` | Generate configuration templates |
+| `kubeaid-cli config generate` | Interactively generate `general.yaml` and `secrets.yaml` |
 | `kubeaid-cli cluster bootstrap` | Create and provision a new cluster |
+| `kubeaid-cli cluster upgrade` | Upgrade to the K8s version and machine images in `general.yaml` |
+| `kubeaid-cli cluster recover` | Recover a cluster from a disaster recovery backup |
+| `kubeaid-cli cluster sync` | Converge a bare-metal (KubeOne) cluster onto `general.yaml` |
+| `kubeaid-cli cluster test` | Verify a cluster was bootstrapped properly |
 | `kubeaid-cli cluster delete main` | Delete the main cluster |
 | `kubeaid-cli cluster delete management` | Delete the local management cluster |
-| `kubeaid-cli cluster upgrade --new-k8s-version <version>` | Upgrade Kubernetes version |
-| `kubeaid-cli --version` | Show CLI version |
+| `kubeaid-cli backup status` | Show backup health of the cluster (CNPG and Velero) |
+| `kubeaid-cli devenv create` | Create the local K3D management cluster on its own |
+| `kubeaid-cli version` | Show CLI version |
 | `kubeaid-cli --help` | Show help and available commands |
+
+> **Note:** `cluster sync` only applies to the bare metal (KubeOne) provider - on the other providers, merged
+> kubeaid-config changes get reconciled by ArgoCD.
 
 > **Note:** KubeAid CLI does not have start/stop/pause/enable/disable commands. Cluster lifecycle is managed
 > through `bootstrap`, `upgrade`, and `delete` operations. For workload management, use standard `kubectl` commands.
@@ -31,7 +39,7 @@ Here's a quick reference of the most common `kubeaid-cli` commands:
 ### Check Cluster Health
 
 ```bash
-export KUBECONFIG=./outputs/kubeconfigs/main.yaml
+export KUBECONFIG=./outputs/kubeconfigs/clusters/main.yaml
 
 # Verify cluster info
 kubectl cluster-info
@@ -63,14 +71,21 @@ All applications should show `Healthy` and `Synced` status.
 
 ### Upgrade Command
 
-To upgrade the Kubernetes version of your cluster:
+To upgrade the Kubernetes version of your cluster, edit `cluster.k8sVersion` in your `general.yaml`, then run:
 
 ```bash
-kubeaid-cli cluster upgrade --new-k8s-version v1.32.0
+kubeaid-cli cluster upgrade
 ```
 
-> **Note:** Replace `v1.32.0` with your target Kubernetes version. Always review the
-> [Kubernetes changelog](https://kubernetes.io/releases/) before upgrading.
+The command upgrades the cluster to the Kubernetes version (and machine images) declared in `general.yaml`. Its
+only flag is `--skip-pr-workflow`, which pushes the resulting kubeaid-config changes directly to the default
+branch instead of opening a PR.
+
+> **Note:** Always review the [Kubernetes changelog](https://kubernetes.io/releases/) before upgrading.
+
+> **EKS / AKS clusters:** `cluster upgrade` refuses to run - the managed control plane is upgraded the GitOps way.
+> Bump `global.kubernetes.version` in `argocd-apps/values-capi-cluster.yaml` in your kubeaid-config repo and let
+> ArgoCD sync; CAPA/CAPZ then upgrade the control plane and roll the node groups.
 
 ---
 
@@ -261,10 +276,10 @@ To create a new cluster with the same configuration:
 
 ```bash
 # Retrieve secrets from password store (example using pass)
-pass kubeaid/my-cluster/secrets.yaml > outputs/configs/secrets.yaml
+pass kubeaid/my-cluster/secrets.yaml > outputs/configs/<cluster>/secrets.yaml
 
 # Bootstrap the cluster
-kubeaid-cli cluster bootstrap
+kubeaid-cli cluster bootstrap --configs-directory ./outputs/configs/<cluster>/
 ```
 
 ---
@@ -278,16 +293,16 @@ kubeaid-cli cluster bootstrap
 | CLI command not found | CLI not installed or not in PATH | Re-run the [CLI installation](./installation.md#installing-kubeaid-cli) |
 | Delete hangs | Resources stuck or network issues | Check cloud provider console for stuck resources |
 | Management cluster already deleted | Running delete twice | This is safe to ignore |
-| Kubeconfig not found | Wrong path or cluster not created | Verify `outputs/kubeconfigs/main.yaml` exists |
+| Kubeconfig not found | Wrong path or cluster not created | Verify `outputs/kubeconfigs/clusters/main.yaml` exists |
 
 ### Viewing Logs
 
 ```bash
-# View operation logs
-cat outputs/.log
+# List operation logs (one timestamped file per run)
+ls outputs/logs/
 
-# Follow logs in real-time
-tail -f outputs/.log
+# Follow the latest log in real-time
+tail -f "outputs/logs/$(ls -t outputs/logs | head -1)"
 ```
 
 ### Getting Help

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,32 +14,26 @@ Ensure you have completed:
 Make sure :
 
 - Docker is running locally
-- Your configuration files are in `outputs/configs/`
+- Your configuration files are in `outputs/configs/<cluster>/` (or `~/.config/kubeaid-cli/<cluster>/configs/`)
 - Your `secrets.yaml` is backed up in your password store
 
 ## Installing KubeAid CLI
 
-If you haven't already installed the KubeAid CLI, run:
+If you haven't already installed the KubeAid CLI, run the official install script:
 
 ```bash
-KUBEAID_CLI_VERSION=$(curl -s "https://api.github.com/repos/Obmondo/kubeaid-cli/releases/latest" | jq -r .tag_name)
-OS=$([ "$(uname -s)" = "Linux" ] && echo "Linux" || echo "Darwin")
-CPU_ARCHITECTURE=$([ "$(uname -m)" = "x86_64" ] && echo "amd64" || echo "arm64")
-
-wget "https://github.com/Obmondo/kubeaid-cli/releases/download/${KUBEAID_CLI_VERSION}/kubeaid-cli_${OS}_${CPU_ARCHITECTURE}.tar.gz"
-tar -xzf kubeaid-cli_${OS}_${CPU_ARCHITECTURE}.tar.gz
-sudo mv kubeaid-cli /usr/local/bin/kubeaid-cli
-sudo chmod +x /usr/local/bin/kubeaid-cli
-rm kubeaid-cli_${OS}_${CPU_ARCHITECTURE}.tar.gz
+curl -fsSL https://raw.githubusercontent.com/Obmondo/kubeaid-cli/main/scripts/install.sh | sh
 ```
 
-> **Note:** This script works on both Linux and macOS. For Linux users who prefer native package managers,
-> see the [Native Package Installation](#native-package-installation) section below.
+It supports `x86_64` and `arm64` on Linux and macOS, and installs to `/usr/local/bin` (may prompt for `sudo`).
+Alternatively, download the right package manually from the
+[releases page](https://github.com/Obmondo/kubeaid-cli/releases) - see the sections below. For Linux users who
+prefer native package managers, see the [Native Package Installation](#native-package-installation) section.
 
 Verify the installation:
 
 ```bash
-kubeaid-cli --version
+kubeaid-cli version
 ```
 
 ### Manual Installation (tar.gz Packages)
@@ -80,7 +74,7 @@ You can also manually download the appropriate tar.gz package for your platform 
 4. **Verify the installation**:
 
    ```bash
-   kubeaid-cli --version
+   kubeaid-cli version
    ```
 
 ### Native Package Installation
@@ -132,10 +126,11 @@ sha256sum -c kubeaid-cli_${KUBEAID_CLI_VERSION#v}_checksums.txt --ignore-missing
 
 ## Bootstrap the Cluster
 
-Run the bootstrap command:
+Run the bootstrap command, pointing it at the configs you generated during
+[pre-configuration](./pre-configuration.md):
 
 ```bash
-kubeaid-cli cluster bootstrap
+kubeaid-cli cluster bootstrap --configs-directory ./outputs/configs/<cluster>/
 ```
 
 ### What Happens During Bootstrap
@@ -178,7 +173,7 @@ flowchart TB
 ### Monitoring Progress
 
 - Logs are streamed to your terminal in real-time
-- All logs are saved to `outputs/.log` for later review
+- All logs are saved to `outputs/logs/` (one timestamped file per run) for later review
 - The process typically takes 10-30 minutes (depending on provider and cluster size)
 
 ### Bootstrap Output
@@ -195,9 +190,14 @@ Upon successful completion, you'll see:
 Set your kubeconfig and verify access:
 
 ```bash
-export KUBECONFIG=./outputs/kubeconfigs/main.yaml
+export KUBECONFIG=./outputs/kubeconfigs/clusters/main.yaml
 kubectl cluster-info
 ```
+
+> **VPN-type clusters** (`cluster.type: vpn`, with NetBird/Keycloak): after bootstrap the public kube-apiserver
+> load balancer is **disabled** and API access moves to the NetBird mesh - the generic kubeconfig flow above
+> doesn't apply. Follow the
+> [post-bootstrap operator guide](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/post-bootstrap.md) instead.
 
 Expected output:
 
@@ -230,7 +230,7 @@ kubectl get applications -n argocd
 
 | Issue | Cause | Solution |
 | ------- | ------- | ---------- |
-| Bootstrap hangs | Network issues or resource constraints | Check logs in `outputs/.log` |
+| Bootstrap hangs | Network issues or resource constraints | Check logs in `outputs/logs/` |
 | Management cluster fails to create | Docker not running | Start Docker and retry |
 | Cloud resources fail to provision | Invalid credentials | Verify `secrets.yaml` credentials |
 | SSH connection fails (bare metal) | SSH key issues | Verify SSH key permissions and host connectivity |
@@ -239,11 +239,11 @@ kubectl get applications -n argocd
 ### Viewing Logs
 
 ```bash
-# View bootstrap logs
-cat outputs/.log
+# List bootstrap logs (one timestamped file per run)
+ls outputs/logs/
 
-# Follow logs in real-time (if bootstrap is running)
-tail -f outputs/.log
+# Follow the latest log in real-time (if bootstrap is running)
+tail -f "outputs/logs/$(ls -t outputs/logs | head -1)"
 ```
 
 ### Retry Bootstrap

--- a/docs/getting-started/post-configuration.md
+++ b/docs/getting-started/post-configuration.md
@@ -8,7 +8,7 @@ These steps are **the same for all providers**.
 ### Check Cluster Status
 
 ```bash
-export KUBECONFIG=./outputs/kubeconfigs/main.yaml
+export KUBECONFIG=./outputs/kubeconfigs/clusters/main.yaml
 
 # Verify cluster info
 kubectl cluster-info
@@ -28,6 +28,11 @@ All nodes should show `Ready` status and all pods should be `Running` or `Comple
 
 KubeAid deploys several web interfaces for managing and monitoring your cluster.
 
+> **VPN-type clusters** (`cluster.type: vpn`, with NetBird/Keycloak): the public kube-apiserver load balancer is
+> disabled after bootstrap and cluster access moves to the NetBird mesh. Follow the
+> [post-bootstrap operator guide](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/post-bootstrap.md)
+> instead of the generic kubeconfig flow on this page.
+
 ### ArgoCD Dashboard
 
 ArgoCD provides GitOps-based application management.
@@ -36,14 +41,14 @@ ArgoCD provides GitOps-based application management.
 # Get ArgoCD URL
 kubectl get ingress -n argocd
 
-# Get admin password (if not set in secrets.yaml)
+# Get admin password
 kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
 ```
 
 **Default credentials:**
 
 - Username: `admin`
-- Password: Set in your `secrets.yaml` or retrieve from the secret above
+- Password: retrieved from the `argocd-initial-admin-secret` Kubernetes secret, as shown above
 
 ### Grafana Dashboard
 
@@ -88,13 +93,23 @@ kubectl -n kube-system exec -it ds/cilium -- cilium status
 kubectl get pods -n kube-system -l name=sealed-secrets-controller
 ```
 
+### Check Backup Health
+
+If disaster recovery is configured, verify backup health (CNPG and Velero) as reported by backup-exporter:
+
+```bash
+kubeaid-cli backup status
+```
+
+See the [backup status guide](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/backup-status.md) for details.
+
 ## Step 4: Configure DNS (If Applicable)
 
 If you're using custom domains for your cluster services, configure DNS records to point to your ingress load balancer:
 
 ```bash
-# Get the external IP/hostname of your ingress
-kubectl get svc -n ingress-nginx
+# Get the external IP/hostname of your ingress (KubeAid deploys Traefik by default)
+kubectl get svc -n traefik
 ```
 
 Create DNS records (A or CNAME) for:
@@ -187,6 +202,6 @@ kubectl get pods -n kube-system -l app=kube2iam
 
 ### Log Locations
 
-- **Bootstrap logs:** `outputs/.log`
+- **Bootstrap logs:** `outputs/logs/` (one timestamped file per run)
 - **Kubeconfig:** `outputs/kubeconfigs/clusters/main.yaml`
-- **Configuration files:** `outputs/configs/`
+- **Configuration files:** `outputs/configs/<cluster>/` (or `~/.config/kubeaid-cli/<cluster>/configs/`)

--- a/docs/getting-started/pre-configuration.md
+++ b/docs/getting-started/pre-configuration.md
@@ -18,75 +18,90 @@ KubeAid uses two configuration files:
 
 ## Step 1: Generate Configuration Files
 
-Run the config generate command with your provider type:
+Run the config generate command:
 
 ```bash
-kubeaid-cli config generate <provider>
+kubeaid-cli config generate --configs-directory ./outputs/configs/<cluster>/
 ```
 
-Replace `<provider>` with one of:
+There is no provider argument - the command walks you through an **interactive prompt** that asks which provider
+you're deploying to (AWS, Azure, Hetzner, bare metal or local) and then collects everything required for it:
+cluster basics, provider credentials, Git / KubeAid fork URLs, and so on. It writes the resulting `general.yaml`
+and `secrets.yaml` under the directory given via `--configs-directory`.
 
-| Provider | Command |
-| ---------- | ------- |
-| AWS | `kubeaid-cli config generate aws` |
-| Azure | `kubeaid-cli config generate azure` |
-| Hetzner HCloud | `kubeaid-cli config generate hetzner hcloud` |
-| Hetzner Bare Metal | `kubeaid-cli config generate hetzner bare-metal` |
-| Hetzner Hybrid | `kubeaid-cli config generate hetzner hybrid` |
-| Bare Metal (SSH-only) | `kubeaid-cli config generate bare-metal` |
-| Local K3D | `kubeaid-cli config generate local` |
-
-The generated templates are saved in `outputs/configs/`.
+> **Note:** Without `--configs-directory`, the prompt asks which cluster you're configuring and writes to
+> `~/.config/kubeaid-cli/<cluster>/configs/` (an existing config in `./outputs/configs/` is offered for reuse).
+> Follow-up commands can then locate that config with `--cluster-name <cluster>` instead of the full path.
 
 ### Generated Directory Structure
 
-After running the config generate command, your working directory will look like:
+After running the config generate command with `--configs-directory ./outputs/configs/<cluster>/`, your working
+directory will look like:
 
 ```bash
 your-working-directory/
 ├── outputs/
 │   ├── configs/
-│   │   ├── general.yaml      # Cluster configuration (edit this)
-│   │   └── secrets.yaml      # Credentials (edit this, store in password manager)
+│   │   └── <cluster>/
+│   │       ├── general.yaml  # Cluster configuration (review this)
+│   │       └── secrets.yaml  # Credentials (review this, store in password manager)
 │   ├── kubeconfigs/          # Generated after bootstrap
-│   │   └── main.yaml         # Kubeconfig for your cluster
-│   └── .log                  # Bootstrap logs
+│   │   └── clusters/
+│   │       └── main.yaml     # Kubeconfig for your cluster
+│   └── logs/                 # One timestamped log file per run
 └── ...
 ```
 
-## Step 2: Configure general.yaml
+## Step 2: Review general.yaml
 
-The `general.yaml` file defines your cluster's infrastructure. Most fields are **common across all providers**.
+The `general.yaml` file defines your cluster's infrastructure. The interactive prompt fills in everything required -
+hand-edit only when you want to override defaults. The authoritative field reference (all providers, all fields) is
+the generated [config reference](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/config-reference.md).
 
 ### Common Configuration (All Providers)
 
 ```yaml
-# Repository URLs
+# Git server SSH access.
+# Exactly one of privateKeyFilePath / useSSHAgent must be set.
+git:
+  sshUsername: git
+  privateKeyFilePath: /home/you/.ssh/id_ed25519
+  # useSSHAgent: true
+
+# Repository fork URLs (SSH URLs; both must be hosted on the same Git server).
 forkURLs:
-  kubeaid: https://github.com/<your-org>/KubeAid
-  kubeaidConfig: https://github.com/<your-org>/kubeaid-config
+  kubeaid:
+    url: git@github.com:<your-org>/KubeAid
+    version: <tag / branch / commit>   # optional: pin the KubeAid version
+  kubeaidConfig:
+    url: git@github.com:<your-org>/kubeaid-config
 
 # Cluster specification
 cluster:
-  name: my-cluster              # Unique cluster name
-  k8sVersion: v1.31.0           # Kubernetes version
-  kubeaidVersion: 18.0.0        # KubeAid version
+  name: my-cluster              # Unique cluster name (no dots allowed)
+  k8sVersion: v1.34.0           # Kubernetes version
 
-# Git configuration
-git:
-  useSSHAgentAuth: false
-  useSSHPrivateKeyAuth: false
-
-# ArgoCD configuration
-argocd:
-  useSSHPrivateKeyAuth: false
-  kubeaidURL: https://github.com/<your-org>/KubeAid
-  kubeaidConfigURL: https://github.com/<your-org>/kubeaid-config
+  # ArgoCD deploy keys (SSH). Each takes privateKeyFilePath or useSSHAgent,
+  # exactly like the git section above.
+  argoCD:
+    deployKeys:
+      kubeaid:
+        useSSHAgent: true
+      kubeaidConfig:
+        useSSHAgent: true
 ```
+
+> **Note on Kubernetes versions:** supported ranges differ per provider. Cluster API clouds (AWS, Azure, Hetzner)
+> support v1.30 up to the latest released (non-EOL) version; bare metal (KubeOne) supports **v1.33 - v1.35** only;
+> EKS requires >= v1.33.
 
 ### Provider-Specific Configuration
 
-The `cloud` section differs by provider. Below are the key fields for each:
+The `cloud` section differs by provider - exactly one of `cloud.aws`, `cloud.azure`, `cloud.hetzner`,
+`cloud.bare-metal` (note the hyphen; Hetzner's *nested* bare-metal key is spelled `bareMetal`) or `cloud.local`
+is set. The interactive prompt generates the correct section for your provider; the samples below only highlight
+the key fields. For the full per-provider schema, see the
+[config reference](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/config-reference.md).
 
 #### AWS
 
@@ -94,13 +109,18 @@ The `cloud` section differs by provider. Below are the key fields for each:
 cloud:
   aws:
     region: eu-central-1         # Frankfurt; change to your preferred region
-    sshKeyName: kubeaid-demo    # Name of your AWS SSH keypair
+    sshKeyName: kubeaid-demo     # Name of your AWS SSH keypair
     controlPlane:
       instanceType: t3.medium
       replicas: 3
-    nodePools:
+      ami:
+        id: <ami-id>
+    nodeGroups:
       - name: workers
         instanceType: t3.large
+        rootVolumeSize: 35
+        cpu: 2
+        memory: 8
         minSize: 1
         maxSize: 10
 ```
@@ -136,21 +156,11 @@ cloud:
 
 #### Azure
 
-```yaml
-cloud:
-  azure:
-    subscriptionId: <subscription-id>
-    resourceGroup: my-cluster-rg
-    location: westeurope          # Amsterdam; change to your preferred region
-    controlPlane:
-      vmSize: Standard_D2s_v3
-      replicas: 3
-    nodePools:
-      - name: workers
-        vmSize: Standard_D4s_v3
-        minSize: 1
-        maxSize: 10
-```
+The `cloud.azure` section takes `tenantID`, `subscriptionID` and `location`, plus a `controlPlane` and `nodeGroups`
+(each node group with `vmSize`, `diskSizeGB`, `cpu`, `memory`, `minSize`, `maxSize`). Self-managed clusters
+additionally need the SSH public key and workload-identity settings described in
+[Prerequisites](./prerequisites.md) - see the
+[config reference](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/config-reference.md) for the full schema.
 
 #### Azure AKS (managed control plane)
 
@@ -187,99 +197,28 @@ cloud:
 > `global.kubernetes.version` in `argocd-apps/values-capi-cluster.yaml` and let
 > ArgoCD sync.
 
-#### Hetzner HCloud
+#### Hetzner
 
-```yaml
-cloud:
-  hetzner:
-    hcloud:
-      region: nbg1
-      sshKeyName: kubeaid-demo
-      controlPlane:
-        serverType: cpx31
-        replicas: 3
-      nodePools:
-        - name: workers
-          serverType: cpx41
-          minSize: 1
-          maxSize: 10
-```
+The `cloud.hetzner` section supports three modes via `mode: hcloud | bare-metal | hybrid`. All modes share a
+Hetzner `sshKeyPair`; HCloud clusters add `hcloud` (zone, image, control plane machine type, node groups), while
+Hetzner bare-metal clusters add the **nested** `bareMetal` key (camelCase - only the *top-level* SSH-only provider
+key `cloud.bare-metal` is hyphenated) with per-host settings such as `wipeDisks`. The interactive prompt
+collects all of this; see the
+[config reference](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/config-reference.md) for the full schema.
 
 > **Note:** HCloud storage only allows a maximum of 16 buckets per physical node. Plan your PV usage accordingly
 > to avoid running out of PVs before node resources are exhausted.
 
-#### Hetzner Bare Metal
-
-```yaml
-cloud:
-  hetzner:
-    bareMetal:
-      wipeDisks: false          # Set true to wipe existing RAID
-      controlPlane:
-        serverIds: [123456, 123457, 123458]  # Must be unique within the cluster
-      nodePools:
-        - name: workers
-          serverIds: [234567, 234568]        # Must be unique within the cluster
-          labels:
-            node-type: worker
-          taints: []
-```
-
-> **Note:** Server IDs must be unique within a cluster. Each server can only belong to one node pool
-> (either control plane or a worker pool).
-
-#### Hetzner Hybrid
-
-```yaml
-cloud:
-  hetzner:
-    hcloud:
-      # Control plane in HCloud
-      controlPlane:
-        serverType: cpx31
-        replicas: 3
-    bareMetal:
-      # Workers in Bare Metal
-      nodePools:
-        - name: bare-metal-workers
-          serverIds: [234567, 234568]
-```
-
 #### Bare Metal (SSH-only)
 
-```yaml
-cloud:
-  bareMetal:
-    controlPlane:
-      hosts:
-        - address: 10.0.0.1
-          user: root
-        - address: 10.0.0.2
-          user: root
-        - address: 10.0.0.3
-          user: root
-    nodePools:
-      - name: workers
-        hosts:
-          - address: 10.0.0.10
-            user: root
-          - address: 10.0.0.11
-            user: root
-        labels:
-          node-type: worker
-        taints: []
-```
+SSH-only bare metal clusters (provisioned via KubeOne) live under the top-level `cloud.bare-metal` key (note the
+hyphen). The interactive prompt collects the control-plane and node-group host addresses and SSH settings; see
+the [config reference](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/config-reference.md) for the full
+schema. KubeOne supports Kubernetes **v1.33 - v1.35** only.
 
-> **Note:** The IP addresses shown above (e.g., `10.0.0.1`) are examples. You can use any valid private IP range
-> (RFC 1918) such as:
->
-> - `10.0.0.0/8` (10.0.0.0 – 10.255.255.255)
-> - `172.16.0.0/12` (172.16.0.0 – 172.31.255.255)
-> - `192.168.0.0/16` (192.168.0.0 – 192.168.255.255)
->
-> These addresses are for **internal cluster communication** and should not be publicly routable.
-> The control plane addresses are used for the Kubernetes API server and etcd cluster,
-> while worker addresses are for node-to-node and pod networking.
+> **Note:** Host addresses should come from a valid private IP range (RFC 1918), e.g. `10.0.0.0/8`,
+> `172.16.0.0/12` or `192.168.0.0/16`. These addresses are for **internal cluster communication** and should not
+> be publicly routable.
 
 #### Local K3D
 
@@ -288,28 +227,14 @@ cloud:
   local: {}
 ```
 
-## Step 3: Configure secrets.yaml
+## Step 3: Review secrets.yaml
 
 The `secrets.yaml` file contains sensitive credentials. **Do not commit this file to Git.**
 
-### Common Secrets (All Providers)
-
-```yaml
-# Git credentials for ArgoCD
-git:
-  username: <git-username>
-  password: <personal-access-token>
-
-# Docker registry (optional)
-dockerRegistry:
-  username: ""
-  password: ""
-
-# ArgoCD admin password
-argocd:
-  admin:
-    password: <strong-password>
-```
+The interactive prompt fills this file in for you. Its only top-level keys are `aws`, `azure`, `hetzner`,
+`keycloak`, `netbird` and `acme`. There are **no Git credentials** here (Git access is SSH-only, configured in
+`general.yaml`) and **no ArgoCD admin password** (that is generated in-cluster - see
+[Post-Configuration](./post-configuration.md)).
 
 ### Provider-Specific Secrets
 
@@ -317,37 +242,37 @@ argocd:
 
 ```yaml
 aws:
-  accessKeyId: <aws-access-key>
+  accessKeyID: <aws-access-key>
   secretAccessKey: <aws-secret-key>
+  sessionToken: <session-token>         # Only when using temporary credentials
 ```
 
 #### Azure Secrets
 
 ```yaml
 azure:
-  clientId: <service-principal-client-id>
+  clientID: <service-principal-client-id>
   clientSecret: <service-principal-secret>
-  tenantId: <azure-tenant-id>
 ```
 
 #### Hetzner
 
 ```yaml
 hetzner:
-  hcloudToken: <hcloud-api-token>
-  robotUser: <robot-username>           # For bare metal only
-  robotPassword: <robot-password>       # For bare metal only
+  apiToken: <hcloud-api-token>
+  robot:                                # For bare metal only
+    user: <robot-username>
+    password: <robot-password>
 ```
 
-#### Bare Metal (SSH-only) Secrets
+#### Keycloak / NetBird / ACME (VPN-type clusters)
 
-```yaml
-ssh:
-  privateKey: |
-    -----BEGIN OPENSSH PRIVATE KEY-----
-    ...
-    -----END OPENSSH PRIVATE KEY-----
-```
+The `keycloak`, `netbird` and `acme` keys hold secrets for VPN-type clusters (`cluster.type: vpn`). Values left
+blank are auto-generated on first run where possible. See the
+[config reference](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/config-reference.md) for details.
+
+> **Note:** Bare metal (SSH-only) clusters need no `secrets.yaml` entries - node access uses the SSH key or
+> SSH agent configured in `general.yaml`.
 
 ## Step 4: Validate Configuration
 
@@ -356,7 +281,7 @@ Before proceeding, verify your configuration:
 1. **Check file locations:**
 
    ```bash
-   ls -la outputs/configs/
+   ls -la outputs/configs/<cluster>/
    # Should show: general.yaml, secrets.yaml
    # Expected owner: your current user (or root if running as root)
    # Expected file mode: -rw------- (600) for secrets.yaml to protect credentials
@@ -366,13 +291,13 @@ Before proceeding, verify your configuration:
 2. **Validate YAML syntax:**
 
    ```bash
-   yq eval '.' outputs/configs/general.yaml > /dev/null && echo "general.yaml is valid"
-   yq eval '.' outputs/configs/secrets.yaml > /dev/null && echo "secrets.yaml is valid"
+   yq eval '.' outputs/configs/<cluster>/general.yaml > /dev/null && echo "general.yaml is valid"
+   yq eval '.' outputs/configs/<cluster>/secrets.yaml > /dev/null && echo "secrets.yaml is valid"
    ```
 
 3. **Store secrets securely:**
 
    ```bash
    # Example using pass
-   pass insert kubeaid/my-cluster/secrets.yaml < outputs/configs/secrets.yaml
+   pass insert kubeaid/my-cluster/secrets.yaml < outputs/configs/<cluster>/secrets.yaml
    ```

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -63,13 +63,14 @@ Before setting up any KubeAid cluster, ensure you have the following tools and r
   
 The following packages must be installed on your local machine:  
   
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) - Kubernetes command-line tool  
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) - Kubernetes command-line tool (for operating the cluster)  
 - [`jq`](https://jqlang.org/download/) - JSON processor  
-- [`terragrunt`](https://terragrunt.gruntwork.io/docs/getting-started/install/) - Terraform wrapper  
-- [`terraform`](https://developer.hashicorp.com/terraform/install) - Infrastructure as Code tool  
-- [`bcrypt`](https://www.npmjs.com/package/bcrypt) - Password hashing utility  
+- [`yq`](https://github.com/mikefarah/yq) - YAML processor  
+- [`cilium-cli`](https://github.com/cilium/cilium-cli) - only required for `kubeaid-cli cluster test`  
 - [`wireguard`](https://www.wireguard.com/install/) - VPN software (optional, for private cluster access)  
-- [`yq`](https://github.com/mikefarah/yq) - YAML processor
+
+> **Note:** `kubeaid-cli` bundles the rest of its tooling (K3D, Helm, clusterctl, KubeOne) as Go libraries -
+> you do **not** need to install Terraform, Terragrunt or similar infrastructure tools.
   
 ### Docker  
   
@@ -130,22 +131,18 @@ flowchart LR
 > **Key Concept:** The KubeAid repo contains Helm charts and templates.
 > Your KubeAid Config repo contains values files and ArgoCD Application manifests that reference those charts.
   
-### Git Provider Credentials  
+### Git Access (SSH-only)  
   
-Keep your Git provider credentials ready. These will be used by ArgoCD for GitOps operations.  
+`kubeaid-cli` and ArgoCD access your Git repositories over **SSH only** - Personal Access Tokens (PATs) are not
+used by `kubeaid-cli` itself. Keep ready:  
   
-#### GitHub  
+- an SSH keypair whose public key is registered with your Git provider (or added as a deploy key on your forks), or  
+- a running `ssh-agent` with that key loaded (use the agent for passphrase-protected or hardware-backed keys).  
   
-Create a [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
-with permission to write to your KubeAid Config fork. This PAT will be used as the password.
+In `general.yaml` you point `kubeaid-cli` at this key via `git.privateKeyFilePath` **or** `git.useSSHAgent`
+(exactly one of the two), and give ArgoCD its own deploy keys under `cluster.argoCD.deployKeys`.  
   
-**Best Practice**: Create a separate user called `obmondo-<service>-user`
-and use its Personal Access Token instead of your personal account token.
-  
-#### GitLab  
-  
-For GitLab, you can create a Project Access Token (available in self-hosted and enterprise GitLab)
-or create a separate user called `obmondo-<service>-user` and provide its Personal Access Token.
+**Best Practice**: Create dedicated deploy keys per repository instead of reusing your personal SSH key.
   
 ## Provider-Specific Prerequisites  
   

--- a/docs/guides/access-token/github.md
+++ b/docs/guides/access-token/github.md
@@ -3,6 +3,11 @@
 
 ## Note
 
+GitHub offers two kinds of Personal Access Tokens: **fine-grained tokens** (recommended, scoped to
+specific repositories and permissions) and **classic tokens** (scoped to broad, repo-wide
+permissions). The scope-based walkthrough below describes the classic token path; for new tokens,
+prefer fine-grained tokens where your workflow supports them.
+
 It is not a good practice to provide Personal Access Token for any public/general usage.
 
 So it is advised to create separate user called `obmondo-<service>-user` and

--- a/docs/guides/backup-exporter.md
+++ b/docs/guides/backup-exporter.md
@@ -1,18 +1,31 @@
 # Backup Exporter
 
-The `obmondo-backup-exporter` chart deploys a Prometheus exporter that monitors the health of your
-backup infrastructure. It exposes metrics and ships PrometheusRule alerts for both **Velero** and
-**PostgreSQL** backups.
+The `backup-exporter` chart deploys a Prometheus exporter that monitors the health of your backup
+infrastructure. It exposes metrics and ships PrometheusRule alerts for **PostgreSQL**, **Velero**,
+**MongoDB**, and **Sealed Secrets** backups.
 
 ## What It Monitors
 
 | Backup System | Alert | Fires When |
 | ------------- | ----- | ---------- |
-| PostgreSQL | `PostgresBackupExporterJobFailed` | A PostgreSQL backup job reports an error (`backup_exporter_postgres_error == 1`) |
-| Velero | `VeleroBackupExporterJobFailed` | A Velero backup job reports an error (`backup_exporter_velero_error == 1`) |
+| PostgreSQL | `PostgresBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_postgres_error == 1`) |
+| PostgreSQL | `PostgresLogicalBackupExceededRPO` | Latest logical backup age exceeds `max_rpo` |
+| PostgreSQL | `PostgresCNPGWALBackupExceededRPO` | Latest CNPG WAL backup age exceeds `max_rpo` |
+| PostgreSQL | `PostgresLogicalBackupMissing` | No logical backup has ever been recorded |
+| PostgreSQL | `PostgresWALBackupMissing` | No WAL backup has ever been recorded |
+| Velero | `VeleroBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_velero_error == 1`) |
+| Velero | `VeleroBackupExceededRPO` | Latest backup age exceeds `max_rpo` |
+| Velero | `VeleroBackupMissing` | No backup has ever been recorded |
+| MongoDB | `MongoDBBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_mongodb_error == 1`) |
+| MongoDB | `MongoDBDumpBackupExceededRPO` | Latest dump backup age exceeds `max_rpo` |
+| MongoDB | `MongoDBDumpBackupMissing` | No dump backup has ever been recorded |
+| Sealed Secrets | `SealedSecretsBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_sealedsecrets_error == 1`) |
+| Sealed Secrets | `SealedSecretsKeyBackupExceededRPO` | Latest key backup age exceeds `max_rpo` |
+| Sealed Secrets | `SealedSecretsKeyBackupMissing` | No key backup has ever been recorded |
 
-Both alerts default to `critical` severity and fire after 5 minutes. These are configurable via the
-values file.
+All alerts default to `critical` severity and fire after 5 minutes. These are configurable via the
+values file. MongoDB and Sealed Secrets monitoring are opt-in (`enabled: false` by default) since
+not every cluster runs those backups.
 
 ## Deployment
 
@@ -29,6 +42,16 @@ prometheusRule:
     alertForDuration: 5m
   velero:
     enabled: true
+    namespace: monitoring
+    severity: critical
+    alertForDuration: 5m
+  mongodb:
+    enabled: false               # Follows exporter.mongodb.enabled
+    namespace: monitoring
+    severity: critical
+    alertForDuration: 5m
+  sealedSecrets:
+    enabled: false               # Follows exporter.sealedSecrets.enabled
     namespace: monitoring
     severity: critical
     alertForDuration: 5m

--- a/docs/guides/cilium-host-firewall.md
+++ b/docs/guides/cilium-host-firewall.md
@@ -15,8 +15,9 @@ When enabled, the policy:
   never the open internet)
 - Allows HTTP (80) and HTTPS (443) plus ICMP from the world
 
-The policy is **disabled by default**. After bootstrapping, `kubeaid-cli cluster lockdown` flips it on
-during the pivot phase.
+The policy is **disabled by default**. There is no standalone `kubeaid-cli cluster lockdown`
+subcommand; you enable it by setting `hostNetworkPolicy.enabled: true` in your per-cluster Cilium
+values overlay (see Configuration below) and rolling it out via ArgoCD.
 
 ## Configuration
 
@@ -61,16 +62,13 @@ and creates a `CiliumClusterwideNetworkPolicy` targeting the host endpoint. Traf
 allow rule is **dropped** by default (Cilium's host-firewall operates in default-deny mode when a policy
 is attached to the host endpoint).
 
-## Integration with kubeaid-cli
+## Enabling After Pivot
 
 After the cluster is bootstrapped and the management cluster has pivoted to the workload cluster,
-run:
-
-```bash
-kubeaid-cli cluster lockdown
-```
-
-This enables the host-firewall policy along with other post-pivot hardening steps.
+apply the same `hostNetworkPolicy.enabled: true` values change and let ArgoCD sync it. Note that
+`kubeaid-cli`'s interactive config prompt separately exposes a `lockdown` field that gets rendered
+into the generated `cluster.lockdown` setting — that's unrelated config plumbing, not a trigger for
+this policy.
 
 ## See Also
 

--- a/docs/guides/ciso-assistant.md
+++ b/docs/guides/ciso-assistant.md
@@ -38,7 +38,7 @@ After the chart is deployed and synced via ArgoCD:
 3. **Configure email** (optional but recommended for invitations):
 
    ```yaml
-   ciso-assistant:
+   ciso-assistant-next:
      backend:
        config:
          smtp:

--- a/docs/guides/harbor-registry.md
+++ b/docs/guides/harbor-registry.md
@@ -24,10 +24,11 @@ Deployment Steps:
 2. Update the values file with your specific configurations.
 3. Push the changes to your kubeaid-config repository.
 4. Sync the changes in ArgoCD root application, you can choose to just sync your harbor application as well
-5. Now you will have harbor set up successfully. you can refer to our configuration guide for various actions
-   With these steps, Harbor will be up and running,
+5. Now you will have harbor set up successfully.
+   With these steps, Harbor will be up and running.
 
-You can set up Keycloak for authentication using our Keycloak guide.
+See Harbor's official docs for further configuration, including
+[OIDC/Keycloak authentication setup](https://goharbor.io/docs/edge/administration/configure-authentication/oidc-auth/).
 
 ## Using CLI Tools with Harbor
 
@@ -107,18 +108,25 @@ on:
     branches: [main]
 
 jobs:
-  build-pull-request:
-  runs-on: [server-name]
-  needs: [ci]
-  uses: []
-  with:
-    push: true
-    file: ./Dockerfile
-    tags: harbor.example.com/organization/project-name:${{ gitea.event.number }}
-  secrets:
-    username: ${{ secrets.HARBOR_USERNAME }}
-    password: ${{ secrets.HARBOR_PASSWORD }}
-    
+  build-and-push:
+    runs-on: [server-name]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: harbor.example.com
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          file: ./Dockerfile
+          tags: harbor.example.com/organization/project-name:${{ gitea.event.number }}
+
   some-other-action:
     runs-on: [server-name]
     container:

--- a/docs/guides/helm_charts.md
+++ b/docs/guides/helm_charts.md
@@ -5,31 +5,31 @@
 ### Add a new chart
 
 ```sh
-./bin/helm-repo-update.sh --add-new-chart <chart-name> <chart-url> <version> 
+./bin/manage-helm-chart.sh --add-helm-chart <chart-name> <chart-url> <chart-version>
 ```
 
 ### Update a specific chart
 
 ```sh
-./bin/helm-repo-update.sh --update-helm-chart <name-of-chart>
+./bin/manage-helm-chart.sh --update-helm-chart <name-of-chart>
 ```
 
 ### Update a specific chart to a specific version
 
 ```sh
-./bin/helm-repo-update.sh --update-helm-chart <name-of-chart> --chart-version <version>
+./bin/manage-helm-chart.sh --update-helm-chart <name-of-chart> --chart-version <version>
 ```
 
 ### Update all charts
 
 ```sh
-./bin/helm-repo-update.sh --update-all
+./bin/manage-helm-chart.sh --update-all
 ```
 
 ### Update all charts except certain ones
 
 ```sh
-./bin/helm-repo-update.sh --update-all --skip-charts 'chart1,chart2,chart3'
+./bin/manage-helm-chart.sh --update-all --skip-charts 'chart1,chart2,chart3'
 ```
 
 **Note**: `--skip-charts` must be used with `--update-all` or `--update-helm-chart`
@@ -37,7 +37,7 @@
 ### Get help
 
 ```sh
-./bin/helm-repo-update.sh --help
+./bin/manage-helm-chart.sh --help
 ```
 
 Note:
@@ -47,5 +47,9 @@ Note:
 For example `postgres-operator` for postgres for postgresql database and so on.
 <!-- markdownlint-disable -->
 - Check
-[doc](postgres-operator/README.md) about postgres operator and how that works.
+[doc](../../argocd-helm-charts/postgres-operator/README.md) about postgres operator and how that works.
 <!-- markdownlint-enable -->
+
+## See also
+
+- [Helm Umbrella Pattern](../kubeaid/helm-umbrella-pattern.md) - how these charts fit into the umbrella chart

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -11,7 +11,8 @@ The following tools are required locally:
 - `helm` (>= 3.8.0)
 - `yq` (Go version)
 
-The repository must have the `github` remote configured for pushing to GitHub.
+The repository must have the `origin` remote configured for pushing to GitHub, and a `gitea`
+remote configured for pushing to the internal Gitea mirror.
 
 ## 1. Update Managed Helm Charts
 
@@ -48,7 +49,7 @@ The script requires Linux (GNU sed). For macOS users, use the provided Docker wo
    ```bash
    apt-get update && apt-get install -y git curl
    curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
-   curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4
+   curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
    chmod 700 get_helm.sh && ./get_helm.sh
    ./bin/manage-helm-chart.sh --update-all
    ```
@@ -126,7 +127,7 @@ The script will:
 4. Generate `CHANGELOG.md` and `.release-notes.md`
 5. Commit the changelog and release notes
 6. Create an annotated git tag from the `VERSION` file
-7. Push the commit and tag to both **Gitea** (`origin`) and **GitHub** (`github`)
+7. Push the commit and tag to both **GitHub** (`origin`) and the internal **Gitea** mirror (`gitea`)
 
 After the tag is pushed, GoReleaser CI workflows run automatically on both Gitea and GitHub to
 publish the release using the generated `.release-notes.md`.

--- a/docs/hosting/bare-metal.md
+++ b/docs/hosting/bare-metal.md
@@ -6,6 +6,9 @@ access**. There is no cloud API host management-you manage the server lifecycle 
 > Uses [Kubermatic KubeOne](https://github.com/kubermatic/kubeone) under the hood for SSH-only access platforms without
   API host management support.
 
+This page covers generic SSH-only bare metal. Hetzner Bare Metal is provisioned differently, via
+[ClusterAPI/CAPH](./cloud-providers.md#bare-metal-mode) instead of KubeOne - see [Cloud Providers](./cloud-providers.md).
+
 ## Features
 
 - [Cilium](https://cilium.io) CNI in [kube-proxyless mode](https://cilium.io/use-cases/kube-proxy/)
@@ -53,8 +56,8 @@ sudo chmod +x /usr/local/bin/kubeaid-cli
 ## Setup
 
 ```bash
-# Generate configuration
-kubeaid-cli config generate bare-metal
+# Generate configuration (interactive prompt; select bare-metal when asked for a provider)
+kubeaid-cli config generate
 
 # Edit outputs/configs/general.yaml and secrets.yaml
 
@@ -62,11 +65,11 @@ kubeaid-cli config generate bare-metal
 kubeaid-cli cluster bootstrap
 
 # Access the cluster
-export KUBECONFIG=./outputs/kubeconfigs/main.yaml
+export KUBECONFIG=./outputs/kubeconfigs/clusters/main.yaml
 kubectl cluster-info
 ```
 
-Logs are saved in `outputs/.log`. Access the ArgoCD and Grafana dashboards.
+Logs are saved in `outputs/logs`. Access the ArgoCD and Grafana dashboards.
 
 ## Cleanup
 

--- a/docs/hosting/cloud-providers.md
+++ b/docs/hosting/cloud-providers.md
@@ -53,8 +53,8 @@ aws ec2 create-key-pair \
 ### AWS Setup
 
 ```bash
-# Generate configuration
-kubeaid-cli config generate aws
+# Generate configuration (interactive prompt; select aws when asked for a provider)
+kubeaid-cli config generate
 
 # Edit outputs/configs/general.yaml and secrets.yaml
 
@@ -62,9 +62,18 @@ kubeaid-cli config generate aws
 kubeaid-cli cluster bootstrap
 
 # Access the cluster
-export KUBECONFIG=./outputs/kubeconfigs/main.yaml
+export KUBECONFIG=./outputs/kubeconfigs/clusters/main.yaml
 kubectl cluster-info
 ```
+
+### AWS EKS (managed control plane)
+
+Set `cloud.aws.eks: true` to get an AWS-managed (EKS) control plane instead of the self-managed
+CAPA one. `cluster bootstrap` and `cluster delete` work as above; `cluster upgrade` refuses on EKS
+clusters - bump `global.kubernetes.version` in the kubeaid-config repo's `values-capi-cluster.yaml`
+instead and let ArgoCD/CAPA roll the control plane and node-groups. `cluster recover` isn't
+supported yet for EKS. See [Pre-Configuration](../getting-started/pre-configuration.md#aws-eks-managed-control-plane)
+for the full field list.
 
 ### AWS Cleanup
 
@@ -109,8 +118,8 @@ Provisions a KubeAid-managed Kubernetes cluster in Azure with:
 ### Azure Setup
 
 ```bash
-# Generate configuration
-kubeaid-cli config generate azure
+# Generate configuration (interactive prompt; select azure when asked for a provider)
+kubeaid-cli config generate
 
 # Edit outputs/configs/general.yaml and secrets.yaml
 
@@ -118,15 +127,27 @@ kubeaid-cli config generate azure
 kubeaid-cli cluster bootstrap
 
 # Access the cluster
-export KUBECONFIG=./outputs/kubeconfigs/main.yaml
+export KUBECONFIG=./outputs/kubeconfigs/clusters/main.yaml
 kubectl cluster-info
 ```
 
+### Azure AKS (managed control plane)
+
+Set `cloud.azure.aks: true` to get an Azure-managed (AKS) control plane instead of the self-managed
+CAPZ one. `cluster bootstrap` and `cluster delete` work as above; `cluster upgrade` refuses on AKS
+clusters - bump `global.kubernetes.version` in the kubeaid-config repo's `values-capi-cluster.yaml`
+instead and let ArgoCD/CAPZ roll the control plane and agent pools. `cluster recover` isn't
+supported yet for AKS. See [Pre-Configuration](../getting-started/pre-configuration.md#azure-aks-managed-control-plane)
+for the full field list.
+
 ### Azure Upgrade
 
+There are no `--new-k8s-version` / `--new-image-offer` flags. Edit `cluster.k8sVersion` (and the
+machine image fields) in `general.yaml`, then run:
+
 ```bash
-kubeaid-cli cluster upgrade --new-k8s-version v1.32.0
-# Add --new-image-offer for OS upgrade
+kubeaid-cli cluster upgrade
+# --skip-pr-workflow pushes changes directly instead of opening a PR
 ```
 
 ### Azure Cleanup
@@ -167,7 +188,8 @@ All modes include:
 #### HCloud Setup
 
 ```bash
-kubeaid-cli config generate hetzner hcloud
+# Interactive prompt; select hetzner, then hcloud, when asked
+kubeaid-cli config generate
 # Edit outputs/configs/general.yaml and secrets.yaml
 kubeaid-cli cluster bootstrap
 ```
@@ -193,7 +215,7 @@ For each server:
 - **Level 1 SWRAID** across specified disk WWNs
 - **25G LVG** named `vg0` with 10G root volume
 
-Configure further via `diskLayoutSetupCommands`. Recommendations:
+Configure further via `installImage.vg0.{size,rootVolumeSize}` and `wipeDisks`. Recommendations:
 
 - Allocate HDDs/SSDs to **Ceph**
 - Allocate NVMes to a **ZPool** (mirror mode) for ContainerD, logs, and OpenEBS ZFS LocalPV
@@ -205,7 +227,8 @@ Configure further via `diskLayoutSetupCommands`. Recommendations:
 #### Bare Metal Setup
 
 ```bash
-kubeaid-cli config generate hetzner bare-metal
+# Interactive prompt; select hetzner, then bare-metal, when asked
+kubeaid-cli config generate
 # Edit outputs/configs/general.yaml and secrets.yaml
 kubeaid-cli cluster bootstrap
 ```
@@ -248,7 +271,8 @@ is the operator's responsibility.
 #### Hybrid Setup
 
 ```bash
-kubeaid-cli config generate hetzner hybrid
+# Interactive prompt; select hetzner, then hybrid, when asked
+kubeaid-cli config generate
 # Edit outputs/configs/general.yaml and secrets.yaml
 kubeaid-cli cluster bootstrap
 ```
@@ -271,11 +295,11 @@ kubeaid-cli cluster delete management
 ### Access Cluster
 
 ```bash
-export KUBECONFIG=./outputs/kubeconfigs/main.yaml
+export KUBECONFIG=./outputs/kubeconfigs/clusters/main.yaml
 kubectl cluster-info
 ```
 
-Logs are saved in `outputs/.log`. Access the ArgoCD and Grafana dashboards for monitoring.
+Logs are saved in `outputs/logs`. Access the ArgoCD and Grafana dashboards for monitoring.
 
 ## See Also
 

--- a/docs/hosting/single-host-k8s.md
+++ b/docs/hosting/single-host-k8s.md
@@ -33,8 +33,8 @@ sudo chmod +x /usr/local/bin/kubeaid-cli
 ## Setup
 
 ```bash
-# Generate configuration
-kubeaid-cli config generate local
+# Generate configuration (interactive prompt; select local when asked for a provider)
+kubeaid-cli config generate
 
 # Edit outputs/configs/general.yaml and secrets.yaml
 
@@ -42,11 +42,11 @@ kubeaid-cli config generate local
 kubeaid-cli cluster bootstrap
 
 # Access the cluster
-export KUBECONFIG=./outputs/kubeconfigs/main.yaml
+export KUBECONFIG=./outputs/kubeconfigs/clusters/main.yaml
 kubectl cluster-info
 ```
 
-Logs are saved in `outputs/.log`. Access the ArgoCD and Grafana dashboards.
+Logs are saved in `outputs/logs`. Access the ArgoCD and Grafana dashboards.
 
 ## Cleanup
 

--- a/docs/kubeaid/comparison.md
+++ b/docs/kubeaid/comparison.md
@@ -50,8 +50,10 @@ two YAML files (`general.yaml` for what you want, `secrets.yaml` for
 credentials), and you get a production-ready cluster with GitOps,
 monitoring, networking, and security configured out of the box.
 
-The same workflow works on AWS, Azure, Hetzner, and bare metal.
-Learn it once, use it everywhere.
+The same workflow works on AWS, Azure, Hetzner, and bare metal -
+self-managed clusters and the managed control planes (EKS and AKS)
+alike, which KubeAid can bootstrap and delete, with upgrades done as
+a GitOps version bump. Learn it once, use it everywhere.
 
 ### 100+ Helm Charts, Curated and Tested
 
@@ -302,7 +304,7 @@ seamlessly - so you do not spend months integrating them yourself.
 | Drift detection | Only on next plan/apply | Only on refresh | None (run-and-done) | Agent checks ~30 min | **Continuous** |
 | Manual changes | Silent disaster | Same as Terraform | Does not track | May revert on next run | **Detected immediately** |
 | Kubernetes-native | No | Partial | No | No | **Yes** |
-| Multi-cloud | Per-provider modules | Per-provider code | Per-host playbooks | Per-host manifests | **One workflow, any cloud** |
+| Multi-cloud | Per-provider modules | Per-provider code | Per-host playbooks | Per-host manifests | **One workflow, any cloud (incl. EKS/AKS)** |
 | Compliance | DIY | DIY | DIY | DIY | **ISO 27001:2022 built in** |
 | Where we use it | Limited (VPCs, IAM) | We do not | LinuxAid | LinuxAid (legacy) | **End-to-end** |
 <!-- markdownlint-enable MD013 -->

--- a/docs/kubeaid/features-technical-details.md
+++ b/docs/kubeaid/features-technical-details.md
@@ -17,11 +17,14 @@ Read our detailed guide on **[GitOps Drift Detection and Alerting](./gitops-drif
 
 We currently have working autoscale for Amazon Web Services (AWS).
 
-**TODO:** Get autoscaling working for Azure Kubernetes Service (AKS) and Google Cloud Platform (GCP).
+KubeAid also supports the managed control planes on EKS and AKS: it can bootstrap and delete such clusters, and
+upgrades are done as a version bump in your GitOps repository.
 
-### Manage an ever-growing list of Open Source Kubernetes applications (see
+**TODO:** Get autoscaling working for Azure Kubernetes Service (AKS).
 
-[`argocd-helm-charts`](../../argocd-helm-charts/) folder for a list)
+### Manage an ever-growing list of Open Source Kubernetes applications
+
+See the [`argocd-helm-charts`](../../argocd-helm-charts/) folder for the full list of applications.
 
 We use upstream Helm charts preferably - and use the Helm Umbrella pattern in ArgoCD - so the 'root' application,
 manages the rest of the applications in a cluster.
@@ -71,7 +74,7 @@ backups of PVCs.
 Ensuring least privilege between applications in your clusters, via resource limits and per-namespace/per-pod
 firewalling.
 
-We use Calico and NetworkPolicy resources to firewall each pod, so they cannot access anything in the cluster that they
+We use Cilium and NetworkPolicy resources to firewall each pod, so they cannot access anything in the cluster that they
 do not need to.
 
 This protects against a pod compromise and WHEN we block traffic from a pod, it triggers an event in the namespace that
@@ -84,13 +87,11 @@ We use Velero to do regular backups of cluster and PVC data.
 
 On AWS we have snapshot scripts to do regular and quick PVC backups.
 
-**TODO:** Get live cluster migration working - hopefully Calico team will soon enable multi-cluster mesh - so we can get
-start writing it.
+**TODO:** Get live cluster migration working - for example built on Cilium's Cluster Mesh multi-cluster support.
 
 ### Major cluster upgrades, via a shadow Kubernetes setup utilising the recovery and live-migration features
 
-**TODO:** Get live cluster migration working - hopefully Calico team will soon enable multi-cluster mesh - so we can get
-start writing it.
+**TODO:** Get live cluster migration working - for example built on Cilium's Cluster Mesh multi-cluster support.
 
 ### Supply chain attack protection and discovery - and security scans of all software used in the clusters
 

--- a/docs/kubeaid/gitops-drift-detection.md
+++ b/docs/kubeaid/gitops-drift-detection.md
@@ -72,24 +72,23 @@ Resources that exist in the cluster but are not tracked by ArgoCD. These can be:
 
 ## Detecting Unmanaged Resources
 
-ArgoCD can track resources it doesn't manage (orphaned resources). This is configured per Application:
+ArgoCD can warn about resources that live in an Application's namespace but are not managed by any Application
+(orphaned resources). This is configured on the AppProject the Applications belong to:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
-kind: Application
+kind: AppProject
 metadata:
-  name: my-app
+  name: my-project
+  namespace: argocd
 spec:
   # ... other config ...
-  syncPolicy:
-    syncOptions:
-      - CreateNamespace=true
-  # Enable resource tracking
-  source:
-    plugin:
-      env:
-        - name: ARGOCD_APP_SOURCE_REPO
-          value: "true"
+  orphanedResources:
+    warn: true  # Raise a warning condition on Applications with orphaned resources
+    ignore:
+      # Resources to exclude from orphaned-resource monitoring
+      - kind: ConfigMap
+        name: kube-root-ca.crt
 ```
 
 ### Viewing Unmanaged Resources

--- a/docs/kubeaid/prometheus-configuration.md
+++ b/docs/kubeaid/prometheus-configuration.md
@@ -52,23 +52,28 @@ Example configuration:
 
 ```jsonnet
 {
-  // Cluster identification
-  cluster_name: 'production',
-  cluster_domain: 'example.com',
+  // Which platform Kubernetes runs on, e.g. 'kubeadm', 'kops' or 'aks'
+  platform: 'kubeadm',
+
+  // Connect to Obmondo monitoring; certname format is '<cluster>.<customerid>'
+  connect_obmondo: true,
+  certname: 'production.customer1',
   
   // kube-prometheus version to use
   kube_prometheus_version: 'v0.18.0',
   
   // Prometheus configuration
-  prometheus_replicas: 2,
-  prometheus_retention: '30d',
-  prometheus_storage_size: '100Gi',
-  
-  // Alertmanager configuration
-  alertmanager_replicas: 3,
+  prometheus+: {
+    retention: '30d',
+    storage: {
+      size: '100Gi',
+      classname: 'rook-ceph-block',
+    },
+  },
   
   // Grafana configuration
-  grafana_domain: 'grafana.example.com',
+  grafana_root_url: 'https://grafana.example.com',
+  grafana_ingress_host: 'grafana.example.com',
   
   // Namespaces to scrape metrics from
   prometheus_scrape_namespaces: [
@@ -83,7 +88,7 @@ Example configuration:
   enable_custom_metrics_apiservice: true,
   
   // Enable mixins
-  addMixins: {
+  addMixins+: {
     ceph: true,
     sealedsecrets: true,
     etcd: true,
@@ -126,11 +131,8 @@ kubeaid-config/k8s/<cluster-name>/kube-prometheus/
 
 ### Applying to Cluster
 
-Commit the generated manifests and sync via ArgoCD, or apply manually:
-
-```bash
-kubectl apply -f ../kubeaid-config/k8s/<cluster-name>/kube-prometheus/
-```
+Commit the generated manifests to your `kubeaid-config` repository and let ArgoCD sync them - every change goes
+through Git.
 
 ## Common Configuration Options
 
@@ -179,8 +181,8 @@ grafana_dashboards: {
 },
 ```
 
-See the [build/kube-prometheus
-README](../../build/kube-prometheus/README.md#adding-support-for-custom-dashboards-in-grafana) for detailed
+See the [build/kube-prometheus Grafana
+docs](../../build/kube-prometheus/docs/grafana.md#adding-custom-dashboards-via-gitops) for detailed
 instructions.
 
 ### Alertmanager Configuration

--- a/docs/kubeaid/why-kubeaid.md
+++ b/docs/kubeaid/why-kubeaid.md
@@ -71,13 +71,16 @@ is the *exact same* as what every other team needs.
 ## One Way to Install, On Any Cloud (Even Your Own)
 
 KubeAid was designed to solve this by giving you **one unified way to install Kubernetes**, regardless of where you
-choose to run it: AWS, Azure, Hetzner, bare metal, or your own data centre.
+choose to run it: AWS, Azure, Hetzner, bare metal, or your own data centre. This includes the clouds' managed control
+planes: KubeAid can bootstrap and delete EKS and AKS clusters, with upgrades done as a GitOps version bump.
 
 We tried hard not to reinvent the wheel. For unifying installation automation across every possible target, there is
 only one solution: **[Cluster API](https://cluster-api.sigs.k8s.io/)**.
 
 Cluster API is complex by design. It hides each cloud provider's complexity behind drivers, which are often maintained
-by the cloud vendors themselves. But it removes the vendor lock-in those vendors have worked so hard to build.
+by the cloud vendors themselves. But it removes the vendor lock-in those vendors have worked so hard to build. And it
+unifies the managed paths too: an EKS or AKS cluster is driven through the same Cluster API workflow as a self-managed
+one.
 
 On top of Cluster API, there is a *lot* to set up correctly: GitOps management, identity implementation (which differs
 by provider), networking, monitoring, and more. This is what **KubeAid CLI** handles for you.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -138,7 +138,7 @@ Both alerts fire at `critical` severity after 30 minutes.
 ### Backup exporter
 
 <!-- markdownlint-disable MD013 -->
-The [obmondo-backup-exporter](../argocd-helm-charts/obmondo-backup-exporter/) chart monitors Velero
+The [backup-exporter](../argocd-helm-charts/backup-exporter/) chart monitors Velero
 and PostgreSQL backup health via dedicated Prometheus metrics and alerts. See the
 [Backup Exporter guide](./guides/backup-exporter.md) for details.
 <!-- markdownlint-enable MD013 -->

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -32,7 +32,24 @@ We use logical dumps for databases such as PostgreSQL and MongoDB to ensure port
 
 ### MongoDB
 
-- [Backup and Restore documentation](../../argocd-helm-charts/mongodb-operator/Readme.md#backup-and-restore)
+- The chart was renamed from `mongodb-operator` to
+  [`mongodb-kubernetes`](../../argocd-helm-charts/mongodb-kubernetes/README.md); its README is now a migration guide
+  (MCO to MCK) and doesn't cover backup/restore yet. Documentation pending.
+
+---
+
+## 4. Checking Backup Health
+
+The [backup-exporter](../../argocd-helm-charts/backup-exporter/) chart reads object storage directly and reports
+whether PostgreSQL (CNPG logical and WAL), Velero, MongoDB, and Sealed Secrets backups actually landed. Check status
+with:
+
+```bash
+kubeaid-cli backup status
+```
+
+See the [backup status docs](https://github.com/Obmondo/kubeaid-cli/blob/main/docs/backup-status.md) for the
+metrics reference, JSON output (`-o json`), and alerting behavior.
 
 ## Summary
 

--- a/docs/operations/fixing-a-k8s-node-disk.md
+++ b/docs/operations/fixing-a-k8s-node-disk.md
@@ -155,26 +155,26 @@ zpool replace <pool> \
 zpool status -v <pool>    # use this command to keep monitoring the progress
 ```
 
-### 2. Verify etcd is back to 3/3
+### 4. Verify etcd is back to 3/3
 
 ```sh
 # same endpoint health --cluster command as Phase 1 step 1
 ```
 
-### 3. Uncordon the node
+### 5. Uncordon the node
 
 ```sh
 kubectl uncordon $NODE
 ```
 
-### 4. Watch Ceph recover (if ceph installed on the node)
+### 6. Watch Ceph recover (if ceph installed on the node)
 
 ```sh
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
 # wait for: 8/8 osds up, all PGs active+clean, 0% degraded
 ```
 
-### 5. Unset noout, only after all PGs are active+clean (if ceph installed on the node)
+### 7. Unset noout, only after all PGs are active+clean (if ceph installed on the node)
 
 Please make sure ```ceph status``` goes back to 0% degradation. it may take 3 to 4 hours sometimes so you need to wait
 
@@ -182,7 +182,7 @@ Please make sure ```ceph status``` goes back to 0% degradation. it may take 3 to
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd unset noout
 ```
 
-### 6. Final verification
+### 8. Final verification
 
 Confirm every layer. nodes, Ceph, ZFS, workloads is fully back before you close the ticket.
 

--- a/docs/operations/monitoring/pod-autoscaling.md
+++ b/docs/operations/monitoring/pod-autoscaling.md
@@ -20,10 +20,13 @@ _This needs to be done only once._
 
 - Set `enable_custom_metrics_apiservice: true` in your kubeaid managed cluster's prometheus build jsonnet vars file
   `(kubeaid-config/k8s/<clustername>/<clustername>-vars.jsonnet)`.
-- Ensure `kube_prometheus_version` is newer than `v0.12.0`.
+- Ensure `kube_prometheus_version` is at least `v0.13.0` (the oldest supported release; current examples use
+  `v0.18.0` - run `build.sh --versions` for the full Kubernetes compatibility table).
 
 Regenerate kube prometheus YAML with
-`kubeaid/build/kube-prometheus/build.sh /path/to/kubernetes-config-company/k8s/production.company.io/production.company.io-vars.jsonnet`
+`kubeaid/build/kube-prometheus/build.sh /path/to/kubernetes-config-company/k8s/production.company.io`
+
+(the argument is the cluster directory containing `production.company.io-vars.jsonnet`, not the jsonnet file itself)
 
 This will generate a few YAML files which define (setup or re-configure) prometheus, grafana, alertmanager,
 prometheus-adapter, and other resources and configs needed by them.

--- a/docs/operations/monitoring/prometheus-namespaces.md
+++ b/docs/operations/monitoring/prometheus-namespaces.md
@@ -36,15 +36,15 @@ kube-prometheus. Modify it according to your requirements.
    - Save the `kubeaid-config/k8s/<clustername>/<clustername>-vars.jsonnet` file after making the necessary modifications.
 
 4. Regenerate kube-prometheus YAML:
-   - Run the script to regenerate the kube-prometheus YAML files using the
-   `kubeaid-config/k8s/<clustername>/<clustername-vars>.jsonnet` file.
+   - Run the script to regenerate the kube-prometheus YAML files, passing it the cluster directory (the one
+   containing `<clustername>-vars.jsonnet`), not the jsonnet file itself.
    - Use the following command:
 
      ```bash
-     kubeaid/build/kube-prometheus/build.sh /path/to/kubernetes-config-company/k8s/production.company.io/production.company.io-vars.jsonnet
+     kubeaid/build/kube-prometheus/build.sh /path/to/kubernetes-config-company/k8s/production.company.io
      ```
 
-   - Replace the paths with the appropriate locations for your setup.
+   - Replace the path with the appropriate location for your setup.
 
 5. Commit and Sync:
    - Commit the changes made to the `kubeaid-config/k8s/<clustername>/<clustername>-vars.jsonnet` file to your cluster


### PR DESCRIPTION
Phase 1 (correctness) of the docs overhaul — companion to Obmondo/kubeaid-cli#73. 30 files; every fix verified against kubeaid-cli v0.31.7 source, the charts, or the scripts before writing. No structural moves — those come in Phase 2.

## The six root causes, fixed everywhere they occur
- **`config generate <provider>` doesn't exist** (10+ occurrences): it's a fully interactive prompt; docs now show `--configs-directory` and the real default output dir.
- **`cluster upgrade --new-k8s-version` doesn't exist**: the real flow edits `cluster.k8sVersion` in general.yaml; EKS/AKS refusal + GitOps bump path documented.
- **Wrong paths in 7 files**: kubeconfig is `outputs/kubeconfigs/clusters/main.yaml`, logs are `outputs/logs/`.
- **Broken install instructions**: the `amd64` wget 404s (assets are `x86_64`) → `scripts/install.sh`; `kubeaid-cli version`, not `--version`.
- **EKS/AKS were invisible**: added to the providers table, cloud-providers.md, why-kubeaid, comparison, features-technical-details.
- **Legacy-era claims**: Calico→Cilium, terraform/terragrunt/bcrypt dropped from prerequisites (never invoked), private wiki links stripped from cluster-design.md.

## Fabricated examples replaced with verified ones
- `secrets.yaml`: the invented `git`/`dockerRegistry`/`argocd` blocks are gone; real schema documented (aws, azure, hetzner, keycloak, netbird, acme), with the CLI's generated config-reference as the authoritative schema link.
- `general.yaml` samples: real field names (`git.useSSHAgent`, `argoCD.deployKeys`, `forkURLs.kubeaid.version`, `cloud.bare-metal`).
- Drift detection: real `AppProject.spec.orphanedResources` instead of a nonexistent plugin-env mechanism.
- Prometheus config: example rebuilt from real jsonnet vars (`certname`, `platform`, nested `prometheus.storage`, `grafana_root_url`); `kubectl apply` alternative removed (contradicted decisions/gitops.md).
- `helm_charts.md`: documents the real `bin/manage-helm-chart.sh`.

## Also
- release.md remotes corrected (origin = GitHub, second remote = gitea) and `bin/release.sh`'s mislabeled push echoes aligned.
- backup-exporter.md now covers all 4 backup types and their 14 real alerts; backup-restore.md gains `kubeaid-cli backup status`.
- `cluster lockdown` is a config value, not a CLI command — cilium-host-firewall.md documents `hostNetworkPolicy.enabled`.
- Traefik (not ingress-nginx) in DNS steps; VPN clusters linked to post-bootstrap.md where the generic kubeconfig flow stops applying.
- harbor-registry.md ships a structurally valid CI example; ciso-assistant.md uses the real `ciso-assistant-next` key.
- docs/README.md indexes the four orphaned docs; README front-door links now point at kubeaid.io/docs.

All of this republishes to kubeaid.io/docs on the next site build — the broken commands are currently live there.