### PR TITLE
fix(hetzner): wait for the default route before detecting the primary NIC

### DIFF
--- a/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmConfig.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmConfig.yaml
@@ -181,7 +181,8 @@ spec:
     - |
       {{- include "hetzner.efiBootOrderScript" . | nindent 6 }}
 
-    - export NETWORK_INTERFACE=$(ip route get 8.8.8.8 | awk '{print $5; exit}')
+    - |
+      {{- include "hetzner.detectNetworkInterfaceScript" . | nindent 6 }}
 
     {{- if or (eq $.Values.mode "hybrid") (and (eq $.Values.mode "bare-metal") $.Values.bareMetal.vSwitch) }}
     {{/* Bring up the VLAN sub-interface for the Hetzner vSwitch.

--- a/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmControlPlane.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmControlPlane.yaml
@@ -514,7 +514,7 @@ spec:
           exit 1
         fi
 
-        NETWORK_INTERFACE="$(ip route get 8.8.8.8 | awk '{print $5; exit}')"
+        {{- include "hetzner.detectNetworkInterfaceScript" . | nindent 8 }}
         cat <<EOF > /etc/netplan/60-vlan.yaml
         network:
           version: 2
@@ -559,7 +559,7 @@ spec:
            bare-metal floating IP above) it needs no first-master-only /
            loopback handling. */}}
       - |
-        NETWORK_INTERFACE="$(ip route get 8.8.8.8 | awk '{print $5; exit}')"
+        {{- include "hetzner.detectNetworkInterfaceScript" . | nindent 8 }}
         cat <<EOF > /etc/netplan/60-hcloud-floating-ip.yaml
         network:
           version: 2

--- a/argocd-helm-charts/capi-cluster/charts/hetzner/templates/_helpers.tpl
+++ b/argocd-helm-charts/capi-cluster/charts/hetzner/templates/_helpers.tpl
@@ -60,3 +60,32 @@ else
   fi
 fi
 {{- end -}}
+
+{{/* Set NETWORK_INTERFACE to the NIC carrying the default route.
+     cloud-init's runcmd can start before networking is up — `ip route get`
+     then fails with "Network is unreachable" and NETWORK_INTERFACE ends up
+     empty. Callers interpolate it into netplan (`link: ${NETWORK_INTERFACE}`),
+     so an empty value yields "interface '' is not defined", netplan apply
+     fails, the node never gets its vSwitch address, and kubeadm join times
+     out against the private API endpoint. Observed consistently on Ubuntu
+     26.04, which brings networking up later than 24.04 did.
+     So: wait for the default route, and abort loudly rather than write an
+     invalid netplan. */}}
+{{- define "hetzner.detectNetworkInterfaceScript" -}}
+NETWORK_INTERFACE=""
+attempt=0
+while [ "$attempt" -lt 60 ]; do
+  NETWORK_INTERFACE="$(ip route get 8.8.8.8 2>/dev/null | awk '{print $5; exit}')"
+  if [ -n "$NETWORK_INTERFACE" ]; then
+    break
+  fi
+  attempt=$((attempt + 1))
+  sleep 2
+done
+if [ -z "$NETWORK_INTERFACE" ]; then
+  echo "ERROR: no default route after 120s — cannot determine the primary network interface" >&2
+  exit 1
+fi
+export NETWORK_INTERFACE
+echo "detected primary network interface: $NETWORK_INTERFACE"
+{{- end -}}


### PR DESCRIPTION
## Problem

Bare-metal nodes re-imaged to **Ubuntu 26.04** never join the cluster.

`cloud-init`'s `runcmd` can start before networking is up. The interface detection one-liner then fails:

```
+ ip route get 8.8.8.8
+ awk {print $5; exit}
RTNETLINK answers: Network is unreachable
```

`NETWORK_INTERFACE` ends up empty, so the netplan file written from it gets a bare `link:`, and `netplan apply` rejects the whole config:

```
/etc/netplan/60-vlan.yaml:7:12: Error in network definition: vswitch.4000: interface '' is not defined
```

The vSwitch VLAN is never created → the node has no address on `10.0.1.0/24` and no route to the private network → `kubeadm join` times out against the private API endpoint → `runcmd` fails → `cloud-init status` = `error` → CAPH parks the host in `ensure-provisioned` and retries forever.

Ubuntu 24.04 generally won this race; 26.04 brings networking up later and loses it consistently. Hit on `qa-htz1-kilroy-eu` worker `2836489` during a 32.4.0 + Ubuntu 26.04 upgrade; recovery needed manual SSH intervention on the node.

Note the `kubeaid-storagectl` block a few lines further down already carries a `sleep 10s` "to wait for networking to fully setup during fresh server setups" — the hazard was known, but the mitigation sits *after* the code that needs it.

## Fix

Replace the three copies of the one-liner with a shared `hetzner.detectNetworkInterfaceScript` helper that:

- polls for the default route (60 attempts x 2s) instead of assuming it exists, and
- aborts loudly with a clear error rather than writing an invalid netplan.

Call sites updated: `KubeadmConfig.yaml` (workers), and `KubeadmControlPlane.yaml` twice (bare-metal CP vSwitch VLAN, HCloud floating IPs).

## Testing

- `helm lint` passes.
- Rendered against real cluster values for `qa-htz1-kilroy-eu` and `production-htz1-kilroy-eu`: renders clean, guard present at all call sites, no old-style occurrences remain.
- Generated script verified as POSIX `sh` syntax-clean (`sh -n`) — cloud-init runs `runcmd` under `/bin/sh`.
- The equivalent logic was applied by hand on the failed node: interface detected correctly, netplan applied, VLAN came up, `kubeadm join` succeeded, node Ready on Ubuntu 26.04 / v1.35.0 with Ceph OSDs reattached.