### PR TITLE
feat(security-exporter): read ArgoCD applications to attribute findings

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/charts/security-exporter/templates/rbac.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/security-exporter/templates/rbac.yaml
@@ -84,6 +84,19 @@ rules:
   - apiGroups: ["operator.kubearmor.com"]
     resources: ["kubearmorconfigs"]
     verbs: ["get", "list"]
+
+  # The only rule here that is not about finding vulnerabilities. ArgoCD
+  # applications carry kubeaid.io/managed-by and kubeaid.io/version, stamped by
+  # kubeaid-cli, and they are the sole in-cluster evidence of who can act on a
+  # finding: an image KubeAid pins moves when KubeAid moves, and one the
+  # cluster's owner deploys does not.
+  #
+  # Without it every workload is unattributable, and the exporter reports that
+  # honestly rather than guessing -- so removing this rule degrades the payload
+  # to "owner unknown" everywhere instead of failing loudly.
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Grants the security exporter read on ArgoCD `applications`, so it can say **who
can act** on a finding rather than only what is wrong.

A cluster's owner cannot repin an image KubeAid controls, and we cannot rebuild
theirs. A queue that mixes both is a queue neither party can work. `kubeaid-cli`
already stamps `kubeaid.io/managed-by` and `kubeaid.io/version` on every ArgoCD
application it generates, so reading the applications is enough to attribute
every workload and to report which KubeAid revision the cluster runs — nothing
new has to be published for it.

```yaml
- apiGroups: ["argoproj.io"]
  resources: ["applications"]
  verbs: ["get", "list"]
```

### Why this rule is different

It is the eighth API group the exporter reads and the only one added for a
reason other than finding vulnerabilities, so it carries a comment saying why.

`get` and `list` without `watch`, unlike the equivalent rule on
`obmondo-k8s-agent`: the exporter builds no informers and polls on a timer, so
`watch` would be privilege granted and never exercised.

### It does not fail loudly

Remove the rule and the applications list returns forbidden, the exporter
reports every workload as owner-unknown, and the payload stays honest but
useless for attribution. That is the right direction to fail in and easy to
miss, which is why the reasoning sits on the rule rather than only in a doc.

### Pairs with

`kubeaid-security-exporter` branch `feat/kubeaid-ownership`, which adds
`workloads[].managedBy` and the `kubeAid` block. That side treats an unknown
owner as unassigned rather than defaulting to the customer — telling someone a
problem is theirs when it is ours is a claim about responsibility, not a
miscounted number.

Without this rule the exporter change is inert but harmless; with it, both are
needed for attribution to work.
