### PR TITLE
chore(backup-exporter): check every 10% of max_rpo instead of every 25%

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -33,5 +33,5 @@ dependencies:
     condition: security-exporter.enabled
 
   - name: backup-exporter
-    version: 0.4.6
+    version: 0.4.7
     condition: backup-exporter.enabled

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: backup-exporter
 description: Reports backup health for PostgreSQL, Velero, MongoDB, MariaDB and sealed-secrets.
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: "v1.3.1"

--- a/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/charts/backup-exporter/values.yaml
@@ -140,12 +140,14 @@ exporter:
     # backup age exceeds RPO.
 
     # Rate at which the exporter checks backup health, expressed as a fraction
-    # of max_rpo. For example, 0.25 means the exporter runs every 25% of
-    # max_rpo (e.g. every 6h if max_rpo is 24h), giving multiple chances to
-    # detect a missed backup before the RPO window expires.
+    # of max_rpo. For example, 0.1 means the exporter runs every 10% of
+    # max_rpo (e.g. every 2h if max_rpo is 26h), giving multiple chances to
+    # detect a missed backup before the RPO window expires. It also bounds how
+    # stale a reported age can be: each value is a snapshot that does not move
+    # between runs, so the check rate is the reporting lag.
     # Must be between 0 and 1. Defaults to 0.25 (every 25% of max_rpo) if
     # not set
-    interval_rate: 0.25
+    interval_rate: 0.1
 
     # S3 configuration common for both logical and WAL backups (except region).
     s3:
@@ -163,12 +165,14 @@ exporter:
     max_rpo: 26h
 
     # Rate at which the exporter checks backup health, expressed as a fraction
-    # of max_rpo. For example, 0.25 means the exporter runs every 25% of
-    # max_rpo (e.g. every 6h if max_rpo is 24h), giving multiple chances to
-    # detect a missed backup before the RPO window expires.
+    # of max_rpo. For example, 0.1 means the exporter runs every 10% of
+    # max_rpo (e.g. every 2h if max_rpo is 26h), giving multiple chances to
+    # detect a missed backup before the RPO window expires. It also bounds how
+    # stale a reported age can be: each value is a snapshot that does not move
+    # between runs, so the check rate is the reporting lag.
     # Must be between 0 and 1. Defaults to 0.25 (every 25% of max_rpo) if
     # not set
-    interval_rate: 0.25
+    interval_rate: 0.1
 
     # S3 configuration.
     # Credentials can be provided either via a Kubernetes Secret (secretName)
@@ -198,8 +202,9 @@ exporter:
     max_rpo: 26h
 
     # Rate at which the exporter checks backup health, expressed as a fraction
-    # of max_rpo. Must be between 0 and 1. Defaults to 0.25.
-    interval_rate: 0.25
+    # of max_rpo, which is also the reporting lag: a published age is a snapshot
+    # that does not move between runs. Must be between 0 and 1. Defaults to 0.25.
+    interval_rate: 0.1
 
     # Credentials for listing the dump bucket. Required when enabled: the
     # exporter uses its own read-only keys and never reads the backup CronJob's
@@ -225,8 +230,9 @@ exporter:
     max_rpo: 26h
 
     # Rate at which the exporter checks backup health, expressed as a fraction
-    # of max_rpo. Must be between 0 and 1. Defaults to 0.25.
-    interval_rate: 0.25
+    # of max_rpo, which is also the reporting lag: a published age is a snapshot
+    # that does not move between runs. Must be between 0 and 1. Defaults to 0.25.
+    interval_rate: 0.1
 
     # Credentials for listing the dump bucket. Required when enabled: the
     # exporter uses its own read-only keys and never follows the Backup's
@@ -254,8 +260,9 @@ exporter:
     max_rpo: 26h
 
     # Rate at which the exporter checks backup health, expressed as a fraction
-    # of max_rpo. Must be between 0 and 1. Defaults to 0.25.
-    interval_rate: 0.25
+    # of max_rpo, which is also the reporting lag: a published age is a snapshot
+    # that does not move between runs. Must be between 0 and 1. Defaults to 0.25.
+    interval_rate: 0.1
 
     s3:
       # Bucket and endpoint the key archives are written to. Unlike the other


### PR DESCRIPTION
Each exporter ran on a cron derived from max_rpo x interval_rate: 26h x 0.25 rounds to a 6h schedule. A published age is a snapshot that does not move between runs, so that rate is also the reporting lag -- an age shown anywhere could be six hours out of date, and the agent's own poll interval is added on top of it.

0.1 gives 26h x 0.1 = 2.6h, a 2h schedule. max_rpo is unchanged at 26h and no alert threshold moves: this only decides how often the bucket is read. All five exporters change together, so the report does not mix operators refreshed at different rates.

The cost is S3 list and get calls, which are cheap next to a backup age that reads six hours younger than it is.