### PR TITLE
fix(tetragon): install CRDs via helm so the shipped TracingPolicies sync

### DIFF
--- a/argocd-helm-charts/tetragon/values.yaml
+++ b/argocd-helm-charts/tetragon/values.yaml
@@ -20,7 +20,10 @@ tetragon:
   # - To route events to a different or internet-facing OpenObserve, add a second
   #   exporter + pipeline in the openobserve-collector values (filter on the Tetragon
   #   namespace) — Tetragon itself is unchanged.
-  {}
+  # TracingPolicy CRs ship with this chart, so their CRDs must too — the upstream
+  # "operator" default creates them at runtime and ArgoCD applies the CRs first.
+  crds:
+    installMethod: helm
 
 # KubeAid-owned TracingPolicy set.
 #


### PR DESCRIPTION
The chart ships curated TracingPolicy CRs, but crds.installMethod defaulted to "operator", which creates tracingpolicies.cilium.io at runtime from the tetragon-operator pod. Rendering the chart therefore produced the custom resources but none of their CRDs, so ArgoCD applied the CRs first and failed with "could not find cilium.io/TracingPolicy" on every fresh install.

Switching to the helm method ships all three CRDs in the manifest set; ArgoCD applies CRDs ahead of custom resources, making the install self-contained.