### PR TITLE
chore(backup-exporter): enable sealedSecrets exporter, bump to v1.2.5

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: Reports backup health for PostgreSQL, Velero, MongoDB, MariaDB and sealed-secrets.
 type: application
-version: 0.4.1
-appVersion: "v1.2.2"
+version: 0.4.2
+appVersion: "v1.2.5"

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/values.yaml
@@ -247,7 +247,7 @@ exporter:
     # These keys decrypt every SealedSecret in git, and the backup CronJob is
     # their only copy outside the cluster, so this is the backup with the least
     # margin for error.
-    enabled: false
+    enabled: true
 
     # Maximum acceptable Recovery Point Objective (RPO) for key backups.
     # Supported formats: "24h", "6h", "30m", "1d", "7d"


### PR DESCRIPTION
Enables exporter.sealedSecrets by default (was opt-in/off). mariadb stays opt-in at the chart level, off by default - clusters that need it turn it on themselves in kubeaid-config, since not every cluster using this chart runs mariadb-operator.

Also bumps appVersion to v1.2.5 (image.tag stays empty, so it keeps following appVersion rather than the two disagreeing - see the existing comment on image.tag).