### PR TITLE
chore: update container image kubeaid-agent to v1.1.0

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/values.yaml
@@ -105,7 +105,7 @@ deployment:
 
   image:
     repository: ghcr.io/obmondo/kubeaid-agent
-    tag: v1.0.0
+    tag: v1.1.0
     pullPolicy: Always
 
   env: []


### PR DESCRIPTION
Bumps the agent image to the `v1.1.0` release cut today.

`v1.1.0` is the first agent build that forwards security-posture snapshots from the security-exporter to the Obmondo API, and it adds the exporter-reachability logging — the agent now says when each exporter is reached and its data pulled, so a silent no-op is distinguishable from a successful empty pull.

The `security-exporter` subchart needs no change here: it already pins `ghcr.io/obmondo/kubeaid-security-exporter:v0.1.0`, which was tagged and pushed to ghcr today and therefore resolves to a real image for the first time.

Only `values.yaml` changes, matching the previous bump (53514af9).

Note: no KubeAid release tag yet carries the security-exporter subchart — `32.4.0` ships neither it nor an agent newer than `v0.7.0` — so this reaches version-pinned clusters only after the next `32.x` tag.