### PR TITLE
chore(kubeaid-agent): point liveness and readiness probes at /ping

### DIFF
--- a/argocd-helm-charts/keycloakx/values.yaml
+++ b/argocd-helm-charts/keycloakx/values.yaml
@@ -62,6 +62,7 @@ global:
   blackbox:
     netpol: false
     namespace: ""
+    probe: true
 
   postgresql:
     enabled: true
@@ -113,6 +114,3 @@ global:
         # Whether to enable Kube2IAM integration, instead of providing static AWS credentials
         # from a Kubernetes Secret.
         enableKube2IAMIntegration: true
-
-  blackbox:
-    probe: true

--- a/argocd-helm-charts/kubeaid-agent/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/values.yaml
@@ -120,9 +120,11 @@ deployment:
       drop: ["ALL"]
 
   probes:
+    # Process-only probes: do not call Obmondo/Prometheus. An API outage must
+    # not restart kubeaid-agent across every cluster. Use GET /ping.
     readiness:
       httpGet:
-        path: /healthz
+        path: /ping
         port: http
       initialDelaySeconds: 5
       periodSeconds: 10
@@ -131,7 +133,7 @@ deployment:
       successThreshold: 1
     liveness:
       httpGet:
-        path: /healthz
+        path: /ping
         port: http
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/argocd-helm-charts/prometheus-linuxaid/Chart.lock
+++ b/argocd-helm-charts/prometheus-linuxaid/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kubeaid-addons
+  repository: file://../kubeaid-addons
+  version: 0.1.0
+digest: sha256:bdb24e06cf50b4e684a392bbe22e8b3f19d6e204311d0926882500ecf66b9f4c
+generated: "2026-08-21T20:04:45.424286408+05:30"

--- a/argocd-helm-charts/prometheus-linuxaid/Chart.yaml
+++ b/argocd-helm-charts/prometheus-linuxaid/Chart.yaml
@@ -4,3 +4,7 @@ description: A Helm chart for monitoring linux server, which are subscribed on O
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
+dependencies:
+  - name: kubeaid-addons
+    version: 0.1.0
+    repository: file://../kubeaid-addons

--- a/argocd-helm-charts/prometheus-linuxaid/tests/btrfs.yaml
+++ b/argocd-helm-charts/prometheus-linuxaid/tests/btrfs.yaml
@@ -60,7 +60,7 @@ tests:
               alert_id: monitor::system::disk::btrfs
             exp_annotations:
               summary: "btrfs filesystem is nearly full"
-              description: "btrfs filesystem '4321' on cert1.abc is 94%\nused and has less than 5% of device space left unallocated, so btrfs can no longer\ncarve new chunks. Free space or add/grow a device.\n"
+              description: "btrfs filesystem '4321' on cert1.abc is 94%\nused and has less than 5% of device space left to allocate more, so btrfs can no longer\ncarve new chunks. Free space or add/grow a device.\n"
 
       - alertname: monitor::system::disk::btrfs::metadata_exhaustion
         eval_time: 30m
@@ -73,4 +73,4 @@ tests:
               alert_id: monitor::system::disk::btrfs::metadata_exhaustion
             exp_annotations:
               summary: "btrfs metadata is nearly exhausted"
-              description: "btrfs metadata on meta.abc (filesystem '5321') is\n90% full and less than 5% of device space is unallocated, so btrfs\ncannot allocate a new metadata chunk and the filesystem risks going read-only. Run\n'btrfs balance start -musage=NN /' or add/grow a device.\n"
+              description: "btrfs metadata on meta.abc (filesystem '5321') is\n90% full and less than 5% of device space is left to allocate more, so btrfs\ncannot allocate a new metadata chunk and the filesystem risks going read-only. Run\n'btrfs balance start -musage=NN /' or add/grow a device.\n"

--- a/argocd-helm-charts/prometheus-linuxaid/tests/cert_expiry.yaml
+++ b/argocd-helm-charts/prometheus-linuxaid/tests/cert_expiry.yaml
@@ -11,12 +11,16 @@ tests:
         values: 1x1000
       - series: probe_ssl_earliest_cert_expiry{domain="example.com",certname="dev01.example"}
         values: 1036800x100       # Tuesday, January 13, 1970 12:00:00 AM
+      - series: probe_success{domain="example.com",certname="dev01.example"}
+        values: 1x100             # scrape succeeded within last_over_time window
       - series: threshold::monitor::domains::cert_expiry_days{domain="example.com",certname="dev01.example"}
         values: 10x100            # Alert before 10 days
       - series: obmondo_monitoring{certname="dev02.example", alert_id="monitor::domains::cert_expiry"}
         values: 0x1000
       - series: probe_ssl_earliest_cert_expiry{domain="example.com",certname="dev02.example"}
         values: 1036800x100       # Tuesday, January 13, 1970 12:00:00 AM
+      - series: probe_success{domain="example.com",certname="dev02.example"}
+        values: 1x100
       - series: threshold::monitor::domains::cert_expiry_days{domain="example.com",certname="dev02.example"}
         values: 10x100            # Alert before 10 days
 

--- a/docs/guides/backup-exporter.md
+++ b/docs/guides/backup-exporter.md
@@ -34,12 +34,36 @@ not every cluster runs those backups.
 
 It is deployed with the `kubeaid-agent` Argo CD application, but is **off by default** — it needs S3
 credentials for each backend it reports on, and there is no sane default for those. Set
-`backupExporter.enabled: true` along with the credentials below. Key values, all under the
-`backupExporter` key:
+`backup-exporter.enabled: true` along with the credentials below. The Helm dependency condition
+and parent values key are both hyphenated (`backup-exporter`), matching `Chart.yaml`.
+
+Key values, all under the `backup-exporter` key in `values-kubeaid-agent.yaml` (sibling of
+`appConfig`, not nested under it):
 
 ```yaml
-backupExporter:
+backup-exporter:
   enabled: true
+
+  exporter:
+    # Postgres and Velero collectors run when the chart is enabled; fill S3 for each.
+    postgres:
+      s3:
+        secretName: ""            # Secret with access-key-id / secret-access-key (etc.)
+    velero:
+      s3:
+        url: ""                   # S3 endpoint URL
+        secretName: ""            # Or accessKeyId / secretAccessKey / region / bucket
+    # Opt-in backends (default false):
+    mongodb:
+      enabled: false
+      s3:
+        secretName: ""
+    sealedSecrets:
+      enabled: false
+      s3:
+        bucket: ""                # Must match sealed-secrets chart backup.s3Bucket
+        endpoint: ""              # Must match backup.s3Endpoint
+        secretName: ""
 
   # Enable Prometheus alerting rules
   prometheusRule:


### PR DESCRIPTION
## Summary
- Switch kubeaid-agent chart liveness and readiness from `/healthz` to `/ping`.
- Probes stay process-only: do not depend on Obmondo (or other external APIs).
- Update backup exporter docs
- lint fix blackbox keys