### PR TITLE
fix(kubeaid-agent): add summary annotation to MissingNodeCountDetected

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/13882947?s=250&v=4
 
 type: application
 
-version: 0.5.4
+version: 0.5.5
 appVersion: 0.0.3
 
 keywords:

--- a/argocd-helm-charts/kubeaid-agent/templates/prometheusrule.yaml
+++ b/argocd-helm-charts/kubeaid-agent/templates/prometheusrule.yaml
@@ -18,6 +18,7 @@ spec:
       rules:
         - alert: MissingNodeCountDetected
           annotations:
+            summary: Cluster **{{ "{{ $labels.certname }}" }}** failed to report its node count to the Obmondo API
             description: The cluster **{{ "{{ $labels.certname }}" }}** failed to fetch or report its node count to the Obmondo API. Node count data may be missing for the monthly average calculation.
           expr: kubeaid_agent_node_count_report_status == 1
           for: 1h


### PR DESCRIPTION
The rule only set a description annotation. Opsmondo's alert webhook validation requires an alert to carry a summary as well; an alert with none is rejected, and when it is the only alert in the batch opsmondo returns an unrecoverable 406. That makes the cluster Alertmanager fail every webhook send and fire AlertmanagerFailedToSendAlerts / AlertmanagerClusterFailedToSendAlerts for as long as MissingNodeCountDetected is active.

Add a summary line (every other kubeaid-agent rule already has one) and bump the chart to 0.5.5.