### PR TITLE
fix(trivy-operator): disable SBOM report generation

### DIFF
--- a/argocd-helm-charts/trivy-operator/README.md
+++ b/argocd-helm-charts/trivy-operator/README.md
@@ -18,6 +18,7 @@ cluster and writes results as CRs:
 | `RbacAssessmentReport` | RBAC anti-patterns |
 | `InfraAssessmentReport` | control-plane configuration findings |
 | `ClusterComplianceReport` | CIS Benchmark, NSA/CISA Hardening, Pod Security Standards |
+| `SBOMReport` | full image bill-of-materials — **disabled by default**, see below |
 
 A single built-in Trivy server is shared across scans, so there is no per-scan job pulling the
 database. Metrics are exposed for the existing kube-prometheus-stack to scrape.
@@ -62,9 +63,19 @@ See its `values.yaml` for the full surface; these are the knobs that matter here
 | `trivy-operator.trivy.ignoreUnfixed` | Drop CVEs with no fix available | `true` |
 | `trivy-operator.trivy.severity` | Severities to report | `"CRITICAL,HIGH"` |
 | `trivy-operator.trivy.builtInTrivyServer` | Share one in-cluster Trivy server | `true` |
+| `trivy-operator.operator.sbomGenerationEnabled` | Write an `SBOMReport` per image | `false` |
 
 `ignoreUnfixed: true` is deliberate — a CVE with no published fix is not a work item, and including
 them produces a number nobody can act on.
+
+`sbomGenerationEnabled: false` is also deliberate. An `SBOMReport` is written per container image
+and is by far the largest object this operator produces — tens to hundreds of KB each, refreshed
+every scan cycle. On a cluster running ~900 distinct images that is roughly 95MB of JSON held in
+etcd. etcd charges for that on *every* range request, so the cost is not paid by whoever reads
+SBOMs; it is paid by the apiserver's periodic count of every resource type in the cluster, which
+degrades into multi-second `listWithCount` latency and, past a point, apiserver handler timeouts
+and failed liveness probes. Enable it only if something consumes `ClusterVulnerabilityReports`,
+and size etcd for it first.
 
 ### KubeAid additions (`kubeaid.*`)
 

--- a/argocd-helm-charts/trivy-operator/values.yaml
+++ b/argocd-helm-charts/trivy-operator/values.yaml
@@ -17,6 +17,18 @@ trivy-operator:
     metricsConfigAuditInfo: true
     builtInTrivyServer: true
     scannerReportTTL: "24h"
+    # SBOMReports are the single largest thing this operator writes to etcd —
+    # one per container image, tens to hundreds of KB each, and they are
+    # regenerated on every scan cycle. On a cluster with ~900 images that is
+    # ~95MB of JSON living in etcd permanently, which shows up as multi-second
+    # LIST/count latency across *every* resource type and, downstream, as
+    # apiserver handler timeouts.
+    #
+    # Nothing in this chart reads them: the alerts below key off
+    # trivy_image_vulnerabilities, which comes from VulnerabilityReport.
+    # Turn this back on only if you actually consume ClusterVulnerabilityReports,
+    # and budget the etcd space before you do.
+    sbomGenerationEnabled: false
 
   trivy:
     # Skip CVEs with no fix available — cuts a lot of noise on base images.


### PR DESCRIPTION
## Problem

`trivy-operator.operator.sbomGenerationEnabled` defaults to `true` upstream and KubeAid never overrode it, so every KubeAid cluster running this chart writes one `SBOMReport` per container image into etcd — tens to hundreds of KB each, refreshed on every scan cycle.

Measured on development while investigating 14 consecutive days of `PartiallyFailed` Velero backups:

```
905 sbomreports  ≈ 95MB of JSON     (kubectl get sbomreports -A -o json times out at 2 min)
etcd DB size     790 MB / 782 MB / 786 MB across the 3 members
```

etcd charges for that on *every* range request, not only on reads of SBOMs. The apiserver's periodic count of each resource type degraded accordingly:

| apiserver→etcd operation | p99 (10m) |
|---|---|
| `listWithCount` | **3.83s** |
| `delete` | 2.42s |
| `get` | 1.78s |
| `list` | 1.62s |

Per-key-prefix p99 sat at a flat **~14.4s across all ~318 CRD prefixes** — uniform, because they queue behind one another. Downstream: apiserver `/livez` timed out, kubelet SIGKILLed it (770 restarts on `bm-kcm-1866484`, 303 on `bm-kcm-1866472`), and Velero dataupload operations failed with `the server was unable to return a response in the time allotted`.

## Change

Set `sbomGenerationEnabled: false` in the wrapper's `values.yaml`, plus README rationale and a values-table row.

## Why this is safe

Nothing in this chart reads `SBOMReport`. Both shipped alerts (`TrivyOperatorMetricsMissing`, `ClusterVulnerabilityBacklog`) key off `trivy_image_vulnerabilities`, which comes from `VulnerabilityReport` and is unaffected. The only upstream consumer is `ClusterVulnerabilityReports`, which KubeAid does not use.

Verified rendering:

```
$ helm template t argocd-helm-charts/trivy-operator | grep SBOM
  OPERATOR_SBOM_GENERATION_ENABLED: "false"
  OPERATOR_CLUSTER_SBOM_CACHE_ENABLED: "false"
```

## Scope

This addresses the etcd-bloat half of the kcm incident. The other half — Rook-Ceph OSDs colocated with etcd on untainted control-plane nodes — is cluster config, not chart config, and is tracked in the RCA. Existing SBOMReports are not garbage-collected by this change; they need `kubectl delete sbomreports -A` and an etcd `defrag` on each member.