### PR TITLE
feat(kube-prometheus): set spec.ingressClassName on the grafana, aler…

### DIFF
--- a/build/kube-prometheus/common-template.jsonnet
+++ b/build/kube-prometheus/common-template.jsonnet
@@ -765,6 +765,7 @@ local kp =
               ],
             }],
             vars.grafana_ingress_annotations,
+            vars.grafana_ingress_class_name,
           ),
         },
       } else {}
@@ -799,6 +800,7 @@ local kp =
               ],
             }],
             vars.alertmanager_ingress_annotations,
+            vars.alertmanager_ingress_class_name,
           ),
         },
       } else {}
@@ -833,6 +835,7 @@ local kp =
               ],
             }],
             vars.prometheus_ingress_annotations,
+            vars.prometheus_ingress_class_name,
           ),
         },
       } else {}
@@ -980,8 +983,12 @@ else kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
     for name in std.objectFields(kp.prometheusAdapter)
   } else {}
 ) +
-(if std.objectHas(vars, 'grafana_ingress_host') then { [name + '-ingress']: kp.ingress[name] for name in std.objectFields(kp.ingress) } else {}) +
-(if std.objectHas(vars, 'prometheus_ingress_host') then { [name + '-ingress']: kp.ingress[name] for name in std.objectFields(kp.ingress) } else {}) +
+// Every entry in kp.ingress was already built under its own *_ingress_host
+// guard, so emitting the whole set once covers all three components.
+(if std.objectHas(vars, 'grafana_ingress_host')
+    || std.objectHas(vars, 'prometheus_ingress_host')
+    || std.objectHas(vars, 'alertmanager_ingress_host')
+ then { [name + '-ingress']: kp.ingress[name] for name in std.objectFields(kp.ingress) } else {}) +
 // Rendering prometheusRules object. This is an object compatible with prometheus-operator CRD definition for prometheusRule
 { [o._config.name + '-prometheus-rules']: o.prometheusRules for o in std.filter((function(o) o.prometheusRules != null), mixins) } +
 (if std.objectHas(vars, 'prometheus_ingress_host') && vars.prometheus_blackbox_probe_enabled then {

--- a/build/kube-prometheus/examples/k8id_managed.jsonnet
+++ b/build/kube-prometheus/examples/k8id_managed.jsonnet
@@ -24,7 +24,5 @@
     limits: { memory: '3Gi' },
     requests: { cpu: '200m', memory: '1.5Gi' },
   },
-  grafana_ingress_annotations: {
-    'kubernetes.io/ingress.class': 'traefik-cert-manager',
-  },
+  grafana_ingress_class_name: 'traefik',
 }

--- a/build/kube-prometheus/lib/default_vars.libsonnet
+++ b/build/kube-prometheus/lib/default_vars.libsonnet
@@ -97,6 +97,13 @@
   alertmanager_ingress_annotations: {
     'cert-manager.io/cluster-issuer': 'letsencrypt',
   },
+  // spec.ingressClassName on the monitoring ingresses. Clusters whose Traefik
+  // IngressClass is not named 'traefik' (e.g. traefik-private) must override
+  // this, otherwise nothing claims the ingress and requests 404. Set to null
+  // to omit the field and fall back to the cluster's default IngressClass.
+  grafana_ingress_class_name: 'traefik',
+  prometheus_ingress_class_name: 'traefik',
+  alertmanager_ingress_class_name: 'traefik',
   // app.kubernetes.io/name carried by the Traefik pods that serve the
   // monitoring ingresses. Clusters running Traefik under a differently-named
   // Helm release (e.g. traefik-private) must override this, otherwise the

--- a/build/kube-prometheus/lib/utils.libsonnet
+++ b/build/kube-prometheus/lib/utils.libsonnet
@@ -13,7 +13,7 @@
     },
   },
 
-  ingress(name, namespace, rules, tls, annotations):: {
+  ingress(name, namespace, rules, tls, annotations, ingressClassName=null):: {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'Ingress',
     metadata: {
@@ -22,6 +22,7 @@
       annotations: annotations,
     },
     spec: {
+      [if ingressClassName != null then 'ingressClassName']: ingressClassName,
       rules: rules,
       [if tls != null then 'tls']: tls,
     },


### PR DESCRIPTION
…tmanager and prometheus ingresses

utils.ingress() only ever emitted rules and tls, so the ingress class could reach the cluster solely through the deprecated kubernetes.io/ingress.class annotation.

Add grafana/prometheus/alertmanager_ingress_class_name vars defaulting to 'traefik' and thread them through utils.ingress(). A null value omits the field, leaving the cluster's default IngressClass to claim the ingress.

Also fix the render block: it emitted the whole kp.ingress set guarded on grafana_ingress_host or prometheus_ingress_host only, so a cluster setting alertmanager_ingress_host alone built that ingress and then never rendered it.

Clusters whose Traefik IngressClass is not named 'traefik' must set *_ingress_class_name explicitly and drop the old annotation from their kubeaid-config values, otherwise the annotation and the spec field disagree.

Note for kubeaid-config: overriding *_ingress_annotations with a plain ':' replaces the defaulted map and silently drops cert-manager.io/cluster-issuer. Use '+:' to merge into it.