### PR TITLE
feat(security-exporter): default enabled to false

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/13882947?s=250&v=4
 
 type: application
 
-version: 0.4.0
+version: 0.5.0
 appVersion: 0.0.3
 
 keywords:
@@ -29,7 +29,7 @@ maintainers:
 # agent alone, or the agent plus either exporter.
 dependencies:
   - name: security-exporter
-    version: 0.2.0
+    version: 0.3.0
     condition: security-exporter.enabled
 
   - name: backup-exporter

--- a/argocd-helm-charts/kubeaid-agent/README.md
+++ b/argocd-helm-charts/kubeaid-agent/README.md
@@ -31,9 +31,11 @@ cluster-wide read — the coupling that separating them removed in the first pla
 bounds the blast radius: a security collection pass holds every VulnerabilityReport in memory at once, and as
 a sidecar an OOM there would take down the agent, and with it the cluster-liveness ping.
 
-Each exporter is independently switchable. `security-exporter.enabled` defaults to `true`;
-`backup-exporter.enabled` defaults to **`false`**, because it cannot start without S3 credentials for
-the backends it reports on.
+Each exporter is independently switchable, and **both default to `false`**. `backup-exporter.enabled`
+because it cannot start without S3 credentials for the backends it reports on;
+`security-exporter.enabled` because it holds cluster-wide read across eight API groups, which a chart
+must not grant to every cluster that installs the agent. The security exporter needs no credentials, so
+turning it on is nothing more than `enabled: true`.
 
 Both exporters are discovered by the agent at runtime rather than wired by config, so their object names are
 **pinned** rather than release-derived. The agent finds backup-exporter by the label
@@ -54,7 +56,8 @@ on the `kubeaid` Argo CD project, stored in the `argocd-project-role-kubeaid-age
 - `argocd-project-role-kubeaid-agent` Secret in the `argocd` namespace, holding the Argo CD auth token under the
   `token` key (created automatically by `kubeaid-cli`). Name overridable via
   `appConfig.argocd.authTokenSecretName`.
-- kube-prometheus, if `serviceMonitor` / `security-exporter.prometheusRule` stay enabled (all default to `true`).
+- kube-prometheus, if `serviceMonitor` stays enabled (default `true`), and for
+  `security-exporter.prometheusRule` on clusters where the security exporter is turned on.
 
 The exporter additionally wants, but does not require:
 
@@ -83,7 +86,7 @@ the parent's values file carries only the agent's own settings.
 | `appConfig.securityPosture.pollInterval` | `1h` | Poll cadence. The submit is skipped when `collectedAt` has not advanced, so end-to-end freshness is bounded by `security-exporter.exporter.interval`, not by this. |
 | `obmondoAPITLSSecretName` | `obmondo-clientcert` | Secret with the mTLS keypair. |
 | `extraSecretReaderNamespaces` | `[]` | Extra namespaces where a secrets-read Role/RoleBinding is created for the agent. |
-| `security-exporter.enabled` | `true` | Deploy the security exporter alongside the agent. |
+| `security-exporter.enabled` | `false` | Deploy the security exporter alongside the agent. Off by default: it holds cluster-wide read across eight API groups, so granting it is a per-cluster decision. Needs no credentials. |
 | `backup-exporter.enabled` | `false` | Deploy the backup exporter alongside the agent. Off by default: it needs S3 credentials per backend, so enabling it without those deploys a pod that cannot work. See the [Backup Exporter guide](../../docs/guides/backup-exporter.md). |
 | `security-exporter.exporter.interval` | `12h` | Collection cadence. Trivy refreshes its reports on a 24h TTL, so polling faster re-reads identical data. |
 | `security-exporter.prometheusRule.upgradableThreshold` | `20` | `ImageOutdatedAndVulnerable` fires above this many images having both a fixable Critical/High CVE and a newer tag available. |

--- a/argocd-helm-charts/kubeaid-agent/charts/security-exporter/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/security-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: security-exporter
 description: Collects cluster security posture and serves it for kubeaid-agent to forward.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.1.0"

--- a/argocd-helm-charts/kubeaid-agent/charts/security-exporter/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/security-exporter/values.yaml
@@ -6,9 +6,16 @@
 # because a pod carries one ServiceAccount and co-locating them would hand the
 # credential-holding workload this one's cluster-wide read.
 
-# -- Set false to run the agent without it. The agent tolerates its absence:
-# the poll fails, a metric records it, nothing is submitted.
-enabled: true
+# -- OFF by default. The exporter holds cluster-wide read across eight API
+# groups, and a chart must not grant that to every cluster that installs the
+# agent -- enabling it is a deliberate per-cluster act.
+#
+# Unlike the backup exporter it needs no credentials, so `enabled: true` is the
+# only thing required to turn it on.
+#
+# The agent tolerates its absence: the poll fails, a metric records it, nothing
+# is submitted.
+enabled: false
 
 # -- Overrides the Service and ServiceAccount name. Leave empty. The default
 # matches kubeaid-agent's appConfig.securityPosture.exporterURL, and changing


### PR DESCRIPTION
The exporter holds cluster-wide read across eight API groups. A chart must not grant that to every cluster that installs the agent, so turning it on becomes a deliberate per-cluster act -- the same rule the backup exporter already followed.

This reverses the reasoning in 9e4ca8f4, which kept it on because it needs no credentials. Needing no credentials is why enabling it is a one-line act; it is not a reason to grant the RBAC everywhere by default.

Both chart versions bump, matching bebc7b25: a subchart behaviour change is not visible through the parent's version alone.

Clusters that want it now set security-exporter.enabled: true. Anything tracking the chart at HEAD rather than a pinned release loses the exporter on the next sync unless that value lands first.