### PR TITLE
fix(kubeaid-agent): grant list on deployments for backup-exporter dis…

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/13882947?s=250&v=4
 
 type: application
 
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.0.3
 
 keywords:

--- a/argocd-helm-charts/kubeaid-agent/templates/rbac-cluster-read.yaml
+++ b/argocd-helm-charts/kubeaid-agent/templates/rbac-cluster-read.yaml
@@ -33,20 +33,31 @@ rules:
     resources: ["events"]
     verbs: ["list"]
 
-  # Probing for the sealed-secrets controller (sealedsecret/seal.go).
+  # get  — probing for the sealed-secrets controller (sealedsecret/seal.go).
+  # list — the backup-exporter discovery in internal/core/backup/handler.go
+  #        also lists Services by label after finding the Deployment.
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get"]
+    verbs: ["get", "list"]
 
   # Owner-ref walk targets and their container specs. ReplicaSet is read to
   # reach the Deployment above it; the rest for their pod templates.
   - apiGroups: ["apps"]
     resources:
       - replicasets
-      - deployments
       - statefulsets
       - daemonsets
     verbs: ["get"]
+
+  # Deployments also need list: the backup exporter's Deployment/Service
+  # name is release-derived, not pinned, so the agent's "Backup monitor"
+  # job discovers it cluster-wide by the app.kubernetes.io/name=backup-exporter
+  # label rather than by a known name (internal/core/backup/handler.go).
+  # Without list this job fails Forbidden every cycle and no backup status
+  # ever reaches Obmondo API.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
 
   # Job is read to reach its owning CronJob, both for their pod templates.
   - apiGroups: ["batch"]


### PR DESCRIPTION
…covery

The backup-exporter's Deployment name is release-derived, so the agent's "Backup monitor" job (internal/core/backup/handler.go) discovers it cluster-wide by the app.kubernetes.io/name=backup-exporter label rather than a known name. The least-privilege RBAC rewrite in bfa2007e0 granted only "get" on deployments (for the owner-ref walk from a Pod up to its Deployment), which doesn't cover a label-based list.

Result: every cycle fails with
  listing backup-exporter deployments: deployments.apps is forbidden:
  ... cannot list resource "deployments" in API group "apps" at the
  cluster scope
and no backup status ever reaches Obmondo API on any cluster running backup-exporter under kubeaid-agent >= this RBAC rewrite.

Split deployments into its own rule with get+list, leaving replicasets/statefulsets/daemonsets at get-only (still only ever accessed by name via the owner-ref walk).