### PR TITLE
chore(security-exporter): follow appVersion for the image tag

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -29,7 +29,7 @@ maintainers:
 # agent alone, or the agent plus either exporter.
 dependencies:
   - name: security-exporter
-    version: 0.3.2
+    version: 0.3.3
     condition: security-exporter.enabled
 
   - name: backup-exporter

--- a/argocd-helm-charts/kubeaid-agent/charts/security-exporter/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/security-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: security-exporter
 description: Collects cluster security posture and serves it for kubeaid-agent to forward.
 type: application
-version: 0.3.2
-appVersion: "0.1.2"
+version: 0.3.3
+appVersion: "v0.1.2"

--- a/argocd-helm-charts/kubeaid-agent/charts/security-exporter/templates/deployment.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/security-exporter/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "security-exporter.name" . }}
-          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           env:
             - name: SECURITY_EXPORTER_PORT

--- a/argocd-helm-charts/kubeaid-agent/charts/security-exporter/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/security-exporter/values.yaml
@@ -60,12 +60,17 @@ deployment:
   image:
     repository: ghcr.io/obmondo/kubeaid-security-exporter
 
-    # -- Keep the quotes when overriding. A tag matching digits-e-digits is
-    # valid YAML scientific notation, and Go's parser -- the one Helm and Argo
-    # CD use -- resolves it to a float: a commit tag of 75621e3 renders as
-    # 7.5621e+07 and the pod comes up InvalidImageName. PyYAML disagrees and
-    # returns a string, so validating with python yaml does not catch it.
-    tag: "v0.1.2"
+    # -- Overrides the image tag. Left empty so it follows the chart appVersion,
+    # which keeps the deployed version in one place rather than two that can
+    # disagree.
+    #
+    # Keep the quotes when overriding, and when setting appVersion. A tag
+    # matching digits-e-digits is valid YAML scientific notation, and Go's
+    # parser -- the one Helm and Argo CD use -- resolves it to a float: a commit
+    # tag of 75621e3 renders as 7.5621e+07 and the pod comes up
+    # InvalidImageName. PyYAML disagrees and returns a string, so validating
+    # with python yaml does not catch it.
+    tag: ""
     pullPolicy: IfNotPresent
 
   env: []


### PR DESCRIPTION
`security-exporter` pinned its image tag in `values.yaml` **and** duplicated it in `appVersion`, and the two had already drifted:

```
Chart.yaml     appVersion: "0.1.2"
values.yaml    deployment.image.tag: "v0.1.2"   <- the tag the pod actually pulls
```

Only the `values.yaml` one reached the container, so `appVersion` was decorative and quietly wrong. This makes the tag default to `.Chart.AppVersion`, the way `backup-exporter` already does.

## Verification

The rendered image is **byte-identical** before and after — this changes no running workload:

```
before: ghcr.io/obmondo/kubeaid-security-exporter:v0.1.2
after:  ghcr.io/obmondo/kubeaid-security-exporter:v0.1.2
```

An explicit override still wins (`--set security-exporter.deployment.image.tag=v9.9.9` → `:v9.9.9`), and `backup-exporter`'s render is unaffected.

The scientific-notation warning moved with the field and now covers `appVersion` too — whichever field supplies the tag has to stay quoted, or a commit tag like `75621e3` becomes `7.5621e+07` and the pod comes up `InvalidImageName`.

## Not in this PR

A survey of the charts we author found five where `appVersion` and the hardcoded tag **disagree**, so `appVersion` is currently wrong in each:

| chart | appVersion | tag deployed |
|---|---|---|
| `errbot` | `"6.1.9"` | `"6.1.10"` |
| `hetzner-robot` | `"1.0.0"` | `v1.2.0` |
| `kubeaid-agent` | `0.0.3` | `v1.1.1` |
| `vuls-dictionary` | `"v0.11.0"` | `1.4.1` |
| `calcom/charts/calcom` | `v5.0.19` | `0.0.6` |

Unlike `security-exporter`, converting those would **change the running image** unless `appVersion` is corrected to match the tag first — which of the two is correct depends on what is actually deployed. `errbot` and `calcom` need extra care: their templates already reference `AppVersion` elsewhere, so they likely have two images resolving by different rules.

Separately, `openvox`, `rustfs`, `zfs-localpv` and the `kubeaid-addons` copies have no `appVersion` at all and would need one added first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2ehHLCLNSR15TwQKLTGB4