### PR TITLE
fix(traefik-forward-auth): override image tag to v3.3.0

### DIFF
--- a/argocd-helm-charts/traefik-forward-auth/values.yaml
+++ b/argocd-helm-charts/traefik-forward-auth/values.yaml
@@ -1,4 +1,11 @@
 traefik-forward-auth:
+  # Chart is pinned at appVersion 3.1.0 (image.tag 3.1.0 by default) and
+  # hasn't been bumped since 2023. App itself has moved on to v3.3.0 --
+  # all dependency/go-version bumps and a cache race-condition fix, no
+  # flag/env/config changes -- so it's safe to override here rather than
+  # wait on https://github.com/mesosphere/charts/pull/1666
+  image:
+    tag: v3.3.0
   traefikForwardAuth:
     enabled: true
     clientId: traefik-forward-auth


### PR DESCRIPTION
Chart is pinned at appVersion 3.1.0 (image.tag 3.1.0) and hasn't been bumped upstream since 2023. App has since released v3.2.0, v3.2.1, v3.3.0 -- all dependency/go-version bumps plus a cache race-condition fix, no flag/env/config changes -- verified by running the image locally and confirming a clean OIDC redirect. Overriding here instead of waiting on the chart bump https://github.com/mesosphere/charts/pull/1666 .