### PR TITLE
docs: access management default is NetBird + Keycloak; Teleport is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ and day-2 operations for every supported platform.
   handling of trivial alerts like disks filling up.
 - **Secrets in Git, safely**: [sealed-secrets](./argocd-helm-charts/sealed-secrets/README.md) encrypts secrets locally
   before they are committed to your config repository.
-- **Unified access management** through Teleport for Kubernetes, applications, and databases.
+- **Unified access management**: cluster access runs over the [NetBird](https://netbird.io/) mesh with
+  [Keycloak](https://www.keycloak.org/) as the SSO identity provider by default. Teleport remains available as an
+  optional, deprecated alternative.
 - **Cluster security**: NetworkPolicies enforce least privilege between applications and secure intra-cluster and
   ingress traffic.
 - **Lifecycle operations**: auto-scaling, backup and recovery, live migration of applications or whole clusters, major

--- a/argocd-helm-charts/teleport-cluster/README.md
+++ b/argocd-helm-charts/teleport-cluster/README.md
@@ -4,11 +4,15 @@
 apps). This chart deploys the central Teleport proxy/auth cluster (`clusterName` in values.yaml, e.g.
 `teleport.obmondo.com`) that managed clusters join through.
 
+> **Deprecated:** Teleport is no longer KubeAid's default access layer — new clusters use the NetBird mesh with
+> Keycloak SSO instead. This chart remains available for existing setups.
+
 ## Why it's in KubeAid
 
-KubeAid uses Teleport as the access layer for managed clusters: instead of distributing raw kubeconfigs, each
-managed cluster runs the [`teleport-kube-agent`](../teleport-kube-agent/README.md) chart and joins this central
-cluster, so cluster access can be issued/revoked/audited from one place.
+KubeAid previously used Teleport as the access layer for managed clusters: instead of distributing raw
+kubeconfigs, each managed cluster runs the [`teleport-kube-agent`](../teleport-kube-agent/README.md) chart and
+joins this central cluster, so cluster access can be issued/revoked/audited from one place. On current clusters
+that role is filled by NetBird (mesh access) and Keycloak (SSO).
 
 ## Upgrade
 

--- a/argocd-helm-charts/teleport-kube-agent/README.md
+++ b/argocd-helm-charts/teleport-kube-agent/README.md
@@ -4,10 +4,14 @@ This chart deploys the [Teleport](https://goteleport.com) kube-agent — a light
 cluster's Kubernetes API to the central [`teleport-cluster`](../teleport-cluster/README.md) (see `proxyAddr` in
 values.yaml), so operators access it through Teleport instead of a distributed kubeconfig.
 
+> **Deprecated:** Teleport is no longer KubeAid's default access layer — new clusters use the NetBird mesh with
+> Keycloak SSO instead. This chart remains available for existing setups.
+
 ## Why it's in KubeAid
 
-This is the per-managed-cluster half of KubeAid's Teleport-based access model: `teleport-cluster` runs the central
-proxy/auth service, and every managed cluster runs this agent to expose its API through it.
+This is the per-managed-cluster half of KubeAid's previous Teleport-based access model: `teleport-cluster` runs the
+central proxy/auth service, and every managed cluster runs this agent to expose its API through it. On current
+clusters that role is filled by NetBird (mesh access) and Keycloak (SSO).
 
 **NOTE: if there is no join-token secret, the pod would fail to start.**
 

--- a/docs/kubeaid/features-technical-details.md
+++ b/docs/kubeaid/features-technical-details.md
@@ -91,15 +91,19 @@ On AWS we have snapshot scripts to do regular and quick PVC backups.
 
 ### Supply chain attack protection and discovery - and security scans of all software used in the clusters
 
-We currently store all Helm charts from upstream in the [KubeAid repository](https://github.com/Obmondo/KubeAid). Upon
-updates to newer versions, we generate a `git diff`, which we review for any unexpected changes. This means that we
-would ONLY be vulnerable to supply chain attacks when downloading charts, but we have CI comparing OUR copy of the
-charts in the version we run to the upstream chart repo version (which we download and diff regularly) - that way we
-will detect if anyone has changed the upstream chart code compared to the version we run - which could indicate a supply
-chain attack on the chart repo.
+We store all upstream Helm charts vendored in the [KubeAid repository](https://github.com/Obmondo/KubeAid). Chart
+updates arrive as a pull request whose `git diff` is reviewed for unexpected changes before merging, and clusters
+deploy from your own mirror — so what runs is exactly the code that was reviewed, never something fetched live from
+an upstream registry at deploy time. The window for a supply-chain attack is limited to the moment a chart update is
+downloaded, and the update diff review is the checkpoint that catches it.
 
-**TODO:** Add something like Threadmapper - to scan clusters for security issues
+Complementing this, in-cluster scanning ships as charts:
 
-**TODO:** Add detection of in-use Docker images in cluster and cache all in local registry
-
-**TODO:** Add vulnerability scanning of Docker images used
+- [trivy-operator](../../argocd-helm-charts/trivy-operator/README.md) with
+  [version-checker](../../argocd-helm-charts/version-checker/README.md) scans running images for vulnerabilities and
+  alerts when a fixable CVE has an upgrade available (`cluster.security.vulnerabilityScanning`).
+- [kubescape-operator](../../argocd-helm-charts/kubescape-operator/README.md) scans cluster configuration and
+  workloads for security issues.
+- [Harbor](../../argocd-helm-charts/harbor/README.md) with the
+  [kyverno](../../argocd-helm-charts/kyverno/README.md) proxy-cache policy caches in-use images in your own
+  registry, on clusters that deploy Harbor.

--- a/docs/kubeaid/features-technical-details.md
+++ b/docs/kubeaid/features-technical-details.md
@@ -50,10 +50,6 @@ See our **[Prometheus Configuration Guide](./prometheus-configuration.md)** for 
 
 We currently have CI support for GitLab and GitHub Actions.
 
-**TODO:** Implement Robusta to automate handling of trivial tasks, like increasing size of a PVC (and running disk
-cleanup
-scripts first to try and avoid it), or scaling up instead.
-
 ### Regular application updates with security and bug fixes, ready to be issued to your cluster(s) at will
 
 We update this repository with updated versions of the applications, and improvements - which you will get automatically

--- a/docs/kubeaid/helm-umbrella-pattern.md
+++ b/docs/kubeaid/helm-umbrella-pattern.md
@@ -133,47 +133,59 @@ git pull upstream main
 
 ## Working with the Pattern
 
+Each cluster's applications live in your kubeaid-config repository under `k8s/<cluster>/argocd-apps/`: an
+`Application` manifest per app in `templates/`, and a `values-<app>.yaml` per app next to them.
+
 ### Adding a New Application
 
-1. Check if the chart exists in `argocd-helm-charts/`
-2. Enable it in your cluster's values:
+1. Check that the chart exists in `argocd-helm-charts/`.
+2. Add an `Application` manifest at `k8s/<cluster>/argocd-apps/templates/<app>.yaml`, following the two-source
+   pattern — the chart comes from KubeAid, the values from your kubeaid-config repo:
 
 ```yaml
-# kubeaid-config/k8s/<cluster>/values.yaml
-applications:
-  velero:
-    enabled: true
-    values:
-      # Your custom values here
+# k8s/<cluster>/argocd-apps/templates/velero.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: velero
+  namespace: argocd
+spec:
+  destination:
+    namespace: velero
+    server: https://kubernetes.default.svc
+  project: default
+  sources:
+    - repoURL: https://github.com/Obmondo/kubeaid.git
+      path: argocd-helm-charts/velero
+      targetRevision: <kubeaid-release-tag>
+      helm:
+        valueFiles:
+          - $values/k8s/<cluster>/argocd-apps/values-velero.yaml
+    - repoURL: <your-kubeaid-config-repo-url>
+      targetRevision: HEAD
+      ref: values
 ```
 
-1. Commit and push - ArgoCD will deploy it
+1. Add `k8s/<cluster>/argocd-apps/values-velero.yaml` with your overrides, commit and push — ArgoCD deploys it.
 
 ### Customizing an Application
 
-Override values in your `kubeaid-config` repository:
+Edit the app's values file. Keys under the subchart's name override the vendored upstream chart; top-level keys
+configure the wrapper's own KubeAid additions:
 
 ```yaml
-# kubeaid-config/k8s/<cluster>/argocd/cert-manager.yaml
-spec:
-  source:
-    helm:
-      values: |
-        installCRDs: true
-        global:
-          leaderElection:
-            namespace: cert-manager
+# k8s/<cluster>/argocd-apps/values-cert-manager.yaml
+cert-manager:        # -> the vendored upstream chart
+  installCRDs: true
+issuer:              # -> the KubeAid wrapper's own template
+  name: letsencrypt
+  enabled: true
 ```
 
 ### Disabling an Application
 
-Remove or disable it in your configuration:
-
-```yaml
-applications:
-  some-app:
-    enabled: false
-```
+Delete the app's `Application` manifest from `k8s/<cluster>/argocd-apps/templates/` (and its values file), then
+sync the root app with prune — ArgoCD removes the application and its resources.
 
 ## Relationship with ArgoCD
 


### PR DESCRIPTION
Two docs-accuracy fixes, one commit each:

## 1. Access management default
The README's features list credited Teleport with unified access management. The current model: cluster access runs over the **NetBird mesh** with **Keycloak** as the SSO identity provider by default; Teleport is deprecated but remains available for existing setups. Deprecation banners added to both teleport chart READMEs (also fixes their kubeaid.io/docs/apps pages).

## 2. Real kubeaid-config override structure
helm-umbrella-pattern.md's "Working with the Pattern" examples were invented (`applications:`-enable key, `argocd/<app>.yaml` inline values). Replaced with the real layout, verified against a live kubeaid-config repo: `k8s/<cluster>/argocd-apps/templates/<app>.yaml` two-source Application (chart from KubeAid, values via `$values` ref) + `values-<app>.yaml` keyed by subchart name, wrapper keys top-level.