### PR TITLE
fix(netbird): pin management, signal and relay to a single replica

### DIFF
--- a/argocd-helm-charts/netbird/examples/values.yaml
+++ b/argocd-helm-charts/netbird/examples/values.yaml
@@ -1,6 +1,12 @@
 netbird:
   fullnameOverride: netbird
   management:
+    # Keep at 1: management generates its WireGuard key in-process on startup
+    # (NewTimeBasedAuthSecretsManager -> wgtypes.GeneratePrivateKey) and never persists it.
+    # A second replica has a different key, so a peer that fetched the key from one pod
+    # fails against the other: "error while decrypting peer's message with Wireguard
+    # public key". Upstream HA for management is an enterprise-licensed feature.
+    replicaCount: 1
     configmap: |-
       {
         "Stuns": [
@@ -135,6 +141,10 @@ netbird:
               pathType: ImplementationSpecific
 
   signal:
+    # Keep at 1: signal keeps its connected-peer registry in an in-memory sync.Map with
+    # no shared state, and only looks the destination peer up locally, so peers registered
+    # on different replicas can never exchange offers.
+    replicaCount: 1
     ingress:
       tls:
         - hosts:
@@ -147,6 +157,10 @@ netbird:
               pathType: ImplementationSpecific
 
   relay:
+    # Keep at 1: each relay keeps its connected peers in an in-memory map and every replica
+    # advertises the same NB_EXPOSED_ADDRESS, so two peers can land on different pods and
+    # never reach each other. A multi-relay setup needs one distinct address per instance.
+    replicaCount: 1
     env:
       NB_LOG_LEVEL: info
       NB_LISTEN_ADDRESS: ":33080"

--- a/argocd-helm-charts/netbird/values.yaml
+++ b/argocd-helm-charts/netbird/values.yaml
@@ -30,6 +30,12 @@ externalDatabases:
 netbird:
   fullnameOverride: netbird
   management:
+    # Keep at 1: management generates its WireGuard key in-process on startup
+    # (NewTimeBasedAuthSecretsManager -> wgtypes.GeneratePrivateKey) and never persists it.
+    # A second replica has a different key, so a peer that fetched the key from one pod
+    # fails against the other: "error while decrypting peer's message with Wireguard
+    # public key". Upstream HA for management is an enterprise-licensed feature.
+    replicaCount: 1
     configmap: |-
       {
         "Stuns": [
@@ -187,6 +193,10 @@ netbird:
               pathType: ImplementationSpecific
 
   signal:
+    # Keep at 1: signal keeps its connected-peer registry in an in-memory sync.Map with
+    # no shared state, and only looks the destination peer up locally, so peers registered
+    # on different replicas can never exchange offers.
+    replicaCount: 1
     image:
       tag: 0.76.1
     service:
@@ -206,6 +216,10 @@ netbird:
               pathType: ImplementationSpecific
 
   relay:
+    # Keep at 1: each relay keeps its connected peers in an in-memory map and every replica
+    # advertises the same NB_EXPOSED_ADDRESS, so two peers can land on different pods and
+    # never reach each other. A multi-relay setup needs one distinct address per instance.
+    replicaCount: 1
     image:
       tag: 0.76.1
     env:


### PR DESCRIPTION
## Problem

All NetBird logins on a cluster running this chart failed. Clients got:

```
error while decrypting peer's message with Wireguard public key <client key>
Error: daemon up failed: sso login failed: ... invalid request message
```

It hit everyone, including users who had never logged in before, so it was not stale peer state on any laptop. Both `netbird-management` pods logged `error while decrypting Sync request message from peer ...` continuously.

The cluster had `management`, `signal` and `relay` at `replicaCount: 2`, set in its own kubeaid-config values. Nothing in this chart said that was unsupported — the vendored subchart just happens to default to `1`, and the sample override file in `examples/` was silent on it.

## Cause

None of these three components can be horizontally scaled in open-source NetBird. Verified against `netbirdio/netbird` **v0.76.1**, the tag this chart pins:

| Component | Why 2 replicas breaks it |
|---|---|
| `management` | `NewTimeBasedAuthSecretsManager` (`management/internals/shared/grpc/token_mgr.go`) calls `wgtypes.GeneratePrivateKey()` in the constructor and holds the key in memory; `GetWGKey()` just returns it. It is never persisted, so each replica has a **different** key. A client calls `GetServerKey` on pod A, encrypts with A's key, and its next call is load-balanced to pod B, which cannot decrypt it. A PVC for `Datadir` does **not** help — the key never touches disk or postgres. |
| `signal` | The connected-peer registry is an in-memory `sync.Map` (`signal/peer/peer.go`) and the destination peer is only looked up in the local registry. Peers on different replicas can never exchange offers, so roughly half of all peer pairs silently fail to connect. |
| `relay` | `relay/server/store/store.go` keeps connected peers in an in-memory `map` guarded by a mutex, and every replica advertises the same `NB_EXPOSED_ADDRESS`, so a peer can be routed to a pod the other peer is not connected to. Supported multi-relay setups give each instance a **distinct** address. |

Upstream documents [HA for Management and Signal as an enterprise-licensed feature](https://docs.netbird.io/selfhosted/maintenance/scaling/scaling-your-self-hosted-deployment).

## Change

Set `replicaCount: 1` explicitly on `management`, `signal` and `relay`, each with a comment explaining why it must stay there, in:

- `argocd-helm-charts/netbird/values.yaml` — the chart defaults
- `argocd-helm-charts/netbird/examples/values.yaml` — the sample users copy into their kubeaid-config, which is where the override would actually be typed

The rendered manifests do not change (the vendored subchart already defaults to `1`); this makes the constraint visible and reviewable at the point where someone would otherwise raise it. `dashboard` is a stateless static app and is left alone.

