### PR TITLE
chore(kubeaid-addons/postgresql): defaulting to required pod anti-affinity for CNPG cluster pods

### DIFF
--- a/argocd-helm-charts/kubeaid-addons/templates/postgresql-cluster.yaml
+++ b/argocd-helm-charts/kubeaid-addons/templates/postgresql-cluster.yaml
@@ -13,6 +13,9 @@ metadata:
 spec:
   instances: {{ $postgresql.instances }}
 
+  affinity:
+    podAntiAffinityType: {{ $postgresql.podAntiAffinityType }}
+
   {{- if $postgresql.env }}
   env:
     {{- range $postgresql.env }}

--- a/argocd-helm-charts/kubeaid-addons/values.yaml
+++ b/argocd-helm-charts/kubeaid-addons/values.yaml
@@ -81,6 +81,9 @@ global:
     # -- Number of PostgreSQL instances in the cluster
     instances: 1
 
+    # -- REFER : https://cloudnative-pg.io/docs/1.27/scheduling/#requiring-pod-anti-affinity.
+    podAntiAffinityType: required
+
     # -- Primary database name created during initdb
     database: app
 


### PR DESCRIPTION
`pod anti affinity` for the pods of a `CNPG managed cluster` is set to `required` by default.

CNPG sets it to `preferred` by default. However, in our experience it might not work sometimes : pods for a `CNPG` managed cluster was always landing on the same node.

Suppose, we have **3 nodes** and **3 replicas** : the replicas are spread out across the node.

When a node goes down, the replica corresponding to that node will remain in `Pending` state. And for us, that's okay : we don't want that replica to be scheduled in some other node where 1 replica is already running. It doesn't make sense to run 2 replicas on the same node.