### PR TITLE
fix(backup-exporter): stop alerting on Velero awaiting_first_backup

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -33,5 +33,5 @@ dependencies:
     condition: security-exporter.enabled
 
   - name: backup-exporter
-    version: 0.4.4
+    version: 0.4.5
     condition: backup-exporter.enabled

--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -33,5 +33,5 @@ dependencies:
     condition: security-exporter.enabled
 
   - name: backup-exporter
-    version: 0.4.3
+    version: 0.4.4
     condition: backup-exporter.enabled

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: Reports backup health for PostgreSQL, Velero, MongoDB, MariaDB and sealed-secrets.
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: "v1.2.6"

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: Reports backup health for PostgreSQL, Velero, MongoDB, MariaDB and sealed-secrets.
 type: application
-version: 0.4.4
-appVersion: "v1.2.6"
+version: 0.4.5
+appVersion: "v1.3.0"

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
@@ -15,7 +15,7 @@ spec:
     - name: {{ include "backup-exporter.name" . }}-velero
       rules:
         - alert: VeleroBackupExporterJobFailed
-          expr: max by (type) (backup_exporter_velero_error{type!~"backup_not_enabled|awaiting_first_backup"} == 1) > 0
+          expr: max by (type) (backup_exporter_velero_error{type!~"backup_not_enabled|awaiting_first_backup|velero_not_installed"} == 1) > 0
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.velero.severity | default "critical" }}

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
@@ -15,7 +15,7 @@ spec:
     - name: {{ include "backup-exporter.name" . }}-velero
       rules:
         - alert: VeleroBackupExporterJobFailed
-          expr: max by (type) (backup_exporter_velero_error{type!~"backup_not_enabled"} == 1) > 0
+          expr: max by (type) (backup_exporter_velero_error{type!~"backup_not_enabled|awaiting_first_backup"} == 1) > 0
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.velero.severity | default "critical" }}
@@ -40,7 +40,7 @@ spec:
               {{ `{{ .Labels.resource_name }} ({{ .Labels.resource_type }}, method: {{ .Labels.backup }}, age: {{ .Value | humanizeDuration }})` }}
               {{ `{{- end }}` }}
         - alert: VeleroBackupMissing
-          expr: count by (namespace) (backup_exporter_velero_latest_backup_age == 0 unless on (namespace, resource_name, resource_type) (backup_exporter_velero_error{type="backup_not_enabled"} == 1))
+          expr: count by (namespace) (backup_exporter_velero_latest_backup_age == 0 unless on (namespace, resource_name, resource_type) (backup_exporter_velero_error{type=~"backup_not_enabled|awaiting_first_backup"} == 1))
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.velero.severity | default "critical" }}
@@ -48,7 +48,7 @@ spec:
             summary: 'Velero backups missing in {{ `{{ $labels.namespace }}` }}'
             description: |-
               {{ `{{ $value }}` }} volume(s) in namespace {{ `{{ $labels.namespace }}` }} have never been backed up by Velero:
-              {{ `{{- range printf "backup_exporter_velero_latest_backup_age{namespace=%q} == 0 unless on (namespace, resource_name, resource_type) (backup_exporter_velero_error{namespace=%q,type='backup_not_enabled'} == 1)" $labels.namespace $labels.namespace | query | sortByLabel "resource_name" }}` }}
+              {{ `{{- range printf "backup_exporter_velero_latest_backup_age{namespace=%q} == 0 unless on (namespace, resource_name, resource_type) (backup_exporter_velero_error{namespace=%q,type=~'backup_not_enabled|awaiting_first_backup'} == 1)" $labels.namespace $labels.namespace | query | sortByLabel "resource_name" }}` }}
               {{ `{{ .Labels.resource_name }} ({{ .Labels.resource_type }})` }}
               {{ `{{- end }}` }}
 {{- end }}

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
@@ -27,6 +27,19 @@ spec:
         # single failed run would otherwise page once per volume. The description
         # still names every volume past RPO with its own age: it runs the
         # per-volume query at notification time.
+        # velero_not_installed and no_schedules_found are excluded from
+        # JobFailed because neither is a collector failure. They still mean no
+        # volume on this cluster is protected, which Argo CD does not report
+        # when Velero was removed in git, so they surface here instead: one
+        # alert per cluster, warning rather than critical.
+        - alert: VeleroNoBackupSchedules
+          expr: max by (type) (backup_exporter_velero_error{type=~"velero_not_installed|no_schedules_found"}) == 1
+          for: {{ .Values.prometheusRule.velero.noSchedulesForDuration | default "24h" }}
+          labels:
+            severity: {{ .Values.prometheusRule.velero.noSchedulesSeverity | default "warning" }}
+          annotations:
+            summary: 'No Velero backup schedules on this cluster'
+            description: 'Velero is backing up nothing on this cluster (reason: {{ `{{ $labels.type }}` }}). No PVC is protected.'
         - alert: VeleroBackupExceededRPO
           expr: count by (namespace) (backup_exporter_velero_latest_backup_age > {{ $rpoSeconds }})
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/templates/velero-prometheusrule.yaml
@@ -15,7 +15,7 @@ spec:
     - name: {{ include "backup-exporter.name" . }}-velero
       rules:
         - alert: VeleroBackupExporterJobFailed
-          expr: max by (type) (backup_exporter_velero_error{type!~"backup_not_enabled|awaiting_first_backup|velero_not_installed"} == 1) > 0
+          expr: max by (type) (backup_exporter_velero_error{type!~"backup_not_enabled|awaiting_first_backup|velero_not_installed|no_schedules_found"} == 1) > 0
           for: {{ .Values.prometheusRule.velero.alertForDuration | default "5m" }}
           labels:
             severity: {{ .Values.prometheusRule.velero.severity | default "critical" }}

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
@@ -166,6 +166,44 @@ tests:
         eval_time: 6m
         exp_alerts: []
 
+  # A PVC younger than max_rpo that Velero has not had a scheduled run for yet
+  # (exporter-classified, type=awaiting_first_backup) must not fire
+  # VeleroBackupMissing, even though the age sentinel is 0.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="test-ns",resource_name="pvc-new",resource_type="pvc"}'
+        values: '0x6'
+      - series: 'backup_exporter_velero_error{namespace="test-ns",resource_name="pvc-new",resource_type="pvc",type="awaiting_first_backup"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: VeleroBackupMissing
+        eval_time: 6m
+        exp_alerts: []
+
+  # A namespace holding both a genuinely missing PVC and one still awaiting its
+  # first backup fires for the missing one only, and lists only that one.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="mixed-ns",resource_name="pvc-never",resource_type="pvc"}'
+        values: '0x6'
+      - series: 'backup_exporter_velero_latest_backup_age{backup="",namespace="mixed-ns",resource_name="pvc-new",resource_type="pvc"}'
+        values: '0x6'
+      - series: 'backup_exporter_velero_error{namespace="mixed-ns",resource_name="pvc-new",resource_type="pvc",type="awaiting_first_backup"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: VeleroBackupMissing
+        eval_time: 6m
+        exp_alerts:
+          - exp_labels:
+              alertname: VeleroBackupMissing
+              severity: critical
+              namespace: mixed-ns
+            exp_annotations:
+              summary: 'Velero backups missing in mixed-ns'
+              description: |-
+                1 volume(s) in namespace mixed-ns have never been backed up by Velero:
+                pvc-never (pvc)
+
   # A genuinely missing, in-scope PVC (no matching not-enabled error) must
   # still fire VeleroBackupMissing.
   - interval: 1m
@@ -277,6 +315,18 @@ tests:
         values: '93600x6'
     alert_rule_test:
       - alertname: VeleroBackupExceededRPO
+        eval_time: 6m
+        exp_alerts: []
+
+  # A PVC still inside its first-backup grace window is exporter bookkeeping,
+  # not a collector failure: awaiting_first_backup must not fire
+  # VeleroBackupExporterJobFailed either.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_error{namespace="test-ns",resource_name="pvc-new",resource_type="pvc",type="awaiting_first_backup"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: VeleroBackupExporterJobFailed
         eval_time: 6m
         exp_alerts: []
 

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
@@ -330,6 +330,36 @@ tests:
         eval_time: 6m
         exp_alerts: []
 
+  # A cluster without Velero's CRDs has nothing to check, and Argo CD already
+  # reports a Velero that should be installed and is not. Reporting it here
+  # would page on a permanent, expected state.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_error{type="velero_not_installed"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: VeleroBackupExporterJobFailed
+        eval_time: 6m
+        exp_alerts: []
+
+  # A listing failure that is not a missing CRD -- API server down, RBAC
+  # revoked -- is a real failure and must still page.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_error{type="schedule_list_failed"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: VeleroBackupExporterJobFailed
+        eval_time: 6m
+        exp_alerts:
+          - exp_labels:
+              alertname: VeleroBackupExporterJobFailed
+              severity: critical
+              type: schedule_list_failed
+            exp_annotations:
+              summary: 'Velero backup exporter job failed'
+              description: 'Velero backup exporter error (type: schedule_list_failed)'
+
   # A genuine failure type must still fire VeleroBackupExporterJobFailed.
   - interval: 1m
     input_series:

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
@@ -342,6 +342,18 @@ tests:
         eval_time: 6m
         exp_alerts: []
 
+  # Velero installed but declaring no Schedules is a configuration statement,
+  # not a collector failure: Argo CD reports schedules that should exist and
+  # do not, so paging here would duplicate it.
+  - interval: 1m
+    input_series:
+      - series: 'backup_exporter_velero_error{type="no_schedules_found"}'
+        values: '1x6'
+    alert_rule_test:
+      - alertname: VeleroBackupExporterJobFailed
+        eval_time: 6m
+        exp_alerts: []
+
   # A listing failure that is not a missing CRD -- API server down, RBAC
   # revoked -- is a real failure and must still page.
   - interval: 1m

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/test/prometheusRuleTest.yaml
@@ -342,6 +342,55 @@ tests:
         eval_time: 6m
         exp_alerts: []
 
+  # Neither bookkeeping state pages as a failure, but both mean the cluster
+  # protects nothing, so VeleroNoBackupSchedules reports it once, as a warning,
+  # only after a full day so a cluster rebuild does not trip it.
+  - interval: 5m
+    input_series:
+      - series: 'backup_exporter_velero_error{type="velero_not_installed"}'
+        values: '1x300'
+    alert_rule_test:
+      - alertname: VeleroNoBackupSchedules
+        eval_time: 1h
+        exp_alerts: []
+      - alertname: VeleroNoBackupSchedules
+        eval_time: 25h
+        exp_alerts:
+          - exp_labels:
+              alertname: VeleroNoBackupSchedules
+              severity: warning
+              type: velero_not_installed
+            exp_annotations:
+              summary: 'No Velero backup schedules on this cluster'
+              description: 'Velero is backing up nothing on this cluster (reason: velero_not_installed). No PVC is protected.'
+
+  # Same for a Velero that is installed but has no Schedules.
+  - interval: 5m
+    input_series:
+      - series: 'backup_exporter_velero_error{type="no_schedules_found"}'
+        values: '1x300'
+    alert_rule_test:
+      - alertname: VeleroNoBackupSchedules
+        eval_time: 25h
+        exp_alerts:
+          - exp_labels:
+              alertname: VeleroNoBackupSchedules
+              severity: warning
+              type: no_schedules_found
+            exp_annotations:
+              summary: 'No Velero backup schedules on this cluster'
+              description: 'Velero is backing up nothing on this cluster (reason: no_schedules_found). No PVC is protected.'
+
+  # A cluster with real backups never reports either type, so it stays quiet.
+  - interval: 5m
+    input_series:
+      - series: 'backup_exporter_velero_latest_backup_age{backup="CSISnapshot",namespace="test-ns",resource_name="pvc-a",resource_type="pvc"}'
+        values: '3600x300'
+    alert_rule_test:
+      - alertname: VeleroNoBackupSchedules
+        eval_time: 25h
+        exp_alerts: []
+
   # Velero installed but declaring no Schedules is a configuration statement,
   # not a collector failure: Argo CD reports schedules that should exist and
   # do not, so paging here would duplicate it.

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/values.yaml
@@ -287,6 +287,10 @@ prometheusRule:
     severity: critical
     alertForDuration: 5m
     namespace: monitoring
+    # VeleroNoBackupSchedules only reports that the cluster protects nothing,
+    # so it is a warning, and long enough to ride out a cluster rebuild.
+    noSchedulesSeverity: warning
+    noSchedulesForDuration: 24h
   mongodb:
     # Follows exporter.mongodb.enabled -- rules for an exporter that is not
     # running would alert on series that never appear.

--- a/docs/guides/backup-exporter.md
+++ b/docs/guides/backup-exporter.md
@@ -18,6 +18,7 @@ Deployment alongside the agent, so one Argo CD application covers both.
 | PostgreSQL | `PostgresWALBackupMissing` | No WAL backup has ever been recorded |
 | Velero | `VeleroBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_velero_error == 1`) |
 | Velero | `VeleroBackupExceededRPO` | One or more volumes in a namespace have a latest backup older than `max_rpo` (one alert per namespace, the description lists each volume and its age) |
+| Velero | `VeleroNoBackupSchedules` | Velero is not installed, or declares no `Schedule` resources, so no volume on the cluster is protected. One warning per cluster, after 24h |
 | Velero | `VeleroBackupMissing` | One or more volumes in a namespace have never had a backup recorded (one alert per namespace, the description lists each volume). Volumes in namespaces no schedule covers, and volumes younger than `max_rpo` still awaiting their first scheduled run, are excluded |
 | MongoDB | `MongoDBBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_mongodb_error == 1`) |
 | MongoDB | `MongoDBDumpBackupExceededRPO` | Latest dump backup age exceeds `max_rpo` |

--- a/docs/guides/backup-exporter.md
+++ b/docs/guides/backup-exporter.md
@@ -18,7 +18,7 @@ Deployment alongside the agent, so one Argo CD application covers both.
 | PostgreSQL | `PostgresWALBackupMissing` | No WAL backup has ever been recorded |
 | Velero | `VeleroBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_velero_error == 1`) |
 | Velero | `VeleroBackupExceededRPO` | One or more volumes in a namespace have a latest backup older than `max_rpo` (one alert per namespace, the description lists each volume and its age) |
-| Velero | `VeleroBackupMissing` | One or more volumes in a namespace have never had a backup recorded (one alert per namespace, the description lists each volume) |
+| Velero | `VeleroBackupMissing` | One or more volumes in a namespace have never had a backup recorded (one alert per namespace, the description lists each volume). Volumes in namespaces no schedule covers, and volumes younger than `max_rpo` still awaiting their first scheduled run, are excluded |
 | MongoDB | `MongoDBBackupExporterJobFailed` | The exporter job itself reports an error (`backup_exporter_mongodb_error == 1`) |
 | MongoDB | `MongoDBDumpBackupExceededRPO` | Latest dump backup age exceeds `max_rpo` |
 | MongoDB | `MongoDBDumpBackupMissing` | No dump backup has ever been recorded |


### PR DESCRIPTION
`awaiting_first_backup` is exporter bookkeeping, not a collector failure. The exporter tags a PVC younger than `max_rpo` that Velero has not had a scheduled run for yet, so its absence from the backup bucket is expected rather than a gap.

Both Velero rules still read that tag as a failure, which left the exporter-side change that introduces it completely **inert** — a brand-new PVC paged exactly as before.

## What changed

- **`VeleroBackupMissing`** joins on the tag to stay quiet, so the new type goes in the `expr` *and* again in the `description`'s per-volume query, which repeats the same PromQL to name the offending volumes. Fixing only the `expr` would leave the alert body listing volumes it had just excluded.
- **`VeleroBackupExporterJobFailed`** matched every type but `backup_not_enabled`, so the new one would have paged as a **critical exporter failure** — worse than the missing-backup alert it was meant to silence.
- Three `promtool` cases; `backup-exporter` subchart `0.4.3` → `0.4.4` plus the `kubeaid-agent` dependency pin; alert table in `docs/guides/backup-exporter.md`.

## Verification

Rendered with the CI recipe and run through `promtool`:

- Against **master's** rules the three new cases fail — the new PVC fires `VeleroBackupMissing`, the mixed-namespace alert body lists 2 volumes instead of 1, and the awaiting PVC fires `VeleroBackupExporterJobFailed`.
- Against this branch: `promtool check rules` SUCCESS (8 rules), full suite SUCCESS.

## Depends on

https://gitea.obmondo.com/EnableIT/backup-exporter/pulls/74 — this rule change is a no-op until the exporter that emits `awaiting_first_backup` ships. `appVersion` stays `v1.2.6` and should move when that release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2ehHLCLNSR15TwQKLTGB4