### PR TITLE
fix(backup-exporter): stop alerting on Velero backup_not_enabled

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -33,5 +33,5 @@ dependencies:
     condition: security-exporter.enabled
 
   - name: backup-exporter
-    version: 0.4.0
+    version: 0.4.1
     condition: backup-exporter.enabled

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: Reports backup health for PostgreSQL, Velero, MongoDB, MariaDB and sealed-secrets.
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "v1.2.2"

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
@@ -14,7 +14,7 @@ spec:
     - name: {{ include "backup-exporter.name" . }}-velero
       rules:
         - alert: VeleroBackupExporterJobFailed
-          expr: max by (type) (backup_exporter_velero_error == 1) > 0
+          expr: max by (type) (backup_exporter_velero_error{type!~"backup_not_enabled"} == 1) > 0
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.velero.severity | default "critical" }}

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
@@ -185,3 +185,33 @@ tests:
             exp_annotations:
               summary: 'Velero backup missing'
               description: 'No backup found for puppetserver-enableit/code-claim (pvc, method: )'
+
+  # A PVC outside every schedule's included namespaces is exporter bookkeeping,
+  # not a collector failure: backup_not_enabled must not fire
+  # VeleroBackupExporterJobFailed either, the same way it does not fire
+  # VeleroBackupMissing.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_error{namespace="not-scheduled-ns",resource_name="some-pvc",resource_type="pvc",type="backup_not_enabled"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: VeleroBackupExporterJobFailed
+        eval_time: 6m
+        exp_alerts: []
+
+  # A genuine failure type must still fire VeleroBackupExporterJobFailed.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_error{namespace="monitoring",resource_name="prometheus-k8s-db-prometheus-k8s-0",resource_type="pvc",type="s3_connection_failed"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: VeleroBackupExporterJobFailed
+        eval_time: 6m
+        exp_alerts:
+          - exp_labels:
+              alertname: VeleroBackupExporterJobFailed
+              severity: critical
+              type: s3_connection_failed
+            exp_annotations:
+              summary: 'Velero backup exporter job failed'
+              description: 'Velero backup exporter error (type: s3_connection_failed)'

--- a/docs/guides/backup-exporter.md
+++ b/docs/guides/backup-exporter.md
@@ -33,6 +33,13 @@ MariaDB clusters whose `Backup` resources are all suspended
 (`spec.schedule.suspend: true`) are not monitored — a schedule switched off on purpose is not a
 missing backup.
 
+The `*BackupExporterJobFailed` alerts fire on collector failures only. The exporter also emits
+`backup_exporter_*_error` series for resources that are deliberately out of scope
+(`type="backup_not_enabled"`, and for Postgres `cronjob_not_found` / `no_scheduled_backups`) — a PVC
+in a namespace no Velero schedule includes, for instance. Those types are excluded from the
+`JobFailed` alerts and suppress the matching `*BackupMissing` alert, so a resource nobody chose to
+back up stays silent.
+
 All alerts default to `critical` severity and fire after 5 minutes. These are configurable via the
 values file. MongoDB, MariaDB and Sealed Secrets monitoring are opt-in (`enabled: false` by default) since
 not every cluster runs those backups.


### PR DESCRIPTION
Closes the noise behind [EnableIT/qd2xcggwag#5207](https://gitea.obmondo.com/EnableIT/qd2xcggwag/issues/5207) (`vpn.qd2xcggwag`, firing since 27 Aug).

## The problem

`backup_not_enabled` is exporter bookkeeping, not a collector failure. The exporter tags every resource that no Velero schedule covers with it, and `VeleroBackupMissing` already joins on that tag to stay quiet — there is a promtool case locking that in. `VeleroBackupExporterJobFailed`, however, matched every error type:

```promql
max by (type) (backup_exporter_velero_error == 1) > 0
```

So a PVC nobody chose to back up pages as a critical exporter failure.

On `vpn.qd2xcggwag`, scraped from the running exporter:

```
backup_exporter_velero_error{namespace="crossplane-system",resource_name="crossview-db-1",resource_type="pvc",type="backup_not_enabled"} 1
backup_exporter_velero_error{namespace="crossplane-system",resource_name="crossview-db-2",resource_type="pvc",type="backup_not_enabled"} 1
```

Every other Velero error series is `0` and the in-scope PVCs back up fine. Both schedules include only `[capi-cluster monitoring]`, so `crossplane-system` is outside them by design.

## The fix

Exclude `backup_not_enabled`, matching what the Postgres rule has always done (`type!~"backup_not_enabled|cronjob_not_found|no_scheduled_backups"`). Only `backup_not_enabled` is excluded here — it is the one benign type the Velero collector emits; Velero has no CronJob or scheduled-backup equivalent.

Chart `0.4.0` → `0.4.1`, parent dependency pin moved with it.

## Verification

`promtool check rules` + `promtool test rules` pass against the rendered chart. Two new cases: `backup_not_enabled` must not fire, a genuine type (`s3_connection_failed`) still must. Reverting just the expression makes the first fail with exactly the alert from the ticket:

```
exp:[], got:[ Labels:{alertname="VeleroBackupExporterJobFailed", severity="critical", type="backup_not_enabled"} ]
```

