### PR TITLE
feat(kubeaid-security-exporter): add chart, move posture collection o…

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/templates/rbac-cluster-read.yaml
+++ b/argocd-helm-charts/kubeaid-agent/templates/rbac-cluster-read.yaml
@@ -1,23 +1,19 @@
 {{/*
      The agent's cluster-scoped read access — one ClusterRole, one binding.
 
-     Replaces the built-in `view` ClusterRole this chart used to bind. `view` was
-     simultaneously too wide and too narrow:
-
-       too wide   — read on nearly every namespaced resource in the cluster,
-                    plus `watch` on all of them. The agent needs neither.
-
-       too narrow — custom resources appear in `view` only when their vendor
-                    ships a ClusterRole labelled aggregate-to-view. Cilium 1.20
-                    and Tetragon ship none; trivy-operator aggregates only three
-                    of its report kinds, not the rbac/infra assessments. Relying
-                    on `view` half-worked, which is worse than failing outright.
+     Replaces the built-in `view` ClusterRole this chart used to bind: `view`
+     grants read on nearly every namespaced resource plus `watch` on all of them,
+     and the agent needs neither.
 
      Every rule names the call site that needs it. Verbs are exactly what the
      code calls — the agent builds no informers, so `watch` is granted nowhere.
 
      Secrets are deliberately absent: they stay on the namespaced Role in
      rbac-secret-reader.yaml, which is what keeps that access scoped.
+
+     Security-posture reads — Trivy, Cilium, Tetragon, KubeArmor — are NOT here.
+     They belong to kubeaid-security-exporter, which collects that data and
+     serves it to the agent over HTTP. The agent holds no CRD access at all.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -37,12 +33,10 @@ rules:
     resources: ["events"]
     verbs: ["list"]
 
-  # get  — probing for the sealed-secrets controller (sealedsecret/seal.go)
-  # list — locating version-checker's metrics endpoint by label
-  #        (securityposture/versionchecker.go)
+  # Probing for the sealed-secrets controller (sealedsecret/seal.go).
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get", "list"]
+    verbs: ["get"]
 
   # Owner-ref walk targets and their container specs. ReplicaSet is read to
   # reach the Deployment above it; the rest for their pod templates.
@@ -60,72 +54,6 @@ rules:
       - jobs
       - cronjobs
     verbs: ["get"]
-{{- if .Values.appConfig.securityPosture.enabled }}
-
-  {{/*
-       Security posture. Gated by the SAME flag the agent reads, so the RBAC and
-       the CRON job can never disagree — granting these while the collector is
-       off is dead access, and running the collector without them fails on every
-       cycle.
-
-       IMPORTANT: every rule below is consumed through a DYNAMIC client. Nothing
-       in the agent's Go code references these resource names as imported types,
-       so a reader grepping for "vulnerabilityreports" finds only this file and
-       can reasonably conclude the rule is unused. Removing any of them does not
-       fail the build, does not fail startup, and does not log an obvious error
-       — the collector returns no data and the Obmondo UI renders the cluster as
-       clean. This is the same trap already hit in backup-exporter.
-  */}}
-
-  # Trivy Operator — vulnerabilities and least-privilege posture.
-  - apiGroups: ["aquasecurity.github.io"]
-    resources:
-      - vulnerabilityreports
-      - configauditreports
-      - rbacassessmentreports
-      - infraassessmentreports
-    verbs: ["get", "list"]
-
-  # Upstream NetworkPolicy, read alongside CiliumNetworkPolicy to decide whether
-  # an app ships a policy at all.
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["networkpolicies"]
-    verbs: ["get", "list"]
-
-  # Cilium — CiliumEndpoint carries the realised per-direction enforcement
-  # state; CiliumNetworkPolicy is what an app ships; TracingPolicy is Tetragon's
-  # runtime detection posture. All under cilium.io.
-  #
-  # The collector swallows a list error on the policy kinds, so omitting either
-  # policy rule reports every app as shipping no network policy — no error, no
-  # log, no metric.
-  - apiGroups: ["cilium.io"]
-    resources:
-      - ciliumendpoints
-      - ciliumnetworkpolicies
-      - tracingpolicies
-      - tracingpoliciesnamespaced
-    verbs: ["get", "list"]
-
-  # KubeArmor — the second runtime engine, reported alongside Tetragon. All four
-  # policy kinds are read: host and cluster policies are cluster-scoped, the
-  # other two namespaced, and an operator can enforce through any of them.
-  - apiGroups: ["security.kubearmor.com"]
-    resources:
-      - kubearmorpolicies
-      - kubearmorclusterpolicies
-      - kubearmorhostpolicies
-      - kubearmornetworkpolicies
-    verbs: ["get", "list"]
-
-  # KubeArmorConfig carries the cluster-wide default postures (file, network,
-  # capabilities → audit or block). It lives under the OPERATOR's group, not the
-  # policy group, and without it a cluster whose policies all audit is
-  # indistinguishable from one whose defaults block.
-  - apiGroups: ["operator.kubearmor.com"]
-    resources: ["kubearmorconfigs"]
-    verbs: ["get", "list"]
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/argocd-helm-charts/kubeaid-agent/values.schema.json
+++ b/argocd-helm-charts/kubeaid-agent/values.schema.json
@@ -47,11 +47,15 @@
           "type": "object",
           "properties": {
             "enabled": {
-              "description": "When true, the agent collects vulnerability and posture snapshots and submits them to Obmondo API. Also gates the corresponding RBAC rules. Set false on clusters that must not ship vulnerability detail off-site.",
+              "description": "When true, the agent polls kubeaid-security-exporter and forwards its snapshots to Obmondo API. Set false on clusters that must not ship vulnerability detail off-site.",
               "type": "boolean"
             },
-            "interval": {
-              "description": "Cadence of the full posture collection. Trivy refreshes its reports on a 24h TTL, so polling faster re-reads identical data.",
+            "exporterURL": {
+              "description": "In-cluster URL of kubeaid-security-exporter. A bare Service name resolves within the agent's own namespace.",
+              "type": "string"
+            },
+            "pollInterval": {
+              "description": "How often the agent polls the exporter. The submit is skipped when collectedAt has not advanced.",
               "type": "string"
             },
             "windowCheckInterval": {
@@ -310,29 +314,6 @@
           "type": "object"
         },
         "scrapeTimeout": {
-          "type": "string"
-        }
-      }
-    },
-    "prometheusRule": {
-      "description": "Alerts on the agent's security-posture metrics. Only rendered when appConfig.securityPosture.enabled is true.",
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
-        "additionalLabels": {
-          "type": "object"
-        },
-        "additionalAnnotations": {
-          "type": "object"
-        },
-        "upgradableThreshold": {
-          "description": "Alert when more than this many images have both a fixable Critical/High finding and a newer tag upstream. One alert per cluster.",
-          "type": "integer"
-        },
-        "upgradableFor": {
-          "description": "How long the count must stay above the threshold before alerting.",
           "type": "string"
         }
       }

--- a/argocd-helm-charts/kubeaid-agent/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/values.yaml
@@ -45,21 +45,28 @@ appConfig:
     # enough not to thrash the API when no window is open.
     checkInterval: 15m
 
-  # Security posture: vulnerabilities with full CVE detail, least-privilege
-  # findings, per-app network enforcement and runtime detection posture,
-  # submitted to the Obmondo API for display in the UI.
+  # Security posture: vulnerabilities, least-privilege findings, network
+  # enforcement and runtime detection posture. The agent collects none of this
+  # itself — kubeaid-security-exporter does, and the agent forwards it.
   securityPosture:
-    # -- When false, neither CRON job is scheduled, no snapshot is sent to
-    # Obmondo API, and the corresponding RBAC rules are not created. This is
-    # the switch for clusters that must not ship vulnerability detail off-site.
+    # -- When false, the agent neither polls the exporter nor forwards anything
+    # to Obmondo API. This is the switch for clusters that must not ship
+    # vulnerability detail off-site.
     #
-    # Safe to leave on where no scanner is installed: the collector detects
-    # that through API discovery and does nothing, rather than erroring.
+    # Safe to leave on where the exporter is not installed: the poll fails, a
+    # metric records it, and nothing is submitted.
     enabled: true
 
-    # -- Cadence of the full posture collection. Trivy refreshes its reports on
-    # a 24h scannerReportTTL, so polling faster re-reads identical data.
-    interval: 12h
+    # -- In-cluster URL of kubeaid-security-exporter. A bare Service name
+    # resolves within the agent's own namespace; qualify it if the two charts
+    # deploy to different namespaces.
+    exporterURL: http://kubeaid-security-exporter
+
+    # -- How often the agent polls the exporter. Cheap, because the exporter
+    # serves a cached snapshot and the agent skips the submit when collectedAt
+    # has not advanced. End-to-end freshness is bounded by the EXPORTER's
+    # collection interval, not by this one.
+    pollInterval: 1h
 
     # -- Cadence at which the agent checks for a service-window edge, to capture
     # a before/after pair around maintenance. This bounds how precisely an edge
@@ -161,27 +168,4 @@ serviceMonitor:
 
   interval: 30s
   scrapeTimeout: 10s
-
-# Alerts on the agent's own security-posture metrics. Only rendered when
-# appConfig.securityPosture.enabled is true, since without collection the
-# metrics never appear and every rule would evaluate against nothing.
-prometheusRule:
-  enabled: true
-
-  # -- Extra labels on the PrometheusRule object, for Prometheus selector
-  # matching.
-  additionalLabels: {}
-  additionalAnnotations: {}
-
-  # -- Alert when more than this many images have BOTH a fixable Critical/High
-  # finding and a newer tag upstream. One alert per cluster, not one per image.
-  #
-  # Deliberately high. Every real cluster carries a few of these at any moment,
-  # so a low threshold fires everywhere on day one and gets ignored. The signal
-  # worth acting on is a pile of easy upgrades, not the existence of one.
-  upgradableThreshold: 20
-
-  # -- How long the count must stay above the threshold. Long by design: this
-  # is a backlog to work through, not an incident.
-  upgradableFor: 24h
 

--- a/argocd-helm-charts/kubeaid-security-exporter/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-security-exporter/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: kubeaid-security-exporter
+description: Collects cluster security posture — vulnerabilities, least-privilege findings, network enforcement and runtime detection — and serves it over HTTP and Prometheus.
+icon: https://avatars.githubusercontent.com/u/13882947?s=250&v=4
+
+type: application
+
+version: 0.1.0
+appVersion: 0.1.0
+
+keywords:
+  - obmondo
+  - kubeaid
+  - security
+  - trivy
+
+maintainers:
+  - name: Sanskar Bhushan
+    email: sanskar@obmondo.com
+    url: https://github.com/sbdtu5498
+  - name: Archisman Mridha
+    email: archisman@obmondo.com
+    url: https://github.com/Archisman-Mridha
+  - name: Basit Hasan
+    email: basit@obmondo.com
+    url: https://github.com/basit9958

--- a/argocd-helm-charts/kubeaid-security-exporter/templates/_helpers.tpl
+++ b/argocd-helm-charts/kubeaid-security-exporter/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/* Determine the final chart name. */}}
+{{- define "kubeaid-security-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Determine the final application name. */}}
+{{- define "kubeaid-security-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Common conventional labels. */}}
+{{- define "kubeaid-security-exporter.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "kubeaid-security-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end -}}
+
+{{/* Selector labels. */}}
+{{- define "kubeaid-security-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubeaid-security-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/argocd-helm-charts/kubeaid-security-exporter/templates/deployment.yaml
+++ b/argocd-helm-charts/kubeaid-security-exporter/templates/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubeaid-security-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubeaid-security-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      {{- include "kubeaid-security-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kubeaid-security-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.deployment.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kubeaid-security-exporter.fullname" . }}
+      {{- with .Values.deployment.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "kubeaid-security-exporter.name" . }}
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          env:
+            - name: SECURITY_EXPORTER_PORT
+              value: {{ .Values.exporter.port | quote }}
+            - name: SECURITY_EXPORTER_INTERVAL
+              value: {{ .Values.exporter.interval | quote }}
+            {{- with .Values.deployment.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.exporter.port }}
+              protocol: TCP
+          {{- with .Values.deployment.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.deployment.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.deployment.probes.readiness }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.probes.liveness }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.deployment.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
+      {{- with .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/argocd-helm-charts/kubeaid-security-exporter/templates/prometheusrule.yaml
+++ b/argocd-helm-charts/kubeaid-security-exporter/templates/prometheusrule.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.appConfig.securityPosture.enabled .Values.prometheusRule.enabled }}
+{{- if .Values.prometheusRule.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ include "kubeaid-agent.fullname" . }}-security-posture
+  name: {{ include "kubeaid-security-exporter.fullname" . }}
   labels:
-    {{- include "kubeaid-agent.labels" . | nindent 4 }}
+    {{- include "kubeaid-security-exporter.labels" . | nindent 4 }}
     {{- with .Values.prometheusRule.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -14,16 +14,16 @@ metadata:
   {{- end }}
 spec:
   groups:
-    - name: kubeaid-agent.security-posture
+    - name: kubeaid-security-exporter
       rules:
         # Images with a fixable Critical/High finding AND a newer tag upstream
-        # — the set worth acting on. The agent computes the join, because
+        # — the set worth acting on. The exporter computes the join, because
         # rebuilding image references in PromQL fails silently.
         #
         # A count, so one alert per cluster rather than one per image.
         - alert: ImageOutdatedAndVulnerable
           expr: |
-            kubeaid_agent_security_posture_upgradable_vulnerable_images
+            security_exporter_upgradable_vulnerable_images
               > {{ .Values.prometheusRule.upgradableThreshold }}
           for: {{ .Values.prometheusRule.upgradableFor }}
           labels:
@@ -32,7 +32,7 @@ spec:
             summary: "{{ "{{ $value }}" }} images have fixable Critical/High CVEs with an upgrade available"
             description: "These images can be moved to a newer tag today, and doing so clears a known fixable exposure. List them with: kubectl get vulnerabilityreports -A"
 
-        # Collection status is exported as kubeaid_agent_security_posture_collection
+        # Collection status is exported as security_exporter_collection
         # (1 ok, 0 failed, -1 not installed) but deliberately not alerted on —
         # it is a debugging signal, not something worth waking anyone for.
 {{- end }}

--- a/argocd-helm-charts/kubeaid-security-exporter/templates/rbac-cluster-read.yaml
+++ b/argocd-helm-charts/kubeaid-security-exporter/templates/rbac-cluster-read.yaml
@@ -1,0 +1,87 @@
+{{/*
+     Cluster-scoped read access. Every rule is consumed through a DYNAMIC client,
+     so no Go code references these resource names as imported types — a reader
+     grepping for "vulnerabilityreports" finds only this file.
+
+     Removing any of them does not fail the build, does not fail startup and logs
+     nothing obvious: the collector returns no data and the cluster renders as
+     clean. Same trap already hit in backup-exporter.
+
+     Verbs are exactly what the code calls. The exporter builds no informers, so
+     `watch` is granted nowhere.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubeaid-security-exporter.fullname" . }}-read
+  labels:
+    {{- include "kubeaid-security-exporter.labels" . | nindent 4 }}
+rules:
+  # Locating version-checker's metrics endpoint by label, which is how image
+  # tags get compared against upstream.
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+
+  # Trivy Operator — vulnerabilities and least-privilege posture.
+  - apiGroups: ["aquasecurity.github.io"]
+    resources:
+      - vulnerabilityreports
+      - configauditreports
+      - rbacassessmentreports
+      - infraassessmentreports
+    verbs: ["get", "list"]
+
+  # Upstream NetworkPolicy, read alongside CiliumNetworkPolicy to decide whether
+  # an app ships a policy at all.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list"]
+
+  # CiliumEndpoint carries the realised per-direction enforcement state;
+  # CiliumNetworkPolicy is what an app ships; TracingPolicy is Tetragon's runtime
+  # detection posture. All three live under cilium.io.
+  #
+  # A list error on the policy kinds is swallowed, so omitting either policy rule
+  # reports every app as shipping no network policy — no error, no log, no metric.
+  - apiGroups: ["cilium.io"]
+    resources:
+      - ciliumendpoints
+      - ciliumnetworkpolicies
+      - tracingpolicies
+      - tracingpoliciesnamespaced
+    verbs: ["get", "list"]
+
+  # KubeArmor — the second runtime engine. All four policy kinds: host and
+  # cluster policies are cluster-scoped, the other two namespaced, and an
+  # operator can enforce through any of them.
+  - apiGroups: ["security.kubearmor.com"]
+    resources:
+      - kubearmorpolicies
+      - kubearmorclusterpolicies
+      - kubearmorhostpolicies
+      - kubearmornetworkpolicies
+    verbs: ["get", "list"]
+
+  # KubeArmorConfig carries the cluster-wide default postures (file, network,
+  # capabilities → audit or block). It lives under the OPERATOR's group, not the
+  # policy group, and without it a cluster whose policies all audit is
+  # indistinguishable from one whose defaults block.
+  - apiGroups: ["operator.kubearmor.com"]
+    resources: ["kubearmorconfigs"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubeaid-security-exporter.fullname" . }}-read
+  labels:
+    {{- include "kubeaid-security-exporter.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubeaid-security-exporter.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubeaid-security-exporter.fullname" . }}-read

--- a/argocd-helm-charts/kubeaid-security-exporter/templates/service.yaml
+++ b/argocd-helm-charts/kubeaid-security-exporter/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubeaid-security-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubeaid-security-exporter.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "kubeaid-security-exporter.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/argocd-helm-charts/kubeaid-security-exporter/templates/serviceaccount.yaml
+++ b/argocd-helm-charts/kubeaid-security-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubeaid-security-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubeaid-security-exporter.labels" . | nindent 4 }}

--- a/argocd-helm-charts/kubeaid-security-exporter/templates/servicemonitor.yaml
+++ b/argocd-helm-charts/kubeaid-security-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kubeaid-security-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubeaid-security-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kubeaid-security-exporter.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/argocd-helm-charts/kubeaid-security-exporter/values.schema.json
+++ b/argocd-helm-charts/kubeaid-security-exporter/values.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "exporter": {
+      "type": "object",
+      "properties": {
+        "port": {
+          "description": "Port the exporter listens on. Serves /healthz, /readyz, /metrics and /api/v1/security-posture.",
+          "type": "integer"
+        },
+        "interval": {
+          "description": "Cadence of the full posture collection, and the staleness bound on what kubeaid-agent forwards.",
+          "type": "string"
+        }
+      }
+    },
+    "deployment": {
+      "type": "object",
+      "properties": {
+        "replicas": {
+          "type": "integer"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "imagePullSecrets": {
+          "type": "array"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            }
+          }
+        },
+        "env": {
+          "type": "array"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "probes": {
+          "type": "object",
+          "properties": {
+            "readiness": {
+              "type": "object"
+            },
+            "liveness": {
+              "type": "object"
+            }
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "extraVolumes": {
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "type": "array"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "object"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "port": {
+          "type": "integer"
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "interval": {
+          "type": "string"
+        },
+        "scrapeTimeout": {
+          "type": "string"
+        }
+      }
+    },
+    "prometheusRule": {
+      "description": "Alerts on the exporter's security-posture metrics.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "additionalLabels": {
+          "type": "object"
+        },
+        "additionalAnnotations": {
+          "type": "object"
+        },
+        "upgradableThreshold": {
+          "description": "Alert when more than this many images have both a fixable Critical/High finding and a newer tag upstream. One alert per cluster.",
+          "type": "integer"
+        },
+        "upgradableFor": {
+          "description": "How long the count must stay above the threshold before alerting.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/argocd-helm-charts/kubeaid-security-exporter/values.yaml
+++ b/argocd-helm-charts/kubeaid-security-exporter/values.yaml
@@ -1,0 +1,119 @@
+nameOverride: ""
+fullnameOverride: ""
+
+exporter:
+  # -- Port the exporter listens on. Serves /healthz, /readyz, /metrics and
+  # /api/v1/security-posture — the last is what kubeaid-agent GETs.
+  port: 8080
+
+  # -- Cadence of the full posture collection. Trivy refreshes its reports on a
+  # 24h scannerReportTTL, so polling faster re-reads identical data.
+  #
+  # This is also the staleness bound on what kubeaid-agent forwards: the agent
+  # serves whatever was last collected, it does not trigger a fresh pass.
+  interval: 12h
+
+deployment:
+  replicas: 1
+
+  podLabels: {}
+  podAnnotations: {}
+
+  imagePullSecrets: []
+
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
+
+  image:
+    repository: ghcr.io/obmondo/kubeaid-security-exporter
+    tag: v0.1.0
+    pullPolicy: IfNotPresent
+
+  env: []
+
+  securityContext:
+    privileged: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    capabilities:
+      drop: ["ALL"]
+
+  probes:
+    readiness:
+      httpGet:
+        path: /readyz
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    liveness:
+      httpGet:
+        path: /healthz
+        port: http
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 2
+      successThreshold: 1
+
+  # -- A collection pass holds every VulnerabilityReport in the cluster in
+  # memory at once, so the ceiling scales with image count rather than with
+  # request rate. Raise the limit before lowering it.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  terminationGracePeriodSeconds: 10
+
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+service:
+  labels: {}
+  annotations: {}
+
+  port: 80
+
+serviceMonitor:
+  enabled: true
+
+  labels: {}
+  annotations: {}
+
+  interval: 30s
+  scrapeTimeout: 10s
+
+prometheusRule:
+  enabled: true
+
+  # -- Extra labels on the PrometheusRule object, for Prometheus selector
+  # matching.
+  additionalLabels: {}
+  additionalAnnotations: {}
+
+  # -- Alert when more than this many images have BOTH a fixable Critical/High
+  # finding and a newer tag upstream. One alert per cluster, not one per image.
+  #
+  # Deliberately high. Every real cluster carries a few of these at any moment,
+  # so a low threshold fires everywhere on day one and gets ignored. The signal
+  # worth acting on is a pile of easy upgrades, not the existence of one.
+  upgradableThreshold: 20
+
+  # -- How long the count must stay above the threshold. Long by design: this
+  # is a backlog to work through, not an incident.
+  upgradableFor: 24h


### PR DESCRIPTION
…ff the agent

Security posture collection becomes its own workload. The new chart owns the Deployment, Service, ServiceMonitor, the cluster-read ClusterRole and the ImageOutdatedAndVulnerable alert.

kubeaid-agent drops all of it and now holds no CRD access whatsoever: the four Trivy report kinds, cilium.io, security.kubearmor.com, operator.kubearmor.com and networking.k8s.io/networkpolicies all move to a ServiceAccount that does nothing else. The services grant narrows to get, since the list verb was version-checker discovery and moved with the collector.

The agent reaches the data over HTTP instead: securityPosture.interval is replaced by exporterURL and pollInterval. Polling is hourly rather than 12-hourly because the exporter serves a cached snapshot and the submit is skipped when collectedAt has not advanced, so freshness is bounded by the exporter collection interval rather than the agent poll.

The alert moved with the metric it reads, now security_exporter_upgradable_vulnerable_images.