### PR TITLE
fix(argo-cd-mixin): remove WhiteListedApplicationOutOfSync 

### DIFF
--- a/build/kube-prometheus/mixins/argo-cd/mixin.libsonnet
+++ b/build/kube-prometheus/mixins/argo-cd/mixin.libsonnet
@@ -8,32 +8,10 @@
       {
         name: 'argocd-sync-state',
         rules: [
-          {
-            alert: 'WhiteListedApplicationOutOfSync',
-            expr: 'argocd_application_sync_state{argocd_application_name!="", application_namespace!="", whitelisted="true", result="waiting"} == 1',
-            'for': '30m',
-            labels: {
-              severity: 'critical',
-              alert_id: 'WhiteListedApplicationOutOfSync',
-            },
-            annotations: {
-              description: 'The application **{{ .Labels.argocd_application_name }}**/**{{ .Labels.application_namespace }}** has been out of sync for more than 30 minutes.',
-              summary: 'Kubernetes version is close to end of support.',
-            },
-          },
-          {
-            alert: 'CronSyncFailed',
-            expr: 'argocd_application_sync_state{argocd_application_name!="", application_namespace!="", whitelisted="true", result="failed"} == 1',
-            'for': '15m',
-            labels: {
-              severity: 'critical',
-              alert_id: 'CronSyncFailed',
-            },
-            annotations: {
-              description: 'Argo CD WhiteListed Application **{{ .Labels.argocd_application_name }}**/**{{ .Labels.application_namespace }}** sync failed.',
-              summary: 'The application has been out of sync for more than 15 minutes.',
-            },
-          },
+          // Removed WhiteListedApplicationOutOfSync/CronSyncFailed: redundant with
+          // ArgoCdAppOutOfSync below, expr and summary didn't match (waiting/failed
+          // vs "out of sync"), the whitelisted="true" label doesn't exist on this
+          // cluster's metrics, and neither ever fired a single notification in Gitea.
           // Inspiration from here https://github.com/adinhodovic/argo-cd-mixin/blob/main/alerts/alerts.libsonnet
           {
             alert: 'ArgoCdAppOutOfSync',

--- a/build/kube-prometheus/mixins/argo-cd/prometheus.yaml
+++ b/build/kube-prometheus/mixins/argo-cd/prometheus.yaml
@@ -1,45 +1,27 @@
 groups:
-  - name: argocd-sync-state
-    rules:
-      - alert: WhiteListedApplicationOutOfSync
-        annotations:
-          description: The application **{{ .Labels.argocd_application_name }}**/**{{ .Labels.application_namespace }}** has been out of sync for more than 30 minutes.
-          summary: Kubernetes version is close to end of support.
-        expr: argocd_application_sync_state{argocd_application_name!="", application_namespace!="", whitelisted="true", result="waiting"} == 1
-        for: 30m
-        labels:
-          alert_id: WhiteListedApplicationOutOfSync
-          severity: critical
-      - alert: CronSyncFailed
-        annotations:
-          description: Argo CD WhiteListed Application **{{ .Labels.argocd_application_name }}**/**{{ .Labels.application_namespace }}** sync failed.
-          summary: The application has been out of sync for more than 15 minutes.
-        expr: argocd_application_sync_state{argocd_application_name!="", application_namespace!="", whitelisted="true", result="failed"} == 1
-        for: 15m
-        labels:
-          alert_id: CronSyncFailed
-          severity: critical
-      - alert: ArgoCdAppOutOfSync
-        annotations:
-          description: |
-            The following applications under project '{{ .Labels.project }}' are out of sync (status: {{ .Labels.sync_status }}):
-            {{- range query (printf "sum by (name, project) (argocd_app_info{project='%s', sync_status='%s'}) and on(name, project) kubeaidManagedApps" .Labels.project .Labels.sync_status) }}
-            - {{ .Labels.name }}
-            {{- end }}
-          summary: ArgoCD Application is Out Of Sync.
-        expr: count by (project, sync_status) ((sum by (name, job, dest_server, project, sync_status) (argocd_app_info{job=~".*",sync_status!="Synced"}) >= 1) + on (name, project) group_left kubeaidManagedApps)
-        for: 2h
-        labels:
-          severity: warning
-      - alert: ArgoCdAppUnhealthy
-        annotations:
-          description: |
-            The following applications under project '{{ .Labels.project }}' are not healthy (status: {{ .Labels.health_status }}):
-            {{- range query (printf "sum by (name, project) (argocd_app_info{project='%s', health_status='%s'}) and on(name, project) kubeaidManagedApps" .Labels.project .Labels.health_status) }}
-            - {{ .Labels.name }}
-            {{- end }}
-          summary: ArgoCD Application is not healthy.
-        expr: count by (health_status,project) ((sum by (name, job, dest_server, project, health_status) (argocd_app_info{health_status!~"Healthy|Progressing"}) >= 1) + on (name, project) group_left kubeaidManagedApps)
-        for: 2h
-        labels:
-          severity: warning
+- name: argocd-sync-state
+  rules:
+  - alert: ArgoCdAppOutOfSync
+    annotations:
+      description: |
+        The following applications under project '{{ .Labels.project }}' are out of sync (status: {{ .Labels.sync_status }}):
+        {{- range query (printf "sum by (name, project) (argocd_app_info{project='%s', sync_status='%s'}) and on(name, project) kubeaidManagedApps" .Labels.project .Labels.sync_status) }}
+        - {{ .Labels.name }}
+        {{- end }}
+      summary: ArgoCD Application is Out Of Sync.
+    expr: count by (project, sync_status) ((sum by (name, job, dest_server, project, sync_status) (argocd_app_info{job=~".*",sync_status!="Synced"}) >= 1) + on (name, project) group_left kubeaidManagedApps)
+    for: 2h
+    labels:
+      severity: warning
+  - alert: ArgoCdAppUnhealthy
+    annotations:
+      description: |
+        The following applications under project '{{ .Labels.project }}' are not healthy (status: {{ .Labels.health_status }}):
+        {{- range query (printf "sum by (name, project) (argocd_app_info{project='%s', health_status='%s'}) and on(name, project) kubeaidManagedApps" .Labels.project .Labels.health_status) }}
+        - {{ .Labels.name }}
+        {{- end }}
+      summary: ArgoCD Application is not healthy.
+    expr: count by (health_status,project) ((sum by (name, job, dest_server, project, health_status) (argocd_app_info{health_status!~"Healthy|Progressing"}) >= 1) + on (name, project) group_left kubeaidManagedApps)
+    for: 2h
+    labels:
+      severity: warning


### PR DESCRIPTION

Redundant with ArgoCdAppOutOfSync below. weird alert The expr and summary didn't match (waiting/failed vs "out of sync" vs "kubernetes out of version" vs "cronsync") doesn't make sense. The whitelisted="true" label doesn't exist on this cluster's metrics.  alert ever fired a single notification in Gitea on any customer.