### PR TITLE
feat(kubeaid-addons): add generic PriorityClass and PodDisruptionBudget + configure harbor in HA

### DIFF
--- a/argocd-helm-charts/harbor/values.yaml
+++ b/argocd-helm-charts/harbor/values.yaml
@@ -5,6 +5,39 @@ global:
   harbor:
     netpol: false
 
+  # Opt-in PriorityClass for Harbor's own components. Worth enabling when Harbor is
+  # used as a pull-through cache, since image pulls across the whole cluster end up
+  # depending on its availability. Reference the name via harbor.<component>.priorityClassName.
+  priorityClass:
+    enabled: false
+    entries:
+      - name: harbor-critical
+        value: 900000
+        description: "Used by Harbor components; cluster-wide image pulls may depend on Harbor's availability."
+
+  # Opt-in PodDisruptionBudgets for portal/core/jobservice/registry. Only enable this
+  # for components whose replicas is >= 2 (harbor.<component>.replicas) - with a single
+  # replica, maxUnavailable: 1 would block voluntary node drains/evictions entirely.
+  podDisruptionBudget:
+    enabled: false
+    entries:
+      - name: harbor-portal
+        maxUnavailable: 1
+        matchLabels:
+          component: portal
+      - name: harbor-core
+        maxUnavailable: 1
+        matchLabels:
+          component: core
+      - name: harbor-jobservice
+        maxUnavailable: 1
+        matchLabels:
+          component: jobservice
+      - name: harbor-registry
+        maxUnavailable: 1
+        matchLabels:
+          component: registry
+
   postgresql:
     enabled: true
     instanceName: harbor

--- a/argocd-helm-charts/kubeaid-addons/templates/pod-disruption-budget.yaml
+++ b/argocd-helm-charts/kubeaid-addons/templates/pod-disruption-budget.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.global.podDisruptionBudget.enabled }}
+{{- range .Values.global.podDisruptionBudget.entries }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  {{- if .minAvailable }}
+  minAvailable: {{ .minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .maxUnavailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+{{ toYaml .matchLabels | indent 6 }}
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/kubeaid-addons/templates/priority-class.yaml
+++ b/argocd-helm-charts/kubeaid-addons/templates/priority-class.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.priorityClass.enabled }}
+{{- range .Values.global.priorityClass.entries }}
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .name }}
+value: {{ .value }}
+globalDefault: false
+{{- if .description }}
+description: {{ .description | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/argocd-helm-charts/kubeaid-addons/values.yaml
+++ b/argocd-helm-charts/kubeaid-addons/values.yaml
@@ -436,3 +436,33 @@ global:
   #   dnsNames: opensearch-cluster-master  # auto-generates standard K8s DNS SANs
   #   caSecretName: ""              # optional — defaults to <name>-ca-tls
   #   leafSecretName: ""            # optional — defaults to <name>-tls
+
+  # priorityClass
+  # Generic PriorityClass entries. Useful for shared infra a whole cluster ends up
+  # depending on (e.g. a pull-through image cache), so its pods aren't evicted first
+  # under node pressure.
+  priorityClass:
+    # -- Master switch. Set to true to render PriorityClass resources.
+    enabled: false
+
+    # -- List of PriorityClass entries.
+    entries: []
+    # - name: harbor-critical
+    #   value: 900000
+    #   description: "Used by Harbor components; cluster-wide image pulls may depend on Harbor's availability."
+
+  # podDisruptionBudget
+  # Generic PodDisruptionBudget entries, one PDB per entry. Only enable an entry for
+  # a component whose replica count is >= 2 - with a single replica, maxUnavailable: 1
+  # (or minAvailable: 1) blocks voluntary node drains/evictions entirely.
+  podDisruptionBudget:
+    # -- Master switch. Set to true to render PodDisruptionBudget resources.
+    enabled: false
+
+    # -- List of PodDisruptionBudget entries. Each renders one PDB in the release namespace.
+    # Set either maxUnavailable (default) or minAvailable per entry, not both.
+    entries: []
+    # - name: harbor-core
+    #   maxUnavailable: 1
+    #   matchLabels:
+    #     component: core


### PR DESCRIPTION
https://gitea.obmondo.com/EnableIT/qd2xcggwag/issues/5098
Since Harbor becomes a single point of failure when used as a pull-through cache, the proposed fix is to harden it for high availability:

Run Harbor's components with 2 replicas each.
Add a PriorityClass so Harbor pods aren't evicted under node pressure.
Add topology spread constraints so replicas aren't scheduled onto the same node.
Add a PodDisruptionBudget to protect against voluntary disruptions (node drains, upgrades).
Reduce the blackbox probe interval to catch a failing Harbor instance faster.