### PR TITLE
chore: bump whoami image to v1.12.0

### DIFF
--- a/argocd-helm-charts/whoami/Chart.yaml
+++ b/argocd-helm-charts/whoami/Chart.yaml
@@ -5,3 +5,6 @@ dependencies:
   - name: whoami
     version: 6.0.0
     repository: https://cowboysysop.github.io/charts/
+  - name: kubeaid-addons
+    version: 0.1.0
+    repository: file://../kubeaid-addons

--- a/argocd-helm-charts/whoami/values.yaml
+++ b/argocd-helm-charts/whoami/values.yaml
@@ -5,6 +5,9 @@ whoami:
   ingress:
     enabled: true
 
+  image:
+    tag: v1.12.0
+
 global:
   netpol:
     enabled: false


### PR DESCRIPTION
Image hadn't been updated in the last 6 months - 1 year on the chart we depend on https://github.com/cowboysysop/charts/tree/master/charts/whoami;
 a new upstream release is available: https://github.com/traefik/whoami/releases/tag/v1.12.0
 so pointing the image tag to it for now