### PR TITLE
fix(rook-ceph): retain a prior CephX key and keep rotation opt-in

### DIFF
--- a/argocd-helm-charts/rook-ceph/README.md
+++ b/argocd-helm-charts/rook-ceph/README.md
@@ -19,6 +19,70 @@ If that doesnt work you can use the rook-ceph kubectl plugin
 - Look into alert handling for [CephOSDDiskUnavailable.md](https://gitlab.enableit.dk/obmondo/wiki/-/blobrook-ceph/procedures/alerts/CephOSDDiskUnavailable.md)
     for more debug information.
 
+## CephX key rotation
+
+Rotating CephX keys can take every worker node down at once, so this chart ships with
+rotation disabled and one prior key retained.
+
+Kernel mounts are why. `krbd` and `kcephfs` hold the key they mapped with and never
+pick up a new one. Once the ticket expires and the prior key is gone, the mount fails
+authentication (`mauth authentication failed: -13`), `libceph` retries forever, and
+every process touching that volume blocks in uninterruptible D state. The node then
+goes `NotReady` with `Ready=Unknown` — never `Ready=False` — SSH stops working, and
+nothing is logged because the kernel itself is healthy. Only a reboot clears it.
+Processes stuck this way cannot be killed, so RBD images stay mapped,
+`VolumeAttachment` objects never clear, and rescheduled pods fail with Multi-Attach.
+
+Defaults set in `values.yaml`, applied to `csi`, `daemon` and `rbdMirrorPeer` alike:
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| `keyRotationPolicy` | `Disabled` | rotation must be a deliberate act, never a side effect of an upgrade |
+| `keepPriorKeyCountMax` | `1` | the old key stays valid while mounts migrate |
+| `keyType` | *not set* | depends on the cluster — see below |
+
+Set `keepPriorKeyCountMax` on **every** entity, not just `csi`. Rook reports each one
+separately under `status.cephx`; anything showing `keyGeneration` without a
+`priorKeyCount` has no grace period and will strand on the next rotation.
+
+### Rotating
+
+1. Confirm `keepPriorKeyCountMax` is at least `1` on every entity **before** bumping
+   `keyGeneration`. With it unset, Rook deletes the old key immediately and every
+   mounted volume on every node hangs at once.
+2. Bump `keyGeneration` and let Rook issue the new keys. Existing mounts keep working
+   on the retained prior key.
+3. **Cordon and reboot** the workers one at a time, waiting for `active+clean` between
+   each. A reboot is the only thing that re-keys a live kernel mount.
+4. Only after every node has been cycled, drop the prior key.
+
+Do **not** `kubectl drain`. The D-state process holding the volume prevents the kernel
+from unmapping the RBD, so the `VolumeAttachment` never clears and the evicted pod
+fails Multi-Attach on whatever node it lands on — down until the original node reboots
+anyway. Draining starts the outage earlier and leaves pods scattered for the next
+reboot to disturb again. Cordon stops new scheduling; the reboot does the rest.
+
+### Choosing keyType
+
+Ceph 20.2.4 flags the long-standing `aes` cipher as insecure, which is what prompts
+most people to rotate in the first place. Neither value is right for every cluster,
+which is why this chart does not pin one:
+
+- **`aes`** works with any kernel, but on Ceph 20.2.4+ it raises
+  `AUTH_INSECURE_CLIENT_KEY_TYPE` and needs `mon_auth_allow_insecure_key: true` for the
+  mons to accept and create such keys.
+- **`aes256k`** clears the warning but requires **kernel 7.0+ on every node** and a
+  ceph-csi new enough to handle it. Add a node on an older kernel later and its mounts
+  fail with no obvious explanation.
+
+Whichever you pick, pin it explicitly per cluster. Leaving it unset means a Ceph
+upgrade can move the default underneath you, and the resulting re-key behaves exactly
+like an unplanned rotation. Change `keyType` and `keyGeneration` in separate steps, and
+verify the deployed ceph-csi can actually use the new type before rolling it out to
+every node — a failure here breaks new attachments (`rados: ret=-22`) while existing
+ones are already hung, and rebooting will not help because the replacement mount cannot
+be made either.
+
 ## About upstream charts
 
 This includes both of the two upstream rook-ceph charts listed here

--- a/argocd-helm-charts/rook-ceph/README.md
+++ b/argocd-helm-charts/rook-ceph/README.md
@@ -39,7 +39,7 @@ Defaults set in `values.yaml`, applied to `csi`, `daemon` and `rbdMirrorPeer` al
 | --- | --- | --- |
 | `keyRotationPolicy` | `Disabled` | rotation must be a deliberate act, never a side effect of an upgrade |
 | `keepPriorKeyCountMax` | `1` | the old key stays valid while mounts migrate |
-| `keyType` | *not set* | depends on the cluster — see below |
+| `keyType` | `aes256k` | replaces the `aes` cipher Ceph 20.2.4 flags as insecure — see the node requirement below |
 
 Set `keepPriorKeyCountMax` on **every** entity, not just `csi`. Rook reports each one
 separately under `status.cephx`; anything showing `keyGeneration` without a
@@ -62,26 +62,42 @@ fails Multi-Attach on whatever node it lands on — down until the original node
 anyway. Draining starts the outage earlier and leaves pods scattered for the next
 reboot to disturb again. Cordon stops new scheduling; the reboot does the rest.
 
-### Choosing keyType
+### keyType and the Ubuntu 26.04 requirement
 
-Ceph 20.2.4 flags the long-standing `aes` cipher as insecure, which is what prompts
-most people to rotate in the first place. Neither value is right for every cluster,
-which is why this chart does not pin one:
+Ceph 20.2.4 flags the long-standing `aes` cipher as insecure — that warning is what
+prompts most people to rotate in the first place. This chart pins **`aes256k`** so the
+cipher is a deliberate choice rather than whatever a Ceph upgrade happens to default
+to; an unpinned `keyType` means an upgrade can re-key the cluster unattended, which
+behaves exactly like an unplanned rotation.
 
-- **`aes`** works with any kernel, but on Ceph 20.2.4+ it raises
-  `AUTH_INSECURE_CLIENT_KEY_TYPE` and needs `mon_auth_allow_insecure_key: true` for the
-  mons to accept and create such keys.
-- **`aes256k`** clears the warning but requires **kernel 7.0+ on every node** and a
-  ceph-csi new enough to handle it. Add a node on an older kernel later and its mounts
-  fail with no obvious explanation.
+**`aes256k` requires Linux kernel 7.0 or newer — Ubuntu 26.04 and up.**
 
-Whichever you pick, pin it explicitly per cluster. Leaving it unset means a Ceph
-upgrade can move the default underneath you, and the resulting re-key behaves exactly
-like an unplanned rotation. Change `keyType` and `keyGeneration` in separate steps, and
-verify the deployed ceph-csi can actually use the new type before rolling it out to
-every node — a failure here breaks new attachments (`rados: ret=-22`) while existing
-ones are already hung, and rebooting will not help because the replacement mount cannot
-be made either.
+That requirement applies to **`csi.keyType` only**. Those keys are consumed by the
+in-kernel clients (`krbd`, `kcephfs`), so every node that mounts a Ceph volume has to
+be able to use the cipher. `daemon` and `rbdMirrorPeer` keys are only ever used by
+userspace Ceph daemons and carry no kernel dependency.
+
+So on a cluster whose nodes are older than Ubuntu 26.04, override just that one:
+
+```yaml
+rook-ceph-cluster:
+  cephClusterSpec:
+    security:
+      cephx:
+        csi:
+          keyType: aes
+```
+
+`aes` keeps working on any kernel, at the cost of `AUTH_INSECURE_CLIENT_KEY_TYPE` in
+`ceph status` and needing `mon_auth_allow_insecure_key: true` for the mons to accept
+and create such keys. Adding a pre-26.04 node to an `aes256k` cluster later will strand
+that node's mounts with no obvious explanation, so treat the node OS floor as part of
+the cluster's contract.
+
+Change `keyType` and `keyGeneration` in separate steps, and verify the deployed
+ceph-csi can actually use the new cipher before rolling it out to every node. A failure
+here breaks new attachments (`rados: ret=-22`) while the existing ones are already
+hung, and rebooting will not help because the replacement mount cannot be made either.
 
 ## About upstream charts
 

--- a/argocd-helm-charts/rook-ceph/values.yaml
+++ b/argocd-helm-charts/rook-ceph/values.yaml
@@ -92,19 +92,31 @@ rook-ceph-cluster:
     # they mapped with, so dropping the prior key makes every existing mount fail
     # authentication and hang in uninterruptible D state, recoverable only by
     # rebooting the node. Keep one prior key on every entity and keep rotation
-    # opt-in. keyType is deliberately not pinned here: the right value depends on
-    # the nodes' kernel version and the deployed ceph-csi. See README.md.
+    # opt-in.
+    #
+    # aes256k replaces the aes cipher that Ceph 20.2.4 flags as insecure. Pin it
+    # rather than leaving it unset, so a Ceph upgrade cannot move the default and
+    # re-key the cluster unattended.
+    #
+    # csi.keyType is the one with a node requirement: those keys are consumed by
+    # the kernel clients, so aes256k needs kernel 7.0+, i.e. Ubuntu 26.04 or newer,
+    # on every node. Override it to aes on clusters with older nodes. daemon and
+    # rbdMirrorPeer keys are used only by userspace Ceph daemons and have no such
+    # requirement. See README.md.
     security:
       cephx:
         csi:
           keyRotationPolicy: Disabled
           keepPriorKeyCountMax: 1
+          keyType: aes256k
         daemon:
           keyRotationPolicy: Disabled
           keepPriorKeyCountMax: 1
+          keyType: aes256k
         rbdMirrorPeer:
           keyRotationPolicy: Disabled
           keepPriorKeyCountMax: 1
+          keyType: aes256k
 
   # NOTE copied from rook-ceph-cluster/values.yaml file
   # Since we cannot really overwrite the resource usage

--- a/argocd-helm-charts/rook-ceph/values.yaml
+++ b/argocd-helm-charts/rook-ceph/values.yaml
@@ -88,6 +88,24 @@ rook-ceph-cluster:
       # block eviction of OSDs by default and unblock them safely when drains are detected.
       managePodBudgets: false
 
+    # CephX key rotation strands live kernel mounts: krbd and kcephfs hold the key
+    # they mapped with, so dropping the prior key makes every existing mount fail
+    # authentication and hang in uninterruptible D state, recoverable only by
+    # rebooting the node. Keep one prior key on every entity and keep rotation
+    # opt-in. keyType is deliberately not pinned here: the right value depends on
+    # the nodes' kernel version and the deployed ceph-csi. See README.md.
+    security:
+      cephx:
+        csi:
+          keyRotationPolicy: Disabled
+          keepPriorKeyCountMax: 1
+        daemon:
+          keyRotationPolicy: Disabled
+          keepPriorKeyCountMax: 1
+        rbdMirrorPeer:
+          keyRotationPolicy: Disabled
+          keepPriorKeyCountMax: 1
+
   # NOTE copied from rook-ceph-cluster/values.yaml file
   # Since we cannot really overwrite the resource usage
   cephFileSystems:


### PR DESCRIPTION
The chart set nothing under security.cephx, so a CephX key rotation ran with no
prior key retained. krbd and kcephfs hold the key they mapped with, so deleting
the old key made every existing mount fail authentication and hang in
uninterruptible D state: nodes went NotReady with Ready=Unknown -- never
Ready=False -- SSH stopped working, and nothing was logged because the kernel
itself stayed healthy. Only a console reboot cleared it, and the stuck processes
kept RBD images mapped, so rescheduled pods failed with Multi-Attach.

Set keepPriorKeyCountMax: 1 and keyRotationPolicy: Disabled on csi, daemon and
rbdMirrorPeer alike. Rook reports each entity separately under status.cephx, and
one without a prior key strands on the next rotation regardless of the others.

keyType is deliberately left unpinned: aes raises AUTH_INSECURE_CLIENT_KEY_TYPE
on Ceph 20.2.4+ and needs mon_auth_allow_insecure_key, while aes256k requires
kernel 7.0+ on every node and a ceph-csi new enough to use it. That is a
per-cluster choice, so the README documents how to pick one instead.

The README rotation procedure uses cordon and reboot rather than drain. Draining
evicts pods onto other nodes where the attach fails Multi-Attach, because the
D-state process on the original node never releases the RBD map -- it starts the
outage earlier without avoiding it.
