### PR TITLE
docs(rook-ceph): how to clear AUTH_EMERGENCY_CIPHERS_SET

### DIFF
--- a/argocd-helm-charts/rook-ceph/README.md
+++ b/argocd-helm-charts/rook-ceph/README.md
@@ -106,6 +106,57 @@ ceph-csi can actually use the new cipher before rolling it out to every node. A 
 here breaks new attachments (`rados: ret=-22`) while the existing ones are already
 hung, and rebooting will not help because the replacement mount cannot be made either.
 
+### Clearing AUTH_EMERGENCY_CIPHERS_SET
+
+Ceph 20.2.4 raises `AUTH_EMERGENCY_CIPHERS_SET` — *"Monitors are configured to use
+emergency allowed ciphers"*. This is Rook's **default**, not leftover from an incident:
+with `security.cephx.allowedCiphers` unset, Rook enables every cipher by passing
+`mon_auth_emergency_allowed_ciphers=aes,aes256k` on the mon command line.
+
+That means it does not appear in `ceph config dump` and `ceph config rm` cannot remove
+it. The source is `cmdline`:
+
+```shell
+ceph config show mon.<id> | grep -i ciph
+```
+
+To clear it, restrict the ciphers in the cluster's values:
+
+```yaml
+    security:
+      cephx:
+        allowedCiphers:
+          - aes256k
+```
+
+Rook then sets `auth_allowed_ciphers` and stops passing the emergency flag. It is a
+command-line argument, so the mons roll one at a time to pick it up.
+
+**Verify every key first.** The CRD warns that this setting "can disrupt cluster
+availability", and it means it: restricting the list locks out any entity still holding
+a key of an excluded cipher — including `mon.` and `client.admin`, which costs you the
+cluster with no way back in, since `ceph config` lives in the mon store.
+
+`status.cephx` cannot answer this. A missing `keyType` there means Rook never recorded
+one, **not** that the key is insecure. Compare key lengths instead — an `aes` key is
+visibly shorter than an `aes256k` one:
+
+```shell
+ceph auth ls -f json | jq -r '.auth_dump[].entity' | while read -r e; do
+  printf '%-38s %s\n' "$e" "$(ceph auth get-key "$e" 2>/dev/null | wc -c)"
+done
+```
+
+Every entity reporting the same length means nothing would be locked out. That includes
+the retained prior-generation keys (`<entity>.N`), which `keepPriorKeyCountMax` keeps
+alive and which are equally capable of stranding a mount that still authenticates with
+one.
+
+This chart deliberately leaves `allowedCiphers` unset. Setting it cluster-wide would
+contradict the `csi.keyType: aes` override above — clusters below Ubuntu 26.04 need the
+`aes` cipher allowed — so it belongs in per-cluster values, once that cluster has been
+verified fully migrated.
+
 ## About upstream charts
 
 This includes both of the two upstream rook-ceph charts listed here

--- a/argocd-helm-charts/rook-ceph/README.md
+++ b/argocd-helm-charts/rook-ceph/README.md
@@ -120,7 +120,7 @@ it. The source is `cmdline`:
 ceph config show mon.<id> | grep -i ciph
 ```
 
-To clear it, restrict the ciphers in the cluster's values:
+This chart therefore sets it explicitly:
 
 ```yaml
     security:
@@ -131,6 +131,21 @@ To clear it, restrict the ciphers in the cluster's values:
 
 Rook then sets `auth_allowed_ciphers` and stops passing the emergency flag. It is a
 command-line argument, so the mons roll one at a time to pick it up.
+
+**It pairs with `csi.keyType`.** A cluster below Ubuntu 26.04 that overrides
+`csi.keyType: aes` **must** widen this to match, or the mons reject its own CSI keys:
+
+```yaml
+    security:
+      cephx:
+        allowedCiphers:
+          - aes
+          - aes256k
+        csi:
+          keyType: aes
+```
+
+Change the two together, always.
 
 **Verify every key first.** The CRD warns that this setting "can disrupt cluster
 availability", and it means it: restricting the list locks out any entity still holding
@@ -152,10 +167,11 @@ the retained prior-generation keys (`<entity>.N`), which `keepPriorKeyCountMax` 
 alive and which are equally capable of stranding a mount that still authenticates with
 one.
 
-This chart deliberately leaves `allowedCiphers` unset. Setting it cluster-wide would
-contradict the `csi.keyType: aes` override above — clusters below Ubuntu 26.04 need the
-`aes` cipher allowed — so it belongs in per-cluster values, once that cluster has been
-verified fully migrated.
+**Run that sweep before upgrading an existing cluster to a chart version carrying this
+default.** A cluster that still holds any `aes` key — including a retained prior
+generation — will have that key rejected the moment the mons pick up the restriction.
+Either finish the migration first, or set `allowedCiphers: [aes, aes256k]` in that
+cluster's values until it has.
 
 ## About upstream charts
 

--- a/argocd-helm-charts/rook-ceph/values.yaml
+++ b/argocd-helm-charts/rook-ceph/values.yaml
@@ -133,9 +133,20 @@ rook-ceph-cluster:
     # the kernel clients, so aes256k needs kernel 7.0+, i.e. Ubuntu 26.04 or newer,
     # on every node. Override it to aes on clusters with older nodes. daemon and
     # rbdMirrorPeer keys are used only by userspace Ceph daemons and have no such
-    # requirement. See README.md.
+    # requirement.
+    #
+    # allowedCiphers restricts what the mons accept. Leaving it unset makes Rook
+    # enable every cipher via mon_auth_emergency_allowed_ciphers on the mon command
+    # line, which raises AUTH_EMERGENCY_CIPHERS_SET on Ceph 20.2.4+.
+    #
+    # It pairs with csi.keyType: a cluster that overrides that to aes MUST widen this
+    # to [aes, aes256k] as well, or it locks out its own CSI keys. Before adopting
+    # this on an existing cluster, verify no entity still holds an aes key -- see
+    # README.md, an excluded cipher locks out mon. and client.admin with no way back.
     security:
       cephx:
+        allowedCiphers:
+          - aes256k
         csi:
           keyRotationPolicy: Disabled
           keepPriorKeyCountMax: 1


### PR DESCRIPTION
The warning is Rook's default, not incident leftover: with security.cephx.allowedCiphers unset, Rook enables every cipher by passing mon_auth_emergency_allowed_ciphers=aes,aes256k on the mon command line. It is therefore absent from ceph config dump and cannot be removed with ceph config rm -- the source is cmdline.

Document the fix (allowedCiphers: [aes256k] in the cluster values) and the precondition, because restricting the list locks out any entity still on an excluded cipher, mon. and client.admin included, with no way back in. status.cephx cannot tell you: a missing keyType means Rook recorded none, not that the key is insecure. Comparing key lengths can, so include the sweep.

Left unset in this chart on purpose -- setting it cluster-wide would contradict the documented csi.keyType: aes override for pre-26.04 nodes.