### PR TITLE
fix(rustfs): pull the batching s3-backup-cleanup image

### DIFF
--- a/argocd-helm-charts/rustfs/Chart.yaml
+++ b/argocd-helm-charts/rustfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rustfs
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - name: rustfs
     version: "0.12.0"

--- a/argocd-helm-charts/rustfs/templates/cronjob-backup-cleanup.yaml
+++ b/argocd-helm-charts/rustfs/templates/cronjob-backup-cleanup.yaml
@@ -24,7 +24,7 @@ spec:
             fsGroup: 10001
           containers:
             - name: cleanup
-              image: "{{ (.Values.backupCleanup.image).repository | default "ghcr.io/obmondo/s3-backup-cleanup" }}:{{ (.Values.backupCleanup.image).tag | default "v1.0.0" }}"
+              image: "{{ (.Values.backupCleanup.image).repository | default "ghcr.io/obmondo/s3-backup-cleanup" }}:{{ (.Values.backupCleanup.image).tag | default "v1.0.1" }}"
               imagePullPolicy: IfNotPresent
               env:
                 - name: ENDPOINT

--- a/argocd-helm-charts/rustfs/values.yaml
+++ b/argocd-helm-charts/rustfs/values.yaml
@@ -34,4 +34,4 @@ backupCleanup:
   secretSecretAccessKeyKey: RUSTFS_SECRET_KEY
   image:
     repository: ghcr.io/obmondo/s3-backup-cleanup
-    tag: v1.0.0
+    tag: v1.0.1


### PR DESCRIPTION
v1.0.0 of the cleanup image builds its whole DeleteObjects body into a single argv entry, so the job aborts with "Argument list too long" on any prefix past the kernel's 128 KiB MAX_ARG_STRLEN. On kbm.obmondo.com that is the velero-backup prefix, and rustfs-backup-cleanup has failed nightly since 2026-08-25. v1.0.1 streams the versions and deletes them in batches of 1000 via --cli-input-json.

The tag has to change rather than v1.0.0 being rebuilt in place: the pod runs imagePullPolicy: IfNotPresent, so nodes holding the old layer would keep using it.