### PR TITLE
fix(rustfs): pull s3-backup-cleanup v1.0.3

### DIFF
--- a/argocd-helm-charts/rustfs/Chart.yaml
+++ b/argocd-helm-charts/rustfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rustfs
-version: 0.2.1
+version: 0.2.2
 dependencies:
   - name: rustfs
     version: "0.12.0"

--- a/argocd-helm-charts/rustfs/templates/cronjob-backup-cleanup.yaml
+++ b/argocd-helm-charts/rustfs/templates/cronjob-backup-cleanup.yaml
@@ -24,7 +24,7 @@ spec:
             fsGroup: 10001
           containers:
             - name: cleanup
-              image: "{{ (.Values.backupCleanup.image).repository | default "ghcr.io/obmondo/s3-backup-cleanup" }}:{{ (.Values.backupCleanup.image).tag | default "v1.0.1" }}"
+              image: "{{ (.Values.backupCleanup.image).repository | default "ghcr.io/obmondo/s3-backup-cleanup" }}:{{ (.Values.backupCleanup.image).tag | default "v1.0.3" }}"
               imagePullPolicy: IfNotPresent
               env:
                 - name: ENDPOINT

--- a/argocd-helm-charts/rustfs/values.yaml
+++ b/argocd-helm-charts/rustfs/values.yaml
@@ -34,4 +34,4 @@ backupCleanup:
   secretSecretAccessKeyKey: RUSTFS_SECRET_KEY
   image:
     repository: ghcr.io/obmondo/s3-backup-cleanup
-    tag: v1.0.1
+    tag: v1.0.3


### PR DESCRIPTION
v1.0.3 stops using DeleteObjects. rustfs answers bulk deletes with per-object lock timeouts for batches as small as two keys while sitting idle, so the cleanup deletes one object at a time in parallel instead. It also carries the error-handling fixes that stop the job reporting a successful delete as a failure, and a failed listing as success.

Verified in-cluster against both production buckets before release.