### PR TITLE
fix(kubescape): pin vulnerabilityScan and relevancy explicitly

### DIFF
--- a/argocd-helm-charts/kubescape-operator/values.yaml
+++ b/argocd-helm-charts/kubescape-operator/values.yaml
@@ -18,6 +18,7 @@ kubescape-operator:
     # scanner is triggered daily at midnight.
     #
     # REFER : https://kubescape.io/docs/operator/vulnerabilities/.
+    vulnerabilityScan: enable
 
     # Scan SBOMs embedded inside a container, if found.
     scanEmbeddedSBOMs: enable
@@ -88,6 +89,7 @@ kubescape-operator:
     # Relevancy is installed by default when installing the Kubescape operator through Helm.
     #
     # REFER : https://kubescape.io/docs/operator/relevancy/.
+    relevancy: enable
 
     # Kubescape provides a way to automatically generate Network Policies for your cluster.
     # Once the Network Policy generation feature is enabled, Kubescape will listen to the


### PR DESCRIPTION
## What

Pin `vulnerabilityScan: enable` and `relevancy: enable` in the
`kubescape-operator` wrapper chart values.

## Why

The values file documents the Kubevuln scanner and the relevancy engine at
length — 19 lines on Kubevuln, Grype and the `kubevuln-scheduler` CronJob, and
a further block on relevancy — but never sets either key. Both were inherited
from the upstream `kubescape-operator` chart (1.40.4), where they default to
`enable`.

Two problems with that:

- The file reads as though these capabilities are configured here, while their
  actual value lives upstream.
- An upstream default is not a contract. A chart bump could flip either key
  with no diff in this repo to show it.

Pinning them declares the default where it is already documented, and makes it
survive dependency upgrades.

## Behaviour change

None. `helm template` renders an identical object set before and after — the
only differences are TLS material the chart regenerates on every render.

Verified in both directions: forcing `vulnerabilityScan=disable` drops the
`kubevuln` Deployment and the `kubevuln-scheduler` CronJob, confirming the key
threads through the wrapper into the subchart.

## What this does not do

Clusters that override the capability in their own values keep their override —
a cluster value beats the chart default. Anywhere kubevuln is currently
disabled stays disabled until that override is lifted separately.
