### PR TITLE
docs(readme): drop the table of contents — GitHub's outline covers it

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,6 @@ clusters.
 · [**Getting Started**](https://kubeaid.io/docs/getting-started/)
 · [**Full Documentation**](https://kubeaid.io/docs/)
 
-## Table of Contents
-
-- [What Exactly Is KubeAid?](#what-exactly-is-kubeaid)
-- [How It Works](#how-it-works)
-- [Quick Start](#quick-start)
-- [Features](#features)
-- [Documentation](#documentation)
-- [Contributing](#contributing)
-- [Community and Governance](#community-and-governance)
-- [Roadmap](ROADMAP.md)
-- [Support](#support)
-- [License](#license)
-
 ## What Exactly Is KubeAid?
 
 Installing Kubernetes looks easy until you do it on a second platform. AWS wants IAM roles, Azure wants Workload


### PR DESCRIPTION
The README's TOC duplicated GitHub's built-in outline (the list icon on every rendered README) while pushing the actual content below the fold. The front-door docs links right above it already handle navigation to kubeaid.io.