### PR TITLE
fix(prometheus): stop probe_success guard from hiding cert expiry

### DIFF
--- a/argocd-helm-charts/prometheus-linuxaid/rules/cert_expiry.yaml
+++ b/argocd-helm-charts/prometheus-linuxaid/rules/cert_expiry.yaml
@@ -5,7 +5,6 @@ groups:
         expr: |
           (last_over_time(probe_ssl_earliest_cert_expiry[1d]) - time()) < on(certname, domain) (86400 * threshold::monitor::domains::cert_expiry_days)
           and on(certname) obmondo_monitoring{alert_id="monitor::domains::cert_expiry"} > 0
-          and on(certname, domain) last_over_time(probe_success[1d]) == 1
         for: 0m
         labels:
           severity: critical

--- a/argocd-helm-charts/prometheus-linuxaid/tests/cert_expiry.yaml
+++ b/argocd-helm-charts/prometheus-linuxaid/tests/cert_expiry.yaml
@@ -41,3 +41,57 @@ tests:
       - alertname: monitor::domains::cert_expiry
         eval_time: 1d
         exp_alerts: []
+
+  # Certificate has ALREADY expired. Blackbox verifies TLS, so probe_success
+  # drops to 0 at exactly the moment the alert matters. The alert must still
+  # fire off the last known probe_ssl_earliest_cert_expiry sample.
+  - interval: 1d
+    input_series:
+      - series: obmondo_monitoring{certname="dev03.example", alert_id="monitor::domains::cert_expiry"}
+        values: 1x1000
+      - series: probe_ssl_earliest_cert_expiry{domain="example.com",certname="dev03.example"}
+        values: 172800x100        # Saturday, January 3, 1970 12:00:00 AM
+      - series: probe_success{domain="example.com",certname="dev03.example"}
+        values: 0x100             # TLS verification fails once the cert expires
+      - series: threshold::monitor::domains::cert_expiry_days{domain="example.com",certname="dev03.example"}
+        values: 10x100
+
+    alert_rule_test:
+      - alertname: monitor::domains::cert_expiry
+        eval_time: 8d
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              certname: dev03.example
+              alert_id: monitor::domains::cert_expiry
+              domain: example.com
+            exp_annotations:
+              summary: "SSL certificate will expire soon for domain **example.com**"
+              description: Blackbox exporter on dev03.example, domain example.com certificate expires in -6d 0h 0m 0s
+
+  # A single failed scrape inside the staleness window must not suppress the
+  # alert - the guard looks for any success in the last day, not the last one.
+  # Note: file-level evaluation_interval is 1d, so eval_time must be a whole day.
+  - interval: 1h
+    input_series:
+      - series: obmondo_monitoring{certname="dev04.example", alert_id="monitor::domains::cert_expiry"}
+        values: 1x1000
+      - series: probe_ssl_earliest_cert_expiry{domain="example.com",certname="dev04.example"}
+        values: 259200x100
+      - series: probe_success{domain="example.com",certname="dev04.example"}
+        values: 1x22 0x2          # most recent scrape failed, earlier ones succeeded
+      - series: threshold::monitor::domains::cert_expiry_days{domain="example.com",certname="dev04.example"}
+        values: 10x100
+
+    alert_rule_test:
+      - alertname: monitor::domains::cert_expiry
+        eval_time: 1d
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              certname: dev04.example
+              alert_id: monitor::domains::cert_expiry
+              domain: example.com
+            exp_annotations:
+              summary: "SSL certificate will expire soon for domain **example.com**"
+              description: Blackbox exporter on dev04.example, domain example.com certificate expires in 2d 0h 0m 0s


### PR DESCRIPTION
The staleness guard required the latest probe_success sample to be exactly 1. A probe can fail for reasons unrelated to the certificate while probe_ssl_earliest_cert_expiry is still scraped fine, and the guard then discards a good expiry reading. With a 12h scrape interval, one failed scrape also suppressed the alert for a whole day.

Use max_over_time so any success in the window keeps the alert eligible, and fall back to the presence of an expiry reading so an unreachable probe cannot silence a cert that is about to expire, or has already.

Add tests for an already-expired cert and for a single failed scrape. Both fail against the previous expression.