### PR TITLE
fix(orphan-pvc): scope KubeDetectOrphanPvc to KubeAid-managed namespaces

### DIFF
--- a/build/kube-prometheus/mixins/orphan-pvc/mixin.libsonnet
+++ b/build/kube-prometheus/mixins/orphan-pvc/mixin.libsonnet
@@ -5,12 +5,20 @@
     selector: '',
   },
 
+  // Uses argocd_app_info's dest_namespace directly; kubeaidManagedApps only has the app name,
+  // which isn't always the namespace (e.g. netbird-operator -> netbird, or several apps -> kube-system).
+  local kubeaidAppsFilter =
+    'label_replace(argocd_app_info{project="kubeaid"}, "namespace", "$1", "dest_namespace", "(.*)")',
+  local kubeaidAppsFilterEscaped =
+    'label_replace(argocd_app_info{project=\\"kubeaid\\"}, \\"namespace\\", \\"$1\\", \\"dest_namespace\\", \\"(.*)\\")',
+
   local pvcList =
     '{{ range $i, $r := query (printf "group by (cluster, namespace, persistentvolumeclaim) ('
     + 'kube_persistentvolumeclaim_status_phase{phase=\\"Bound\\",cluster=\\"%s\\"} == 1'
     + ' unless on(persistentvolumeclaim, namespace) kube_pod_spec_volumes_persistentvolumeclaims_info'
-    + ')" $labels.cluster) | sortByLabel "persistentvolumeclaim" | sortByLabel "namespace" }}'
-    + '{{ if $i }}, {{ end }}`{{ $r.Labels.namespace }}/{{ $r.Labels.persistentvolumeclaim }}`'
+    + ') and on(namespace) ' + kubeaidAppsFilterEscaped
+    + '" $labels.cluster) | sortByLabel "persistentvolumeclaim" | sortByLabel "namespace" }}'
+    + '\n- `{{ $r.Labels.namespace }}/{{ $r.Labels.persistentvolumeclaim }}`'
     + '{{ end }}',
 
   prometheusAlerts+:: {
@@ -27,8 +35,9 @@
                   unless on(persistentvolumeclaim, namespace)
                   kube_pod_spec_volumes_persistentvolumeclaims_info
                 )
+                and on(namespace) %s
               ) > 0
-            ||| % $._config,
+            ||| % kubeaidAppsFilter,
             'for': '1h',
             labels: {
               severity: 'warning',
@@ -40,7 +49,7 @@
                 + '{{ if $labels.cluster }} on cluster **{{ $labels.cluster }}**{{ end }}'
                 + '{{ if eq $value 1.0 }} has{{ else }} have{{ end }} been Bound but not mounted by any Pod for at least 1 hour.'
                 + '{{ if eq $value 1.0 }} It may be an orphaned volume{{ else }} They may be orphaned volumes{{ end }} consuming storage unnecessarily.'
-                + ' Orphaned {{ if eq $value 1.0 }}PVC{{ else }}PVCs{{ end }}: ' + pvcList + '.',
+                + '\nOrphaned {{ if eq $value 1.0 }}PVC{{ else }}PVCs{{ end }}:' + pvcList,
             },
           },
         ],

--- a/build/kube-prometheus/mixins/orphan-pvc/prometheus.yaml
+++ b/build/kube-prometheus/mixins/orphan-pvc/prometheus.yaml
@@ -3,7 +3,10 @@ groups:
   rules:
   - alert: KubeDetectOrphanPvc
     annotations:
-      description: '{{ if eq $value 1.0 }}**1 PVC**{{ else }}**{{ $value }} PVCs**{{ end }}{{ if $labels.cluster }} on cluster **{{ $labels.cluster }}**{{ end }}{{ if eq $value 1.0 }} has{{ else }} have{{ end }} been Bound but not mounted by any Pod for at least 1 hour.{{ if eq $value 1.0 }} It may be an orphaned volume{{ else }} They may be orphaned volumes{{ end }} consuming storage unnecessarily. Orphaned {{ if eq $value 1.0 }}PVC{{ else }}PVCs{{ end }}: {{ range $i, $r := query (printf "group by (cluster, namespace, persistentvolumeclaim) (kube_persistentvolumeclaim_status_phase{phase=\"Bound\",cluster=\"%s\"} == 1 unless on(persistentvolumeclaim, namespace) kube_pod_spec_volumes_persistentvolumeclaims_info)" $labels.cluster) | sortByLabel "persistentvolumeclaim" | sortByLabel "namespace" }}{{ if $i }}, {{ end }}`{{ $r.Labels.namespace }}/{{ $r.Labels.persistentvolumeclaim }}`{{ end }}.'
+      description: |-
+        {{ if eq $value 1.0 }}**1 PVC**{{ else }}**{{ $value }} PVCs**{{ end }}{{ if $labels.cluster }} on cluster **{{ $labels.cluster }}**{{ end }}{{ if eq $value 1.0 }} has{{ else }} have{{ end }} been Bound but not mounted by any Pod for at least 1 hour.{{ if eq $value 1.0 }} It may be an orphaned volume{{ else }} They may be orphaned volumes{{ end }} consuming storage unnecessarily.
+        Orphaned {{ if eq $value 1.0 }}PVC{{ else }}PVCs{{ end }}:{{ range $i, $r := query (printf "group by (cluster, namespace, persistentvolumeclaim) (kube_persistentvolumeclaim_status_phase{phase=\"Bound\",cluster=\"%s\"} == 1 unless on(persistentvolumeclaim, namespace) kube_pod_spec_volumes_persistentvolumeclaims_info) and on(namespace) label_replace(argocd_app_info{project=\"kubeaid\"}, \"namespace\", \"$1\", \"dest_namespace\", \"(.*)\")" $labels.cluster) | sortByLabel "persistentvolumeclaim" | sortByLabel "namespace" }}
+        - `{{ $r.Labels.namespace }}/{{ $r.Labels.persistentvolumeclaim }}`{{ end }}
       summary: PersistentVolumeClaims are bound but not used by any Pod.
     expr: |
       count by (cluster) (
@@ -12,6 +15,7 @@ groups:
           unless on(persistentvolumeclaim, namespace)
           kube_pod_spec_volumes_persistentvolumeclaims_info
         )
+        and on(namespace) label_replace(argocd_app_info{project="kubeaid"}, "namespace", "$1", "dest_namespace", "(.*)")
       ) > 0
     for: 1h
     labels:


### PR DESCRIPTION
Filters the alert down to namespaces that are real ArgoCD dest_namespace values for apps under the kubeaid project, instead of flagging orphaned PVCs in any namespace on the cluster (including unrelated user apps).

Refs: https://gitea.obmondo.com/EnableIT/qd2xcggwag/issues/5477