### PR TITLE
docs: honest roadmap + drop stale AKS autoscaling TODO (missed the #204 merge)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,48 +1,32 @@
 # Roadmap
 
-High-level feature goals for KubeAid. The current implementation status of
-each item — what's done, what's in progress, and how it works — is documented
-in [Technical Details on the
-Features](./docs/kubeaid/features-technical-details.md).
+Most of what KubeAid set out to do is shipped — the [README](./README.md#features) lists the feature set and
+[Technical Details on the Features](./docs/kubeaid/features-technical-details.md) documents the implementation
+status of each piece. This roadmap lists what is genuinely open.
 
-This roadmap reflects current priorities and will shift as the project and
-its users grow; it isn't a committed release schedule.
+This reflects current priorities and will shift as the project and its users grow; it isn't a committed release
+schedule.
 
-## Feature goals
+## Cluster lifecycle
 
-* Set up Kubernetes clusters on:
-  * **Physical servers**: On-premise and [Hetzner](https://www.hetzner.com/) Bare Metal
-  * **Cloud VMs**: [Hetzner HCloud](https://www.hetzner.com/cloud), [AWS](https://aws.amazon.com/), and
-    [Azure](https://azure.microsoft.com/)
-  * **Managed control planes**: [AWS EKS](https://aws.amazon.com/eks/) and
-    [Azure AKS](https://azure.microsoft.com/en-us/products/kubernetes-service)
-  * **Hybrid clusters**: Combining Hetzner Bare Metal with HCloud VMs
-* Auto-scaling for all cloud Kubernetes clusters and easy scaling for physical
-  servers
-* Manage an ever-growing list of open-source Kubernetes applications (see the
-  [`argocd-helm-charts/`](./argocd-helm-charts/) folder for the current list)
-* Build advanced, customised Prometheus monitoring using just a per-cluster
-  config file, with automated handling of trivial alerts, like disk filling
-* GitOps setup — ALL changes in a cluster are done via Git, AND we detect if
-  anyone adds anything in the cluster or modifies existing resources without
-  doing it through Git
-* Frequent updates for KubeAid-managed applications with security and bug
-  fixes, ready to be issued to your cluster(s) at will — so you can focus on
-  your business applications
-* [Air-gapped operation](https://kubernetes.io/blog/2023/10/12/bootstrap-an-air-gapped-cluster-with-kubeadm/)
-  of your clusters, to ensure operational stability
-* Cluster security — proper NetworkPolicies to secure intra-cluster and
-  ingress traffic, ensuring least privilege between applications
-* Backup, recovery and live migration of applications or entire clusters
-* Major cluster upgrades via a shadow Kubernetes setup (a parallel failover
-  cluster that allows you to test upgrades and seamlessly switch over),
-  utilising the recovery and live migration features
-* Supply-chain attack protection and discovery, with frequent security scans
-  of all software used in the clusters (as new vulnerabilities are constantly
-  being discovered)
+- **`cluster recover` for cloud and managed control planes** — recovery is wired for self-managed AWS/Azure;
+  EKS and AKS clusters currently re-bootstrap and restore from Velero backups manually.
+- **Hetzner day-2 parity** — `cluster upgrade` and `cluster recover` for Hetzner Cloud, Bare Metal and hybrid
+  clusters are work in progress (see the
+  [kubeaid-cli provider matrix](https://github.com/Obmondo/kubeaid-cli#cloud-providers)).
+- **Day-2 `cluster sync` beyond bare metal** — reconciling config changes onto running Cluster API clusters;
+  tracked in the [kubeaid-cli roadmap](https://github.com/Obmondo/kubeaid-cli/blob/main/ROADMAP.md).
+
+## Resilience
+
+- **Live cluster migration** — moving applications or whole clusters between environments (for example built on
+  Cilium Cluster Mesh), which also unlocks major upgrades via a shadow cluster with seamless switchover.
+- **Full air-gapped operation** — maintaining an in-cluster copy of every container image in use and pointing
+  all charts at it. Harbor proxy-cache with the kyverno rewrite policy covers clusters that deploy Harbor;
+  the platform-wide flow is still open.
 
 ## Contributing to the roadmap
 
-Have a use case this doesn't cover, or want to work on one of the items
-above? Open an [issue](https://github.com/Obmondo/KubeAid/issues) — see
-[CONTRIBUTING.md](./CONTRIBUTING.md) for how to get started.
+Have a use case this doesn't cover, or want to work on one of the items above? Open an
+[issue](https://github.com/Obmondo/KubeAid/issues) — see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to get
+started.

--- a/docs/kubeaid/features-technical-details.md
+++ b/docs/kubeaid/features-technical-details.md
@@ -15,12 +15,11 @@ Read our detailed guide on **[GitOps Drift Detection and Alerting](./gitops-drif
 
 ### Auto-scaling for all cloud Kubernetes clusters and easy scaling for physical servers
 
-We currently have working autoscale for Amazon Web Services (AWS).
+We currently have working autoscale for Amazon Web Services (AWS). On AKS, agent pools are scaled by AKS's
+built-in cluster autoscaler.
 
 KubeAid also supports the managed control planes on EKS and AKS: it can bootstrap and delete such clusters, and
 upgrades are done as a version bump in your GitOps repository.
-
-**TODO:** Get autoscaling working for Azure Kubernetes Service (AKS).
 
 ### Manage an ever-growing list of Open Source Kubernetes applications
 


### PR DESCRIPTION
Two commits that were pushed to the #204 branch moments after it was merged, recovered here:

1. **ROADMAP.md rewritten** — the old feature-goals list had shipped almost entirely; the roadmap now lists only genuinely open work (cloud/managed recover, Hetzner day-2 parity, cluster sync beyond bare metal, live migration → shadow upgrades, full air-gap image mirroring), each grounded in the repo's own status docs.
2. **Stale AKS autoscaling TODO dropped** from features-technical-details — AKS agent pools are scaled by AKS's built-in cluster autoscaler.

Also deleted the stale `readme-header-diagram` remote branch that was carrying these.