### PR TITLE
fix(hetzner): propagate cloud-provider label to hcloud control-plane …

### DIFF
--- a/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmControlPlane.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/hetzner/templates/KubeadmControlPlane.yaml
@@ -842,6 +842,16 @@ spec:
         maxSurge: 0
   {{- else }}
   machineTemplate:
+    metadata:
+      # Label should meet one of the following criterias to propagate to Node :
+      #
+      # (1) Has node-role.kubernetes.io as prefix.
+      # (2) Belongs to node-restriction.kubernetes.io domain.
+      # (3) Belongs to node.cluster.x-k8s.io domain.
+      #
+      # REFER : https://cluster-api.sigs.k8s.io/developer/architecture/controllers/metadata-propagation#machine
+      labels:
+        node.cluster.x-k8s.io/cloud-provider: hcloud
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/argocd-helm-charts/capi-cluster/charts/hetzner/tests/hcloud-private_test.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/hetzner/tests/hcloud-private_test.yaml
@@ -69,3 +69,10 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: propagates the hcloud cloud-provider label to control-plane Nodes
+    template: KubeadmControlPlane.yaml
+    asserts:
+      - equal:
+          path: spec.machineTemplate.metadata.labels["node.cluster.x-k8s.io/cloud-provider"]
+          value: hcloud

--- a/argocd-helm-charts/capi-cluster/charts/hetzner/tests/hcloud-public_test.yaml
+++ b/argocd-helm-charts/capi-cluster/charts/hetzner/tests/hcloud-public_test.yaml
@@ -62,3 +62,10 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: propagates the hcloud cloud-provider label to control-plane Nodes
+    template: KubeadmControlPlane.yaml
+    asserts:
+      - equal:
+          path: spec.machineTemplate.metadata.labels["node.cluster.x-k8s.io/cloud-provider"]
+          value: hcloud


### PR DESCRIPTION
…Nodes

KubeadmControlPlane's hcloud machineTemplate only set infrastructureRef, so node.cluster.x-k8s.io/cloud-provider=hcloud never reached the Machine object and CAPI never propagated it to the Node (unlike MachineDeployment and the bare-metal Machine, which already set it correctly). Without the label, hcloud-csi-driver-node's nodeSelector skips these nodes, so their CSINode never registers a driver and the CSI controller fails with 'no topology key found for node'.