### PR TITLE
chore(kubeaid-agent): point the chart at kubeaid-agent v1.1.2 and fol…

### DIFF
--- a/argocd-helm-charts/kubeaid-agent/Chart.yaml
+++ b/argocd-helm-charts/kubeaid-agent/Chart.yaml
@@ -5,8 +5,8 @@ icon: https://avatars.githubusercontent.com/u/13882947?s=250&v=4
 
 type: application
 
-version: 0.5.7
-appVersion: 0.0.3
+version: 0.5.8
+appVersion: "v1.1.2"
 
 keywords:
   - obmondo

--- a/argocd-helm-charts/kubeaid-agent/templates/deployment.yaml
+++ b/argocd-helm-charts/kubeaid-agent/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "kubeaid-agent.name" . }}
-          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           env:
             {{- with .Values.deployment.env }}

--- a/argocd-helm-charts/kubeaid-agent/values.yaml
+++ b/argocd-helm-charts/kubeaid-agent/values.yaml
@@ -105,7 +105,10 @@ deployment:
 
   image:
     repository: ghcr.io/obmondo/kubeaid-agent
-    tag: v1.1.1
+    # Overrides the image tag. Left empty so it follows the chart appVersion,
+    # which keeps the deployed version in one place rather than two that can
+    # disagree -- as they did until v1.1.2, when appVersion still read 0.0.3.
+    tag: ""
     pullPolicy: Always
 
   env: []


### PR DESCRIPTION
…low appVersion

v1.1.2 polls the backup exporter every 30 minutes instead of every six hours and submits a report only when it changed. Until the chart points at it the agent keeps forwarding a report at most once per six hours, so the check-rate change already merged for the exporter only takes staleness from twelve hours to eight rather than to about two and a half.

The tag is no longer hardcoded. values.yaml pinned v1.1.1 while appVersion read 0.0.3, so the version this chart claimed to ship was not the one it deployed, and every running agent carried app.kubernetes.io/version: 0.0.3. Both now come from appVersion, matching backup-exporter and security-exporter.

Changing appVersion moves that label, which is safe here because it is not part of the Deployment's selector: kubeaid-agent.selectorLabels is name and instance only, so nothing immutable changes and Argo CD has no field it cannot patch.