### PR TITLE
feat(kube-prometheus): alert when containers in a namespace restarts

### DIFF
--- a/build/kube-prometheus/mixins/argo-cd/mixin.libsonnet
+++ b/build/kube-prometheus/mixins/argo-cd/mixin.libsonnet
@@ -71,6 +71,24 @@
           },
         ],
       },
+      {
+        name: 'argocd-container-restarting-frequently',
+        rules: [
+          {
+            alert: 'ContainerRestartingFrequently',
+            expr: 'sum by (namespace) (kube_pod_container_status_restarts_total{job="kube-state-metrics"}) > 5',
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+              alert_id: 'ContainerRestartingFrequently',
+            },
+            annotations: {
+              summary: 'Containers in a namespace are restarting frequently.',
+              description: 'Namespace **{{ .Labels.namespace }}** has {{ .Value }} total container restarts across its pods.',
+            },
+          },
+        ],
+      },
     ],
   },
 }

--- a/build/kube-prometheus/mixins/argo-cd/prometheus.yaml
+++ b/build/kube-prometheus/mixins/argo-cd/prometheus.yaml
@@ -43,3 +43,14 @@ groups:
         for: 2h
         labels:
           severity: warning
+  - name: argocd-container-restarting-frequently
+    rules:
+      - alert: ContainerRestartingFrequently
+        annotations:
+          description: Namespace **{{ .Labels.namespace }}** has {{ .Value }} total container restarts across its pods.
+          summary: Containers in a namespace are restarting frequently.
+        expr: sum by (namespace) (kube_pod_container_status_restarts_total{job="kube-state-metrics"}) > 5
+        for: 15m
+        labels:
+          alert_id: ContainerRestartingFrequently
+          severity: warning


### PR DESCRIPTION
Add a ContainerRestartingTooMuch alert to the argo-cd mixin, firing when a namespace accumulates more than 5 total container restarts for 15m.