### PR TITLE
fix(rook-ceph): correct prepareosod typo, without the OOM-killing limits

### DIFF
--- a/argocd-helm-charts/rook-ceph/values.yaml
+++ b/argocd-helm-charts/rook-ceph/values.yaml
@@ -71,10 +71,10 @@ rook-ceph-cluster:
         requests:
           cpu: "500m"
           memory: "1500Mi"
-      prepareosod:
-        limits:
-          cpu: "100m"
-          memory: "50Mi"
+      # No limits here on purpose: the OSD prepare job is a one-time memory burst
+      # that must not be OOM-killed, and upstream suggests 1200Mi-2Gi if a
+      # LimitRange forces you to set one. cf. rook/rook#11103
+      prepareosd:
         requests:
           cpu: "100m"
           memory: "50Mi"


### PR DESCRIPTION
The key was spelled prepareosod, so it matched nothing and the intended resources were never applied to the OSD prepare job -- it has always run on the vendored default of 500m cpu request. Both keys are visible side by side in a live CephCluster spec.

Renaming it alone would be worse than the typo. The block set limits.memory: 50Mi, and the vendored chart warns directly above that key that limits should not be set at all: the prepare job is a one-time memory burst that must not be OOM-killed, and 1200Mi-2Gi is suggested if a LimitRange forces one (rook/rook#11103). At 50Mi every prepare job would be killed and no OSD would ever provision.

Keep the intended lower cpu request, drop the limits.