### PR TITLE
fix(rook-ceph): drop the daemon.keyType default, it forces the mon emergency-cipher flag

### DIFF
--- a/argocd-helm-charts/rook-ceph/README.md
+++ b/argocd-helm-charts/rook-ceph/README.md
@@ -109,28 +109,38 @@ hung, and rebooting will not help because the replacement mount cannot be made e
 ### Clearing AUTH_EMERGENCY_CIPHERS_SET
 
 Ceph 20.2.4 raises `AUTH_EMERGENCY_CIPHERS_SET` — *"Monitors are configured to use
-emergency allowed ciphers"*. This is Rook's **default**, not leftover from an incident:
-with `security.cephx.allowedCiphers` unset, Rook enables every cipher by passing
-`mon_auth_emergency_allowed_ciphers=aes,aes256k` on the mon command line.
+emergency allowed ciphers"* — whenever a mon runs with
+`--mon-auth-emergency-allowed-ciphers` on its command line. Rook 1.20.7 adds that flag
+(`pkg/operator/ceph/cluster/mon/spec.go:403`) to every mon **whenever
+`security.cephx.daemon.keyType` is set**, regardless of `allowedCiphers`. It is meant as
+a bootstrap workaround, and the Rook docs say to remove `daemon.keyType` afterwards.
+`csi.keyType` and `rbdMirrorPeer.keyType` do not trigger it.
 
-That means it does not appear in `ceph config dump` and `ceph config rm` cannot remove
-it. The source is `cmdline`:
+The flag is a command-line argument, so it does not appear in `ceph config dump` and
+`ceph config rm` cannot remove it. The source is `cmdline`:
 
 ```shell
 ceph config show mon.<id> | grep -i ciph
 ```
 
-This chart therefore sets it explicitly:
+This chart therefore leaves `daemon.keyType` unset and sets `allowedCiphers` explicitly:
 
 ```yaml
     security:
       cephx:
         allowedCiphers:
           - aes256k
+        daemon:
+          keyRotationPolicy: Disabled
 ```
 
-Rook then sets `auth_allowed_ciphers` and stops passing the emergency flag. It is a
-command-line argument, so the mons roll one at a time to pick it up.
+With `daemon.keyType` unset, Rook sets `auth_allowed_ciphers` from `allowedCiphers` via
+CLI once the mons are running and passes no emergency flag; the mons roll one at a
+time to drop it. If a cluster's values still pin `daemon.keyType`, remove the line.
+Helm cannot null a subchart default from an override (the rendered manifest carries
+`keyType: null`, which the CephCluster CRD rejects), which is why this chart must not
+ship a `daemon.keyType` default. With `keyRotationPolicy: Disabled`, unsetting
+`keyType` never triggers a rotation.
 
 **It pairs with `csi.keyType`.** A cluster below Ubuntu 26.04 that overrides
 `csi.keyType: aes` **must** widen this to match, or the mons reject its own CSI keys:

--- a/argocd-helm-charts/rook-ceph/values.yaml
+++ b/argocd-helm-charts/rook-ceph/values.yaml
@@ -125,9 +125,10 @@ rook-ceph-cluster:
     # is fine: only the csi keys are consumed by in-kernel clients, so only they can
     # strand a mount. Rook restarts the daemons it re-keys.
     #
-    # aes256k replaces the aes cipher that Ceph 20.2.4 flags as insecure. Pin it
-    # rather than leaving it unset, so a Ceph upgrade cannot move the default and
-    # re-key the cluster unattended.
+    # aes256k replaces the aes cipher that Ceph 20.2.4 flags as insecure. With
+    # keyRotationPolicy Disabled a keyType change never re-keys anything (Rook
+    # ShouldRotateCephxKeys returns early), so pinning it is documentation of the
+    # desired cipher, not a safety net.
     #
     # csi.keyType is the one with a node requirement: those keys are consumed by
     # the kernel clients, so aes256k needs kernel 7.0+, i.e. Ubuntu 26.04 or newer,
@@ -135,9 +136,16 @@ rook-ceph-cluster:
     # rbdMirrorPeer keys are used only by userspace Ceph daemons and have no such
     # requirement.
     #
-    # allowedCiphers restricts what the mons accept. Leaving it unset makes Rook
-    # enable every cipher via mon_auth_emergency_allowed_ciphers on the mon command
-    # line, which raises AUTH_EMERGENCY_CIPHERS_SET on Ceph 20.2.4+.
+    # daemon.keyType stays UNSET on purpose. Rook 1.20.7 (pkg/operator/ceph/
+    # cluster/mon/spec.go:403) passes --mon-auth-emergency-allowed-ciphers to
+    # every mon whenever daemon.keyType is set, whatever allowedCiphers says, and
+    # Ceph 20.2.4 answers with AUTH_EMERGENCY_CIPHERS_SET (HEALTH_WARN, ArgoCD
+    # Degraded). csi.keyType and rbdMirrorPeer.keyType do not trigger the flag.
+    # Helm cannot null a subchart default from a values override, so do not add
+    # a daemon.keyType default here; clusters that need one set it themselves.
+    #
+    # allowedCiphers restricts what the mons accept (auth_allowed_ciphers). With
+    # daemon.keyType unset, Rook sets it via CLI after the mons are running.
     #
     # It pairs with csi.keyType: a cluster that overrides that to aes MUST widen this
     # to [aes, aes256k] as well, or it locks out its own CSI keys. Before adopting
@@ -153,7 +161,6 @@ rook-ceph-cluster:
           keyType: aes256k
         daemon:
           keyRotationPolicy: Disabled
-          keyType: aes256k
         rbdMirrorPeer:
           keyRotationPolicy: Disabled
           keyType: aes256k


### PR DESCRIPTION
## Problem

Rook 1.20.7 (`pkg/operator/ceph/cluster/mon/spec.go:403`) adds `--mon-auth-emergency-allowed-ciphers=aes,aes256k` to every mon **whenever `security.cephx.daemon.keyType` is set**, regardless of `allowedCiphers`. Ceph 20.2.4 answers with `AUTH_EMERGENCY_CIPHERS_SET` (HEALTH_WARN) and ArgoCD marks rook-ceph Degraded. Seen on qa-htz1 (EnableIT/qd2xcggwag#5154) and reproduced tonight on production-htz1 immediately after adopting 32.8.0 with the cephx pins (operator log: `op-mon: setting mon-auth-emergency-allowed-ciphers="aes,aes256k"`, flag on all three mon pods).

The chart default `daemon.keyType: aes256k` therefore puts every cluster on this chart into that state, and it cannot be undone from cluster values: Helm does not null a subchart key from an override, the manifest renders `keyType: null`, and the CephCluster CRD rejects it (`enum: aes|aes256k`, SSA error `Unsupported value: null`).

## Change

- `values.yaml`: remove `daemon.keyType`. `csi.keyType` and `rbdMirrorPeer.keyType` stay (they do not trigger the flag). Comments updated.
- `README.md`: the "Clearing AUTH_EMERGENCY_CIPHERS_SET" section claimed `allowedCiphers` alone stops the flag; corrected to name `daemon.keyType` as the cause.

## Safety

With `keyRotationPolicy: Disabled` (chart default) a keyType change never rotates: `ShouldRotateCephxKeys` returns before it looks at keyType. Daemon keys are used only by userspace Ceph daemons. Clusters that pin `daemon.keyType` in their own values (qa-htz1 does) are unaffected by this default change and should drop that line to clear the warning.

Rendered against production-htz1's values: the only diff vs 32.8.0 is the removed `daemon.keyType` line on the CephCluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4D3zWTacWW8BdvaUqs8XB
