### PR TITLE
chore(backup-exporter): point the chart at backup-exporter v1.3.1

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -33,5 +33,5 @@ dependencies:
     condition: security-exporter.enabled
 
   - name: backup-exporter
-    version: 0.4.5
+    version: 0.4.6
     condition: backup-exporter.enabled

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: Reports backup health for PostgreSQL, Velero, MongoDB, MariaDB and sealed-secrets.
 type: application
-version: 0.4.5
-appVersion: "v1.3.0"
+version: 0.4.6
+appVersion: "v1.3.1"


### PR DESCRIPTION
Points the `kubeaid-agent` chart at `backup-exporter` **v1.3.1**.

`ghcr.io/obmondo/backup-exporter:v1.3.1` is published and the manifest resolves (`HTTP 200`), with both `linux/amd64` and `linux/arm64` present. Safe to merge.

## What v1.3.1 fixes

Three defects in the Velero exporter, all one root cause: it built its volume inventory from the S3 bucket and only ever *added* to it, so the bucket outranked the cluster.

| Case | v1.3.0 | v1.3.1 |
|---|---|---|
| PVC deleted after its last backup | Its `volumeinfo` stays in the bucket until Velero's retention expires it. The exporter republishes it every run with a growing age until it crosses `max_rpo` — `VeleroBackupExceededRPO` **critical for the whole retention window**, about a volume nobody can back up. | Pruned, guarded on the PVC listing succeeding so an unreadable cluster retracts nothing. |
| Namespace in no Schedule's `includedNamespaces` | Reported as **"no backup saved"**. The exporter already stamped `backup_not_enabled`, but the API never read the velero error series, so the classification died one layer below where it was made. | Reported as **switched off**. |
| PVC excluded by `velero.io/exclude-from-backup` or a volume policy | **Dropped from the report entirely.** A namespace with 5 PVCs and 2 excluded reported 3, with nothing naming the other two — so a PVC that picked up the label by mistake stopped being backed up with no metric, no row and no alert. | Reported as **switched off**. |

The third is the one to watch after rollout: every CNPG volume caught by a `cnpg-skip-volumes`-style policy becomes a visible "switched off" row instead of being silently absent, sitting next to its `cnpg`/`wal` row showing healthy. More rows, but a volume can no longer fall out of backup unnoticed.

## Chart changes

| | before | after |
|---|---|---|
| `backup-exporter` `version` | 0.4.5 | 0.4.6 |
| `backup-exporter` `appVersion` | v1.3.0 | v1.3.1 |
| `kubeaid-agent` dependency pin | 0.4.5 | 0.4.6 |

`helm template` verified, resolving through `appVersion` as intended:

    image: "ghcr.io/obmondo/backup-exporter:v1.3.1"

## No alert-rule changes

None needed. The deleted-PVC fix resolves `VeleroBackupExceededRPO` on its own by retracting the series, and the other two surface through `backup_not_enabled`, which `VeleroBackupMissing` and `VeleroBackupExporterJobFailed` already exclude.

## No web-app changes

None needed either. `backup-data.ts` already maps `error_type === 'backup_not_enabled'` to `NOT_ENABLED` → "Backups switched off" (grey), and `IGNORED_ERROR_TYPES` does not filter it. Reusing that type rather than introducing a new one is deliberate: any unrecognised type falls through to a red "No backup saved".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2ehHLCLNSR15TwQKLTGB4
