### PR TITLE
fix(backup-exporter): alert VeleroBackupMissing once per namespace, listing every volume without a backup

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
@@ -40,11 +40,15 @@ spec:
               {{ `{{ .Labels.resource_name }} ({{ .Labels.resource_type }}, method: {{ .Labels.backup }}, age: {{ .Value | humanizeDuration }})` }}
               {{ `{{- end }}` }}
         - alert: VeleroBackupMissing
-          expr: backup_exporter_velero_latest_backup_age == 0 unless on (namespace, resource_name, resource_type) (backup_exporter_velero_error{type="backup_not_enabled"} == 1)
+          expr: count by (namespace) (backup_exporter_velero_latest_backup_age == 0 unless on (namespace, resource_name, resource_type) (backup_exporter_velero_error{type="backup_not_enabled"} == 1))
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.velero.severity | default "critical" }}
           annotations:
-            summary: 'Velero backup missing'
-            description: 'No backup found for {{ `{{ $labels.namespace }}` }}/{{ `{{ $labels.resource_name }}` }} ({{ `{{ $labels.resource_type }}` }}, method: {{ `{{ $labels.backup }}` }})'
+            summary: 'Velero backups missing in {{ `{{ $labels.namespace }}` }}'
+            description: |-
+              {{ `{{ $value }}` }} volume(s) in namespace {{ `{{ $labels.namespace }}` }} have never been backed up by Velero:
+              {{ `{{- range printf "backup_exporter_velero_latest_backup_age{namespace=%q} == 0 unless on (namespace, resource_name, resource_type) (backup_exporter_velero_error{namespace=%q,type='backup_not_enabled'} == 1)" $labels.namespace $labels.namespace | query | sortByLabel "resource_name" }}` }}
+              {{ `{{ .Labels.resource_name }} ({{ .Labels.resource_type }})` }}
+              {{ `{{- end }}` }}
 {{- end }}

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
@@ -170,7 +170,7 @@ tests:
   # still fire VeleroBackupMissing.
   - interval: 1m
     input_series:
-      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="puppetserver-enableit",resource_name="code-claim",resource_type="pvc"}'
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="test-ns",resource_name="pvc-never",resource_type="pvc"}'
         values: '0x6'
     alert_rule_test:
       - alertname: VeleroBackupMissing
@@ -179,12 +179,51 @@ tests:
           - exp_labels:
               alertname: VeleroBackupMissing
               severity: critical
-              namespace: puppetserver-enableit
-              resource_name: code-claim
-              resource_type: pvc
+              namespace: test-ns
             exp_annotations:
-              summary: 'Velero backup missing'
-              description: 'No backup found for puppetserver-enableit/code-claim (pvc, method: )'
+              summary: 'Velero backups missing in test-ns'
+              description: |-
+                1 volume(s) in namespace test-ns have never been backed up by Velero:
+                pvc-never (pvc)
+
+  # One alert per namespace, listing only that namespace's missing volumes.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="test-ns",resource_name="pvc-missing-b",resource_type="pvc"}'
+        values: '0x6'
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="test-ns",resource_name="pvc-missing-a",resource_type="pvc"}'
+        values: '0x6'
+      - series: 'backup_exporter_velero_latest_backup_age{backup="test-backup",namespace="test-ns",resource_name="pvc-fine",resource_type="pvc"}'
+        values: '3600x6'
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="other-ns",resource_name="pvc-unscheduled",resource_type="pvc"}'
+        values: '0x6'
+      - series: 'backup_exporter_velero_error{namespace="other-ns",resource_name="pvc-unscheduled",resource_type="pvc",type="backup_not_enabled"}'
+        values: '1x6'
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="third-ns",resource_name="pvc-lonely",resource_type="pvc"}'
+        values: '0x6'
+    alert_rule_test:
+      - alertname: VeleroBackupMissing
+        eval_time: 6m
+        exp_alerts:
+          - exp_labels:
+              alertname: VeleroBackupMissing
+              severity: critical
+              namespace: test-ns
+            exp_annotations:
+              summary: 'Velero backups missing in test-ns'
+              description: |-
+                2 volume(s) in namespace test-ns have never been backed up by Velero:
+                pvc-missing-a (pvc)
+                pvc-missing-b (pvc)
+          - exp_labels:
+              alertname: VeleroBackupMissing
+              severity: critical
+              namespace: third-ns
+            exp_annotations:
+              summary: 'Velero backups missing in third-ns'
+              description: |-
+                1 volume(s) in namespace third-ns have never been backed up by Velero:
+                pvc-lonely (pvc)
 
   # A PVC outside every schedule's included namespaces is exporter bookkeeping,
   # not a collector failure: backup_not_enabled must not fire

--- a/docs/guides/backup-exporter.md
+++ b/docs/guides/backup-exporter.md
@@ -18,7 +18,7 @@ Deployment alongside the agent, so one Argo CD application covers both.
 | PostgreSQL | `PostgresWALBackupMissing` | No WAL backup has ever been recorded |
 | Velero | `VeleroBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_velero_error == 1`) |
 | Velero | `VeleroBackupExceededRPO` | One or more volumes in a namespace have a latest backup older than `max_rpo` (one alert per namespace, the description lists each volume and its age) |
-| Velero | `VeleroBackupMissing` | No backup has ever been recorded |
+| Velero | `VeleroBackupMissing` | One or more volumes in a namespace have never had a backup recorded (one alert per namespace, the description lists each volume) |
 | MongoDB | `MongoDBBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_mongodb_error == 1`) |
 | MongoDB | `MongoDBDumpBackupExceededRPO` | Latest dump backup age exceeds `max_rpo` |
 | MongoDB | `MongoDBDumpBackupMissing` | No dump backup has ever been recorded |


### PR DESCRIPTION


https://github.com/Obmondo/KubeAid/issues/274