### PR TITLE
docs: correct update-rollout and air-gap FAQ answers

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,12 +34,15 @@ chart values per cluster. See the warning in
 
 ## How do updates reach my cluster?
 
-Obmondo updates the upstream KubeAid repository with new application versions and improvements. You pull those into
-your mirror either automatically (grant write access to the GitHub user `obmondo-pushupdate-user`) or manually with a
-`git fetch upstream && git merge upstream/main`. Once your mirror is updated, ArgoCD notices and marks the affected
-applications `OutOfSync`; you can inspect the exact diff before syncing. See
-[Post-Configuration, Step 6](./getting-started/post-configuration.md#step-6-configure-updates) and, for pinning all
-apps to a specific KubeAid release tag during a service window,
+Obmondo updates the upstream KubeAid repository with new application versions and improvements, published as
+[release tags](https://github.com/Obmondo/KubeAid/releases). You pull those into your mirror either automatically
+(grant write access to the GitHub user `obmondo-pushupdate-user`) or manually with
+`git fetch upstream --tags && git merge upstream/master`. Updating the mirror alone changes nothing on the cluster:
+every ArgoCD Application pins the KubeAid repository to a specific release tag (`targetRevision`). To roll an update
+out, bump that pinned tag across all apps with `bin/update-kubeaid-argocd-app.sh -c <cluster-name> -r <tag>` and push
+the resulting kubeaid-config change - only then does ArgoCD mark the affected applications `OutOfSync`, and you can
+inspect the exact diff before syncing during a service window. See
+[Post-Configuration, Step 6](./getting-started/post-configuration.md#step-6-configure-updates) and
 [Update KubeAid ArgoCD Apps](./operations/update-kubeaid-argocd-apps.md).
 
 ## Is auto-sync enabled - who actually applies changes?
@@ -89,10 +92,12 @@ alongside the metrics stack. See [Monitoring](./monitoring.md) for the full pict
 ## Can KubeAid run air-gapped?
 
 Partially, by design. The repository vendors everything needed to set up (or fully recover) a cluster - charts,
-templates, and configuration - and regular PVC backups are part of the model. Maintaining a mirrored copy of all
-container images and pointing every chart at it is still an open TODO, so image pulls currently need registry
-access; hosting your own registry with [Harbor](./guides/harbor-registry.md) is the documented building block for
-that. See [Features Technical Details](./kubeaid/features-technical-details.md).
+templates, and configuration - and regular PVC backups are part of the model. For container images, the kyverno
+chart ships a `harbor-proxy-cache-mutate` ClusterPolicy that rewrites image references (docker.io, and optionally
+ghcr.io and registry.k8s.io) to your own [Harbor](./guides/harbor-registry.md) registry at admission time, so
+workloads pull through your registry instead of the upstream ones - no per-chart image overrides needed. A fully
+disconnected install (every image pre-mirrored, with no upstream access at all) is still on the
+[roadmap](../ROADMAP.md). See [Features Technical Details](./kubeaid/features-technical-details.md).
 
 ## What is a VPN-type cluster?
 

--- a/docs/getting-started/post-configuration.md
+++ b/docs/getting-started/post-configuration.md
@@ -161,10 +161,14 @@ Pull updates manually from the upstream KubeAid repository:
 ```bash
 cd /path/to/your/kubeaid-fork
 git remote add upstream https://github.com/Obmondo/KubeAid.git
-git fetch upstream
-git merge upstream/main
-git push origin main
+git fetch upstream --tags
+git merge upstream/master
+git push origin master --tags
 ```
+
+Updating the mirror makes new release tags available but changes nothing on the cluster by itself - your ArgoCD
+Applications pin the KubeAid repository to a release tag. To roll an update out, bump that pinned tag; see
+[Update KubeAid ArgoCD Apps](../operations/update-kubeaid-argocd-apps.md).
 
 ## Provider-Specific Notes
 

--- a/docs/kubeaid/features-technical-details.md
+++ b/docs/kubeaid/features-technical-details.md
@@ -62,7 +62,10 @@ can go view exact diff this update will cause on your cluster (`app diff`) or ju
 We maintain a copy of everything needed to set up your cluster (or do full recovery) in this repo, and run regular
 backups of PVCs.
 
-**TODO:** Maintain copy of all used Docker images and override images on all charts used to use that instead.
+Container images are redirected to your own Harbor registry by the `harbor-proxy-cache-mutate` Kyverno policy
+(shipped in the kyverno chart), which mutates image references at admission time - no per-chart image overrides
+needed. A fully disconnected install (every image pre-mirrored, with no upstream access at all) is on the
+[roadmap](../../ROADMAP.md).
 
 ### Cluster security
 


### PR DESCRIPTION
Two FAQ answers documented the wrong mechanism:

**How do updates reach my cluster?** claimed ArgoCD notices a mirror merge and marks apps OutOfSync. In reality every Application pins the KubeAid repo to a release tag (`targetRevision`), so a mirror merge changes nothing on the cluster — rollout happens by bumping the pinned tag with `bin/update-kubeaid-argocd-app.sh -c <cluster> -r <tag>`. Also fixed the upstream branch name (`master`, not `main`) here and in Post-Configuration Step 6, and made the manual-update commands fetch/push `--tags` so the pinned tags actually exist in the mirror.

**Can KubeAid run air-gapped?** claimed per-chart image repointing is an open TODO. The kyverno chart ships the `harbor-proxy-cache-mutate` ClusterPolicy, which rewrites docker.io (and optionally ghcr.io / registry.k8s.io) image references to your own Harbor registry at admission time — no per-chart overrides. Same stale TODO dropped from features-technical-details.md; a fully disconnected install stays on the roadmap.