### PR TITLE
fix(traefik): enable access logs

### DIFF
--- a/argocd-helm-charts/traefik/values.yaml
+++ b/argocd-helm-charts/traefik/values.yaml
@@ -25,6 +25,8 @@ traefik:
     revisionHistoryLimit: 0
   log:
     level: INFO
+  accessLog:
+    enabled: true
   ports:
     web:
       http:


### PR DESCRIPTION
The logs.level structure fix (1e0a7981b) renamed logs.access.enabled to log.level, but that's the wrong key: log.level only sets the general/startup log verbosity (already INFO by default) and doesn't enable access logging. accessLog.enabled defaults to false in the current chart schema, so access logs stopped being emitted entirely.